### PR TITLE
Update docs guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENT Instructions
 - Always run `cargo test` after modifications.
 - Keep commit messages concise.
-- Provide inline documentation with examples.
+- Provide clear, insightful inline documentation with examples and doctests when possible.
 - Prefer BDD/TDD style tests.
 - Update `constraints.cypher` whenever Memory types change.


### PR DESCRIPTION
## Summary
- clarify that inline docs should be insightful and include doctests when possible

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_685b72e00f5c8320bca64b7676e6cb83