### PR TITLE
Plug MemoryStore into runtime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod codec;
 pub mod memory;
 pub mod store;
+pub mod runtime;
 
 pub use memory::*;
 pub use store::*;
+pub use runtime::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+use psyche_rs::{Neo4jMemoryStore, MemoryStore, Will};
+use neo4rs::Graph;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let uri = std::env::var("NEO4J_URI").unwrap_or_else(|_| "127.0.0.1:7687".into());
+    let user = std::env::var("NEO4J_USER").unwrap_or_else(|_| "neo4j".into());
+    let pass = std::env::var("NEO4J_PASS").unwrap_or_else(|_| "neo4j".into());
+
+    let graph = Arc::new(Graph::new(&uri, &user, &pass).await.map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?);
+    let store: Arc<dyn MemoryStore> = Arc::new(Neo4jMemoryStore { graph });
+    let _will = Will::new(store);
+    // Application logic would go here
+    Ok(())
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use crate::{Memory, MemoryStore};
+
+/// The `Will` is responsible for remembering [`Memory`] values by writing them
+/// into a shared [`MemoryStore`].
+///
+/// ```no_run
+/// use psyche_rs::{Will, MemoryStore, Memory, Sensation, Completion, Interruption};
+/// use std::sync::Arc;
+/// use serde_json::json;
+/// use std::time::SystemTime;
+/// use uuid::Uuid;
+///
+/// struct DummyStore;
+/// #[async_trait::async_trait]
+/// impl MemoryStore for DummyStore {
+///     async fn save(&self, _m: &Memory) -> anyhow::Result<()> { Ok(()) }
+///     async fn get_by_uuid(&self, _u: Uuid) -> anyhow::Result<Option<Memory>> { Ok(None) }
+///     async fn recent(&self, _l: usize) -> anyhow::Result<Vec<Memory>> { Ok(vec![]) }
+///     async fn of_type(&self, _t: &str, _l: usize) -> anyhow::Result<Vec<Memory>> { Ok(vec![]) }
+///     async fn complete_intention(&self, _:Uuid, _:Completion) -> anyhow::Result<()> { Ok(()) }
+///     async fn interrupt_intention(&self, _:Uuid, _:Interruption) -> anyhow::Result<()> { Ok(()) }
+/// }
+///
+/// # async fn run() -> anyhow::Result<()> {
+/// let store = Arc::new(DummyStore) as Arc<dyn MemoryStore>;
+/// let will = Will::new(store);
+/// let mem = Memory::Sensation(Sensation {
+///     uuid: Uuid::new_v4(),
+///     kind: "ping".into(),
+///     from: "doctest".into(),
+///     payload: json!({"a":1}),
+///     timestamp: SystemTime::now(),
+/// });
+/// will.remember(mem).await?;
+/// # Ok(()) }
+/// ```
+pub struct Will {
+    store: Arc<dyn MemoryStore>,
+}
+
+impl Will {
+    pub fn new(store: Arc<dyn MemoryStore>) -> Self {
+        Self { store }
+    }
+
+    pub async fn remember(&self, memory: Memory) -> anyhow::Result<()> {
+        self.store.save(&memory).await
+    }
+}

--- a/tests/runtime_tests.rs
+++ b/tests/runtime_tests.rs
@@ -1,0 +1,48 @@
+use psyche_rs::{Will, Memory, Sensation, MemoryStore};
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+use std::time::SystemTime;
+
+struct MockStore {
+    memories: Arc<Mutex<HashMap<Uuid, Memory>>>,
+}
+
+impl MockStore {
+    fn new() -> Self {
+        Self { memories: Arc::new(Mutex::new(HashMap::new())) }
+    }
+}
+
+#[async_trait::async_trait]
+impl MemoryStore for MockStore {
+    async fn save(&self, memory: &Memory) -> anyhow::Result<()> {
+        self.memories.lock().await.insert(memory.uuid(), memory.clone());
+        Ok(())
+    }
+    async fn get_by_uuid(&self, uuid: Uuid) -> anyhow::Result<Option<Memory>> {
+        Ok(self.memories.lock().await.get(&uuid).cloned())
+    }
+    async fn recent(&self, _limit: usize) -> anyhow::Result<Vec<Memory>> { Ok(vec![]) }
+    async fn of_type(&self, _t: &str, _l: usize) -> anyhow::Result<Vec<Memory>> { Ok(vec![]) }
+    async fn complete_intention(&self,_:Uuid,_:psyche_rs::Completion)->anyhow::Result<()> { Ok(()) }
+    async fn interrupt_intention(&self,_:Uuid,_:psyche_rs::Interruption)->anyhow::Result<()> { Ok(()) }
+}
+
+#[tokio::test]
+async fn will_writes_memory_to_store() -> anyhow::Result<()> {
+    let store = Arc::new(MockStore::new()) as Arc<dyn MemoryStore>;
+    let will = Will::new(store.clone());
+    let mem = Memory::Sensation(Sensation {
+        uuid: Uuid::new_v4(),
+        kind: "test".into(),
+        from: "unit".into(),
+        payload: json!({"x":1}),
+        timestamp: SystemTime::now(),
+    });
+    will.remember(mem.clone()).await?;
+    assert!(store.get_by_uuid(mem.uuid()).await?.is_some());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- share `Neo4jMemoryStore` via `Arc<dyn MemoryStore>`
- expose a simple `Will` runtime component
- wire up a basic runtime in `main.rs`
- persist memory data as JSON in Neo4j
- test that `Will` forwards memories to its store

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685b753f0dc08320a1fd5312a01c6506