### PR TITLE
Add FondDuCoeur emotional wit

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,4 +1,4 @@
-use crate::memory::{Impression, Sensation, Urge};
+use crate::memory::{Impression, Memory, Sensation, Urge};
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -10,6 +10,9 @@ pub trait LLMClient: Send + Sync {
 
     /// Suggest potential [`Urge`]s based on the given [`Impression`].
     async fn suggest_urges(&self, impression: &Impression) -> Result<Vec<Urge>>;
+
+    /// Evaluate an emotional reaction to a completed or interrupted intention.
+    async fn evaluate_emotion(&self, event: &Memory) -> Result<String>;
 }
 
 /// Trivial implementation used for testing.
@@ -23,5 +26,9 @@ impl LLMClient for DummyLLM {
 
     async fn suggest_urges(&self, _impression: &Impression) -> Result<Vec<Urge>> {
         Ok(vec![])
+    }
+
+    async fn evaluate_emotion(&self, _event: &Memory) -> Result<String> {
+        Ok("I feel indifferent.".to_string())
     }
 }

--- a/src/wits/fond.rs
+++ b/src/wits/fond.rs
@@ -1,0 +1,66 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use uuid::Uuid;
+
+use crate::llm::LLMClient;
+use crate::memory::{Emotion, Memory, MemoryStore};
+use crate::wit::Wit;
+
+/// `FondDuCoeur` observes completed or interrupted intentions and records
+/// Pete's emotional response to them.
+pub struct FondDuCoeur {
+    events: VecDeque<Memory>,
+    pub store: Arc<dyn MemoryStore>,
+    pub llm: Arc<dyn LLMClient>,
+}
+
+impl FondDuCoeur {
+    /// Create a new [`FondDuCoeur`] wit.
+    pub fn new(store: Arc<dyn MemoryStore>, llm: Arc<dyn LLMClient>) -> Self {
+        Self {
+            events: VecDeque::new(),
+            store,
+            llm,
+        }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl Wit<Memory, Memory> for FondDuCoeur {
+    /// Buffer completion or interruption events for later emotional
+    /// evaluation. Other memory types are ignored.
+    async fn observe(&mut self, input: Memory) {
+        match input {
+            Memory::Completion(_) | Memory::Interruption(_) => self.events.push_back(input),
+            _ => {}
+        }
+    }
+
+    /// Produce an [`Emotion`] based on the next buffered event using the
+    /// provided [`LLMClient`]. The resulting emotion is persisted via the
+    /// [`MemoryStore`].
+    async fn distill(&mut self) -> Option<Memory> {
+        let event = self.events.pop_front()?;
+        let reason = self.llm.evaluate_emotion(&event).await.ok()?;
+        let mood = reason
+            .split_whitespace()
+            .skip_while(|w| *w != "feel")
+            .nth(1)
+            .unwrap_or("neutral")
+            .to_string();
+
+        let emotion = Emotion {
+            uuid: Uuid::new_v4(),
+            subject: event.uuid(),
+            mood,
+            reason,
+            timestamp: SystemTime::now(),
+        };
+
+        let mem = Memory::Of(Box::new(emotion));
+        let _ = self.store.save(&mem).await;
+        Some(mem)
+    }
+}

--- a/src/wits/mod.rs
+++ b/src/wits/mod.rs
@@ -1,2 +1,3 @@
+pub mod fond;
 pub mod quick;
 pub mod will;

--- a/src/wits/quick.rs
+++ b/src/wits/quick.rs
@@ -21,7 +21,11 @@ pub struct Quick {
 impl Quick {
     /// Create a new [`Quick`] wit using the given [`MemoryStore`].
     pub fn new(store: Arc<dyn MemoryStore>, llm: Arc<dyn LLMClient>) -> Self {
-        Self { buffer: VecDeque::new(), store, llm }
+        Self {
+            buffer: VecDeque::new(),
+            store,
+            llm,
+        }
     }
 }
 
@@ -92,7 +96,9 @@ mod tests {
 
     impl MockStore {
         fn new() -> Self {
-            Self { data: Arc::new(AsyncMutex::new(HashMap::new())) }
+            Self {
+                data: Arc::new(AsyncMutex::new(HashMap::new())),
+            }
         }
     }
 
@@ -188,7 +194,10 @@ mod tests {
 
     impl MockLLM {
         fn new() -> Self {
-            Self { summaries: Arc::new(AsyncMutex::new(0)), urges: Arc::new(AsyncMutex::new(0)) }
+            Self {
+                summaries: Arc::new(AsyncMutex::new(0)),
+                urges: Arc::new(AsyncMutex::new(0)),
+            }
         }
     }
 
@@ -209,6 +218,10 @@ mod tests {
                 intensity: 1.0,
                 timestamp: impression.timestamp,
             }])
+        }
+
+        async fn evaluate_emotion(&self, _event: &Memory) -> anyhow::Result<String> {
+            Ok("I feel nothing".into())
         }
     }
 

--- a/tests/fond.rs
+++ b/tests/fond.rs
@@ -1,0 +1,121 @@
+use psyche_rs::{
+    Emotion,
+    llm::LLMClient,
+    memory::{Completion, Interruption, Memory, MemoryStore},
+    wit::Wit,
+    wits::fond::FondDuCoeur,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::SystemTime;
+use tokio::sync::Mutex as AsyncMutex;
+use uuid::Uuid;
+
+struct MockStore {
+    data: Arc<AsyncMutex<HashMap<Uuid, Memory>>>,
+}
+
+impl MockStore {
+    fn new() -> Self {
+        Self {
+            data: Arc::new(AsyncMutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl MemoryStore for MockStore {
+    async fn save(&self, memory: &Memory) -> anyhow::Result<()> {
+        let stored = match memory {
+            Memory::Of(boxed) => {
+                if let Some(e) = boxed.downcast_ref::<Emotion>() {
+                    Memory::Of(Box::new(e.clone()))
+                } else {
+                    Memory::Of(Box::new(()))
+                }
+            }
+            other => other.clone(),
+        };
+        self.data.lock().await.insert(memory.uuid(), stored);
+        Ok(())
+    }
+
+    async fn get_by_uuid(&self, uuid: Uuid) -> anyhow::Result<Option<Memory>> {
+        let guard = self.data.lock().await;
+        let mem = guard.get(&uuid).map(|m| match m {
+            Memory::Of(boxed) => {
+                if let Some(e) = boxed.downcast_ref::<Emotion>() {
+                    Memory::Of(Box::new(e.clone()))
+                } else {
+                    Memory::Of(Box::new(()))
+                }
+            }
+            other => other.clone(),
+        });
+        Ok(mem)
+    }
+
+    async fn recent(&self, _limit: usize) -> anyhow::Result<Vec<Memory>> {
+        Ok(Vec::new())
+    }
+    async fn of_type(&self, _t: &str, _l: usize) -> anyhow::Result<Vec<Memory>> {
+        Ok(Vec::new())
+    }
+    async fn complete_intention(&self, _: Uuid, _: Completion) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn interrupt_intention(&self, _: Uuid, _: Interruption) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+struct MockLLM;
+
+#[async_trait::async_trait]
+impl LLMClient for MockLLM {
+    async fn summarize(&self, _input: &[psyche_rs::Sensation]) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+    async fn suggest_urges(
+        &self,
+        _imp: &psyche_rs::Impression,
+    ) -> anyhow::Result<Vec<psyche_rs::Urge>> {
+        Ok(vec![])
+    }
+    async fn evaluate_emotion(&self, _event: &Memory) -> anyhow::Result<String> {
+        Ok("I feel happy because things worked".into())
+    }
+}
+
+fn sample_completion() -> Memory {
+    Memory::Completion(Completion {
+        uuid: Uuid::new_v4(),
+        intention: Uuid::new_v4(),
+        outcome: "ok".into(),
+        transcript: None,
+        timestamp: SystemTime::now(),
+    })
+}
+
+#[tokio::test]
+async fn fond_du_coeur_creates_emotion() {
+    let store = Arc::new(MockStore::new());
+    let llm = Arc::new(MockLLM);
+    let mut fond = FondDuCoeur::new(store.clone(), llm);
+
+    let event = sample_completion();
+    fond.observe(event.clone()).await;
+
+    let mem = fond.distill().await.expect("should output emotion");
+
+    let saved = store.get_by_uuid(mem.uuid()).await.unwrap();
+    assert!(saved.is_some());
+
+    if let Memory::Of(boxed) = mem {
+        let emo = boxed.downcast_ref::<Emotion>().expect("should be emotion");
+        assert_eq!(emo.subject, event.uuid());
+        assert_eq!(emo.mood, "happy");
+    } else {
+        panic!("expected custom memory");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `FondDuCoeur` for emotional evaluation
- extend `LLMClient` with `evaluate_emotion`
- add `Emotion` struct and support custom uuid/timestamp
- update `Quick` test mocks
- test emotional responses

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685b82f0487c8320881815ac192afede