### PR TITLE
Add motor feedback handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
 - GitHub Actions workflow runs `cargo test` using `actions-rs/toolchain@v1` with caching.
 - When adding async traits that don't need `Send`, annotate with `#[async_trait(?Send)]`.
 - If running `rustfmt` touches unrelated files, it's fine to keep those changes.
+- Run `cargo fmt` before committing changes.

--- a/src/motor.rs
+++ b/src/motor.rs
@@ -1,8 +1,16 @@
-use crate::memory::Intention;
+use crate::memory::{Completion, Intention, Interruption};
 
 #[async_trait::async_trait]
 pub trait MotorSystem: Send + Sync {
-    async fn invoke(&self, intention: &Intention) -> anyhow::Result<()>;
+    async fn invoke(&self, intention: &Intention) -> anyhow::Result<MotorFeedback>;
+}
+
+/// Feedback returned from a [`MotorSystem`] invocation.
+pub enum MotorFeedback {
+    /// The intention completed successfully with the given result.
+    Completed(Completion),
+    /// The intention was interrupted and did not complete.
+    Interrupted(Interruption),
 }
 
 /// A basic motor implementation used for testing. It simply prints the intended
@@ -11,8 +19,15 @@ pub struct DummyMotor;
 
 #[async_trait::async_trait]
 impl MotorSystem for DummyMotor {
-    async fn invoke(&self, intention: &Intention) -> anyhow::Result<()> {
+    async fn invoke(&self, intention: &Intention) -> anyhow::Result<MotorFeedback> {
         println!("<{} {:?}/>", intention.motor_name, intention.parameters);
-        Ok(())
+        let comp = Completion {
+            uuid: uuid::Uuid::new_v4(),
+            intention: intention.uuid,
+            outcome: "success".to_string(),
+            transcript: Some(format!("Executed: {}", intention.motor_name)),
+            timestamp: std::time::SystemTime::now(),
+        };
+        Ok(MotorFeedback::Completed(comp))
     }
 }


### PR DESCRIPTION
## Summary
- allow motors to return completion or interruption feedback
- update Will to persist that feedback
- simulate successful results in DummyMotor
- test that completions are stored
- document running cargo fmt before commit

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685b8124ff6c8320ae839b3b9f97d29e