### PR TITLE
Implement voice chat turn

### DIFF
--- a/src/voice.rs
+++ b/src/voice.rs
@@ -16,6 +16,9 @@
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+use crate::conversation::{Conversation, Role};
+use llm::chat::{ChatProvider, ChatResponse};
+
 use serde_json::json;
 use uuid::Uuid;
 
@@ -33,6 +36,12 @@ pub struct Voice {
     pub mouth: Arc<dyn Mouth>,
     /// Store used to persist spoken utterances.
     pub store: Arc<dyn MemoryStore>,
+    /// Conversation history used for chat-based interactions.
+    pub conversation: Conversation,
+    /// Language model used for generating replies.
+    pub llm: Arc<dyn ChatProvider>,
+    /// Identifier for the underlying model variant.
+    pub model: String,
 }
 
 impl Voice {
@@ -43,6 +52,9 @@ impl Voice {
             narrator,
             mouth,
             store,
+            conversation: Conversation::new("You are Pete".into(), 128),
+            llm: Arc::new(NoopChatLLM),
+            model: "dummy".into(),
         }
     }
 
@@ -55,6 +67,20 @@ impl Voice {
     pub fn prompt(&self) -> String {
         let mood = self.current_mood.as_deref().unwrap_or("😐");
         format!("{} You said: ...", mood)
+    }
+
+    /// Generate a chat response using the configured LLM.
+    ///
+    /// The resulting reply is spoken via [`Mouth::say`]. The caller should
+    /// persist the utterance by invoking `Ear::hear_self` with the returned
+    /// text.
+    pub async fn take_turn(&mut self) -> anyhow::Result<String> {
+        let prompt = self.conversation.to_prompt();
+        let response = self.llm.chat(&prompt).await?;
+        let reply = response.text().unwrap_or_default();
+        self.mouth.say(&reply).await?;
+        self.conversation.hear(Role::Me, &reply);
+        Ok(reply)
     }
 
     /// Respond to a memory oriented query by narrating recent events.
@@ -135,6 +161,39 @@ impl MemoryStore for NoopStore {
     }
 }
 
+/// Chat provider implementation that returns an empty response.
+struct NoopChatLLM;
+
+#[async_trait::async_trait]
+impl ChatProvider for NoopChatLLM {
+    async fn chat_with_tools(
+        &self,
+        _messages: &[llm::chat::ChatMessage],
+        _tools: Option<&[llm::chat::Tool]>,
+    ) -> Result<Box<dyn ChatResponse>, llm::error::LLMError> {
+        Ok(Box::new(NoopChatResponse))
+    }
+}
+
+#[derive(Debug)]
+struct NoopChatResponse;
+
+impl ChatResponse for NoopChatResponse {
+    fn text(&self) -> Option<String> {
+        Some(String::new())
+    }
+
+    fn tool_calls(&self) -> Option<Vec<llm::ToolCall>> {
+        None
+    }
+}
+
+impl std::fmt::Display for NoopChatResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "")
+    }
+}
+
 impl Default for Voice {
     fn default() -> Self {
         let store = Arc::new(NoopStore);
@@ -143,6 +202,10 @@ impl Default for Voice {
             store: store.clone(),
             llm,
         };
-        Self::new(narrator, Arc::new(NoopMouth), store)
+        let mut voice = Self::new(narrator, Arc::new(NoopMouth), store);
+        voice.conversation = Conversation::new("You are Pete".into(), 128);
+        voice.llm = Arc::new(NoopChatLLM);
+        voice.model = "dummy".into();
+        voice
     }
 }

--- a/tests/voice_turn.rs
+++ b/tests/voice_turn.rs
@@ -1,0 +1,73 @@
+use async_trait::async_trait;
+use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
+use psyche_rs::{conversation::Conversation, mouth::Mouth, voice::Voice};
+use std::sync::{Arc, Mutex};
+
+struct LoggingMouth {
+    log: Arc<Mutex<Vec<String>>>,
+}
+
+impl LoggingMouth {
+    fn new() -> (Self, Arc<Mutex<Vec<String>>>) {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        (Self { log: log.clone() }, log)
+    }
+}
+
+#[async_trait(?Send)]
+impl Mouth for LoggingMouth {
+    async fn say(&self, phrase: &str) -> anyhow::Result<()> {
+        self.log.lock().unwrap().push(phrase.to_string());
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SimpleResponse(String);
+
+impl ChatResponse for SimpleResponse {
+    fn text(&self) -> Option<String> {
+        Some(self.0.clone())
+    }
+
+    fn tool_calls(&self) -> Option<Vec<llm::ToolCall>> {
+        None
+    }
+}
+
+impl std::fmt::Display for SimpleResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+struct EchoLLM;
+
+#[async_trait]
+impl ChatProvider for EchoLLM {
+    async fn chat_with_tools(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[llm::chat::Tool]>,
+    ) -> Result<Box<dyn ChatResponse>, llm::error::LLMError> {
+        Ok(Box::new(SimpleResponse("Hello!".into())))
+    }
+}
+
+#[tokio::test]
+async fn take_turn_speaks_reply() -> anyhow::Result<()> {
+    let mut voice = Voice::default();
+    voice.conversation = Conversation::new("sys".into(), 10);
+    voice.llm = Arc::new(EchoLLM);
+    let (mouth, log) = LoggingMouth::new();
+    voice.mouth = Arc::new(mouth);
+
+    voice
+        .conversation
+        .hear(psyche_rs::conversation::Role::Interlocutor, "Hi");
+    let reply = voice.take_turn().await?;
+
+    assert_eq!(reply, "Hello!");
+    assert_eq!(log.lock().unwrap()[0], "Hello!");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- extend `Voice` with conversation and chat LLM fields
- implement `take_turn` to call the LLM and speak the reply
- provide a noop chat provider for defaults
- add test for the new conversational turn

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685b9b665040832088a090e47f0f03fe