### PR TITLE
Implement LLM interface for Quick wit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod store;
 pub mod wit;
 pub mod wits;
 pub mod runtime;
+pub mod llm;
 
 pub use memory::*;
 pub use store::*;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,0 +1,27 @@
+use crate::memory::{Impression, Sensation, Urge};
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Abstract interface for language model interactions used by cognitive wits.
+#[async_trait]
+pub trait LLMClient: Send + Sync {
+    /// Summarize a slice of [`Sensation`]s into a natural language description.
+    async fn summarize(&self, input: &[Sensation]) -> Result<String>;
+
+    /// Suggest potential [`Urge`]s based on the given [`Impression`].
+    async fn suggest_urges(&self, impression: &Impression) -> Result<Vec<Urge>>;
+}
+
+/// Trivial implementation used for testing.
+pub struct DummyLLM;
+
+#[async_trait]
+impl LLMClient for DummyLLM {
+    async fn summarize(&self, input: &[Sensation]) -> Result<String> {
+        Ok(format!("I'm seeing {} sensations.", input.len()))
+    }
+
+    async fn suggest_urges(&self, _impression: &Impression) -> Result<Vec<Urge>> {
+        Ok(vec![])
+    }
+}

--- a/tests/quick_stream.rs
+++ b/tests/quick_stream.rs
@@ -1,4 +1,4 @@
-use psyche_rs::{memory::{Sensation, Memory, MemoryStore}, wits::quick::Quick, wit::Wit};
+use psyche_rs::{memory::{Sensation, Memory, MemoryStore}, wits::quick::Quick, wit::Wit, llm::DummyLLM};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -50,7 +50,7 @@ fn make_fake_sensation(n: usize) -> Sensation {
 #[tokio::test]
 async fn quick_summarizes_sensations_stream() {
     let store = Arc::new(DummyMemoryStore::new());
-    let mut quick = Quick::new(store.clone());
+    let mut quick = Quick::new(store.clone(), Arc::new(DummyLLM));
 
     for i in 0..15 {
         quick.observe(make_fake_sensation(i)).await;


### PR DESCRIPTION
## Summary
- add new LLM trait with dummy impl
- integrate Quick with an LLM for summarization and urge generation
- update tests to verify LLM integration

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685b7aed1e288320ba795a76a077b3b5