### PR TITLE
Implement mood expressions via Voice and Countenance

### DIFF
--- a/src/countenance.rs
+++ b/src/countenance.rs
@@ -1,0 +1,21 @@
+/// Traits for reflecting Pete's emotional state externally.
+///
+/// Implementations may update a UI, light pattern, or simply log to the
+/// console.
+///
+/// # Example
+///
+/// ```
+/// use psyche_rs::Countenance;
+///
+/// struct DummyFace;
+/// impl Countenance for DummyFace {
+///     fn reflect(&self, mood: &str) {
+///         println!("Current mood: {}", mood);
+///     }
+/// }
+/// ```
+pub trait Countenance: Send + Sync {
+    /// Reflect the provided mood string.
+    fn reflect(&self, mood: &str);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,17 @@
 pub mod codec;
+pub mod countenance;
+pub mod llm;
 pub mod memory;
-pub mod store;
-pub mod wit;
-pub mod wits;
 pub mod motor;
 pub mod runtime;
-pub mod llm;
+pub mod store;
+pub mod voice;
+pub mod wit;
+pub mod wits;
 
+pub use countenance::*;
 pub use memory::*;
-pub use store::*;
 pub use motor::*;
 pub use runtime::*;
+pub use store::*;
+pub use voice::*;

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1,0 +1,33 @@
+/// Pete's voice system used to craft text responses.
+///
+/// The voice maintains optional context about Pete's current mood in order to
+/// flavour its next utterance.
+///
+/// # Examples
+///
+/// ```
+/// use psyche_rs::voice::Voice;
+///
+/// let mut voice = Voice::default();
+/// assert_eq!(voice.prompt(), "😐 You said: ...");
+/// voice.update_mood("😊".to_string());
+/// assert!(voice.prompt().starts_with("😊"));
+/// ```
+#[derive(Default)]
+pub struct Voice {
+    /// Latest emotional tone to express with the next prompt.
+    pub current_mood: Option<String>,
+}
+
+impl Voice {
+    /// Update the currently expressed mood.
+    pub fn update_mood(&mut self, mood: String) {
+        self.current_mood = Some(mood);
+    }
+
+    /// Compose a prompt incorporating the current mood.
+    pub fn prompt(&self) -> String {
+        let mood = self.current_mood.as_deref().unwrap_or("😐");
+        format!("{} You said: ...", mood)
+    }
+}

--- a/tests/emotion_flow.rs
+++ b/tests/emotion_flow.rs
@@ -1,0 +1,39 @@
+use psyche_rs::{countenance::Countenance, voice::Voice, Emotion};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+use uuid::Uuid;
+
+struct Recorder(Arc<Mutex<Vec<String>>>);
+
+impl Recorder {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+}
+
+impl Countenance for Recorder {
+    fn reflect(&self, mood: &str) {
+        self.0.lock().unwrap().push(mood.to_string());
+    }
+}
+
+#[test]
+fn emotion_updates_voice_and_countenance() {
+    let mut voice = Voice::default();
+    let rec = Recorder::new();
+
+    let emotion = Emotion {
+        uuid: Uuid::new_v4(),
+        subject: Uuid::new_v4(),
+        mood: "joyful".into(),
+        reason: "tests passed".into(),
+        timestamp: SystemTime::now(),
+    };
+
+    // mimic runtime reaction
+    voice.update_mood(emotion.mood.clone());
+    rec.reflect(&emotion.mood);
+
+    assert!(voice.prompt().starts_with("joyful"));
+    assert_eq!(rec.0.lock().unwrap()[0], "joyful");
+}

--- a/tests/voice_countenance.rs
+++ b/tests/voice_countenance.rs
@@ -1,0 +1,34 @@
+use psyche_rs::{countenance::Countenance, voice::Voice};
+use std::sync::{Arc, Mutex};
+
+struct Recorder {
+    log: Arc<Mutex<Vec<String>>>,
+}
+
+impl Recorder {
+    fn new() -> (Self, Arc<Mutex<Vec<String>>>) {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        (Self { log: log.clone() }, log)
+    }
+}
+
+impl Countenance for Recorder {
+    fn reflect(&self, mood: &str) {
+        self.log.lock().unwrap().push(mood.to_string());
+    }
+}
+
+#[test]
+fn voice_incorporates_mood() {
+    let mut voice = Voice::default();
+    assert_eq!(voice.prompt(), "😐 You said: ...");
+    voice.update_mood("happy".into());
+    assert!(voice.prompt().starts_with("happy"));
+}
+
+#[test]
+fn countenance_records_reflection() {
+    let (rec, log) = Recorder::new();
+    rec.reflect("excited");
+    assert_eq!(log.lock().unwrap()[0], "excited");
+}


### PR DESCRIPTION
## Summary
- add `Countenance` trait for mood reflection
- introduce `Voice` struct with optional mood
- expose new modules in `lib.rs`
- cover emotional flow with new tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685b8586cd248320aa96814b51f583c5