### PR TITLE
Add full cycle example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1351,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1620,6 +1637,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1829,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +1991,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2040,6 +2101,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 gag = "1.0"
+tracing-subscriber = "0.3"

--- a/examples/full_cycle.rs
+++ b/examples/full_cycle.rs
@@ -1,0 +1,39 @@
+use psyche_rs::memory::Sensation;
+use psyche_rs::{DummyCountenance, DummyLLM, DummyMouth, DummyStore, Psyche};
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::LocalSet;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let (tx, rx) = mpsc::channel(32);
+    let (stop_tx, _stop_rx) = oneshot::channel();
+
+    let psyche = Psyche::new(
+        Arc::new(DummyStore::new()),
+        Arc::new(DummyLLM),
+        Arc::new(DummyMouth),
+        Arc::new(DummyCountenance),
+        rx,
+        stop_tx,
+        "gemma".into(),
+        "You are Pete.".into(),
+        2048,
+    );
+
+    let local = LocalSet::new();
+    local.spawn_local(async move { psyche.tick().await });
+
+    local
+        .run_until(async move {
+            for i in 0..3 {
+                let s = Sensation::new_text(format!("This is event {}", i), "test");
+                tx.send(s).await.unwrap();
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        })
+        .await;
+}

--- a/src/countenance.rs
+++ b/src/countenance.rs
@@ -19,3 +19,12 @@ pub trait Countenance: Send + Sync {
     /// Reflect the provided mood string.
     fn reflect(&self, mood: &str);
 }
+
+/// [`Countenance`] implementation that logs the reflected mood.
+pub struct DummyCountenance;
+
+impl Countenance for DummyCountenance {
+    fn reflect(&self, mood: &str) {
+        tracing::info!("mood: {}", mood);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod wits;
 
 pub use conversation::*;
 pub use countenance::*;
+pub use llm::*;
 pub use memory::*;
 pub use motor::*;
 pub use mouth::*;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -12,6 +12,25 @@ pub struct Sensation {
     pub timestamp: SystemTime,
 }
 
+impl Sensation {
+    /// Construct a simple text sensation originating from `from`.
+    ///
+    /// ```
+    /// use psyche_rs::Sensation;
+    /// let s = Sensation::new_text("hi", "tester");
+    /// assert_eq!(s.kind, "text/plain");
+    /// ```
+    pub fn new_text(content: impl Into<String>, from: impl Into<String>) -> Self {
+        Self {
+            uuid: Uuid::new_v4(),
+            kind: "text/plain".into(),
+            from: from.into(),
+            payload: serde_json::json!({ "content": content.into() }),
+            timestamp: SystemTime::now(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Impression {
     pub uuid: Uuid,

--- a/src/mouth.rs
+++ b/src/mouth.rs
@@ -26,3 +26,14 @@ pub trait Mouth: Send + Sync {
     /// Speak the provided phrase.
     async fn say(&self, phrase: &str) -> anyhow::Result<()>;
 }
+
+/// [`Mouth`] implementation that logs spoken phrases using [`tracing`].
+pub struct DummyMouth;
+
+#[async_trait(?Send)]
+impl Mouth for DummyMouth {
+    async fn say(&self, phrase: &str) -> anyhow::Result<()> {
+        tracing::info!("say: {}", phrase);
+        Ok(())
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,5 +1,6 @@
 use neo4rs::{Graph, query};
 use serde_json::to_string as json_to_string;
+use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -44,6 +45,78 @@ impl MemoryStore for Neo4jMemoryStore {
         _keyword: &str,
     ) -> anyhow::Result<Vec<crate::Impression>> {
         Ok(Vec::new())
+    }
+
+    async fn complete_intention(
+        &self,
+        _intention_id: Uuid,
+        _completion: Completion,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn interrupt_intention(
+        &self,
+        _intention_id: Uuid,
+        _interruption: Interruption,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+/// Simple in-memory store useful for examples and tests.
+pub struct DummyStore {
+    data: Arc<tokio::sync::Mutex<HashMap<Uuid, Memory>>>,
+}
+
+impl DummyStore {
+    /// Create a new empty store.
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl MemoryStore for DummyStore {
+    async fn save(&self, memory: &Memory) -> anyhow::Result<()> {
+        let stored = match memory {
+            Memory::Of(boxed) => {
+                if let Some(e) = boxed.downcast_ref::<crate::Emotion>() {
+                    Memory::Of(Box::new(e.clone()))
+                } else {
+                    Memory::Of(Box::new(()))
+                }
+            }
+            other => other.clone(),
+        };
+        self.data.lock().await.insert(memory.uuid(), stored);
+        Ok(())
+    }
+
+    async fn get_by_uuid(&self, uuid: Uuid) -> anyhow::Result<Option<Memory>> {
+        let guard = self.data.lock().await;
+        Ok(guard.get(&uuid).cloned())
+    }
+
+    async fn recent(&self, _limit: usize) -> anyhow::Result<Vec<Memory>> {
+        Ok(vec![])
+    }
+
+    async fn of_type(&self, _type_name: &str, _limit: usize) -> anyhow::Result<Vec<Memory>> {
+        Ok(vec![])
+    }
+
+    async fn recent_since(&self, _since: std::time::SystemTime) -> anyhow::Result<Vec<Memory>> {
+        Ok(vec![])
+    }
+
+    async fn impressions_containing(
+        &self,
+        _keyword: &str,
+    ) -> anyhow::Result<Vec<crate::Impression>> {
+        Ok(vec![])
     }
 
     async fn complete_intention(


### PR DESCRIPTION
## Summary
- add full_cycle example using dummy psyche components
- provide helper Sensation::new_text
- implement DummyStore, DummyMouth, DummyCountenance
- re-export llm module

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685c256453dc8320b7f991dd83661580