### PR TITLE
Set up CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-rust@v1
+      - uses: actions/setup-rust@v2
         with:
           rust-version: stable
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+          cache: true
+      - run: cargo test --all-features --all-targets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-rust@v2
+      - uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
-          cache: true
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: cargo test --all-features --all-targets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,4 @@
 - Provide inline documentation with examples.
 - Prefer BDD/TDD style tests.
 - Update `constraints.cypher` whenever Memory types change.
-- GitHub Actions workflow runs `cargo test` using `actions/setup-rust@v2` with caching.
+- GitHub Actions workflow runs `cargo test` using `actions-rs/toolchain@v1` with caching.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,4 @@
 - Provide inline documentation with examples.
 - Prefer BDD/TDD style tests.
 - Update `constraints.cypher` whenever Memory types change.
-- GitHub Actions workflow runs `cargo test`; adjust if additional steps are needed.
+- GitHub Actions workflow runs `cargo test` using `actions/setup-rust@v2` with caching.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Provide inline documentation with examples.
 - Prefer BDD/TDD style tests.
 - Update `constraints.cypher` whenever Memory types change.
+- GitHub Actions workflow runs `cargo test`; adjust if additional steps are needed.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -104,6 +104,16 @@ impl Clone for Memory {
 }
 
 impl Memory {
+    /// Attempt to borrow a custom memory stored via [`Memory::Of`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use psyche_rs::Memory;
+    /// let m = Memory::Of(Box::new(42u32));
+    /// assert_eq!(m.try_as::<u32>(), Some(&42u32));
+    /// assert!(m.try_as::<i32>().is_none());
+    /// ```
     pub fn try_as<T: 'static>(&self) -> Option<&T> {
         match self {
             Memory::Of(boxed) => boxed.downcast_ref::<T>(),

--- a/tests/variants.rs
+++ b/tests/variants.rs
@@ -1,0 +1,123 @@
+use psyche_rs::{Completion, Impression, Intention, IntentionStatus, Interruption, Memory, Sensation, Urge};
+use psyche_rs::codec::serialize_memory;
+use serde_json::json;
+use std::time::UNIX_EPOCH;
+use uuid::Uuid;
+
+fn sample_sensation() -> Sensation {
+    Sensation {
+        uuid: Uuid::new_v4(),
+        kind: "vision".into(),
+        from: "eye".into(),
+        payload: json!({"light":true}),
+        timestamp: UNIX_EPOCH,
+    }
+}
+
+fn sample_impression(source: &Sensation) -> Impression {
+    Impression {
+        uuid: Uuid::new_v4(),
+        how: "see".into(),
+        topic: "object".into(),
+        composed_of: vec![source.uuid],
+        timestamp: UNIX_EPOCH,
+    }
+}
+
+fn sample_urge(source: &Sensation) -> Urge {
+    Urge {
+        uuid: Uuid::new_v4(),
+        source: source.uuid,
+        motor_name: "move".into(),
+        parameters: json!({"dir":"forward"}),
+        intensity: 0.5,
+        timestamp: UNIX_EPOCH,
+    }
+}
+
+fn sample_intention(urge: &Urge) -> Intention {
+    Intention {
+        uuid: Uuid::new_v4(),
+        urge: urge.uuid,
+        motor_name: urge.motor_name.clone(),
+        parameters: urge.parameters.clone(),
+        issued_at: UNIX_EPOCH,
+        resolved_at: None,
+        status: IntentionStatus::Pending,
+    }
+}
+
+fn sample_completion(intention: &Intention) -> Completion {
+    Completion {
+        uuid: Uuid::new_v4(),
+        intention: intention.uuid,
+        outcome: "done".into(),
+        transcript: None,
+        timestamp: UNIX_EPOCH,
+    }
+}
+
+fn sample_interruption(intention: &Intention) -> Interruption {
+    Interruption {
+        uuid: Uuid::new_v4(),
+        intention: intention.uuid,
+        reason: "stop".into(),
+        timestamp: UNIX_EPOCH,
+    }
+}
+
+#[test]
+fn serialize_all_variants() {
+    let sens = sample_sensation();
+    let imp = sample_impression(&sens);
+    let urge = sample_urge(&sens);
+    let intent = sample_intention(&urge);
+    let comp = sample_completion(&intent);
+    let intr = sample_interruption(&intent);
+
+    let cases = vec![
+        Memory::Sensation(sens.clone()),
+        Memory::Impression(imp),
+        Memory::Urge(urge.clone()),
+        Memory::Intention(intent.clone()),
+        Memory::Completion(comp),
+        Memory::Interruption(intr),
+    ];
+
+    for memory in cases {
+        let (label, map) = serialize_memory(&memory).unwrap();
+        match memory {
+            Memory::Sensation(_) => assert_eq!(label, "Sensation"),
+            Memory::Impression(_) => assert_eq!(label, "Impression"),
+            Memory::Urge(_) => assert_eq!(label, "Urge"),
+            Memory::Intention(_) => assert_eq!(label, "Intention"),
+            Memory::Completion(_) => assert_eq!(label, "Completion"),
+            Memory::Interruption(_) => assert_eq!(label, "Interruption"),
+            Memory::Of(_) => unreachable!(),
+        }
+        assert!(map.get("uuid").is_some());
+    }
+}
+
+#[test]
+fn uuid_and_timestamp_for_variants() {
+    let sens = sample_sensation();
+    let imp = sample_impression(&sens);
+    let urge = sample_urge(&sens);
+    let intent = sample_intention(&urge);
+    let comp = sample_completion(&intent);
+    let intr = sample_interruption(&intent);
+    let cases = vec![
+        (Memory::Sensation(sens.clone()), sens.uuid),
+        (Memory::Impression(imp.clone()), imp.uuid),
+        (Memory::Urge(urge.clone()), urge.uuid),
+        (Memory::Intention(intent.clone()), intent.uuid),
+        (Memory::Completion(comp.clone()), comp.uuid),
+        (Memory::Interruption(intr.clone()), intr.uuid),
+    ];
+
+    for (mem, id) in cases {
+        assert_eq!(mem.uuid(), id);
+        assert_eq!(mem.timestamp().unwrap(), UNIX_EPOCH);
+    }
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running cargo tests with caching
- document `Memory::try_as` usage
- exercise all memory variants in new tests
- document CI workflow in AGENTS notes

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685b726c370483209a1dc9bb1a2ef634