### PR TITLE
Implement embedding-based recall

### DIFF
--- a/src/psyche.rs
+++ b/src/psyche.rs
@@ -11,6 +11,7 @@ use crate::{
     motor::DummyMotor,
     mouth::Mouth,
     narrator::Narrator,
+    store::NoopRetriever,
     voice::Voice,
     wit::Wit,
     wits::{fond::FondDuCoeur, quick::Quick, will::Will},
@@ -66,6 +67,7 @@ impl Psyche {
         let narrator = Narrator {
             store: store.clone(),
             llm: llm.clone(),
+            retriever: Arc::new(NoopRetriever),
         };
 
         let mut voice = Voice::new(narrator.clone(), mouth, store.clone());

--- a/src/store/embedding_store.rs
+++ b/src/store/embedding_store.rs
@@ -82,3 +82,16 @@ pub fn simple_embed(text: &str) -> Vec<f32> {
     }
     v
 }
+
+/// [`MemoryRetriever`] implementation that never returns any results.
+///
+/// This is useful in tests and default configurations where an embedding
+/// backend is unavailable.
+pub struct NoopRetriever;
+
+#[async_trait::async_trait(?Send)]
+impl MemoryRetriever for NoopRetriever {
+    async fn find_similar(&self, _text: &str, _top_k: usize) -> Result<Vec<Uuid>> {
+        Ok(Vec::new())
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -5,5 +5,5 @@ pub mod embedding_store;
 pub mod neo4j_store;
 
 pub use dummy_store::DummyStore;
-pub use embedding_store::{MemoryRetriever, QdrantEmbeddingStore};
+pub use embedding_store::{MemoryRetriever, NoopRetriever, QdrantEmbeddingStore};
 pub use neo4j_store::Neo4jStore;

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 
 use crate::memory::{Memory, MemoryStore};
 use crate::narrator::Narrator;
+use crate::store::NoopRetriever;
 
 use crate::mouth::Mouth;
 
@@ -201,6 +202,7 @@ impl Default for Voice {
         let narrator = Narrator {
             store: store.clone(),
             llm,
+            retriever: Arc::new(NoopRetriever),
         };
         let mut voice = Self::new(narrator, Arc::new(NoopMouth), store);
         voice.conversation = Conversation::new("You are Pete".into(), 128);

--- a/tests/full_cycle.rs
+++ b/tests/full_cycle.rs
@@ -195,6 +195,7 @@ async fn day_in_the_life_of_pete() {
     let narrator = Narrator {
         store: store.clone(),
         llm: llm.clone(),
+        retriever: Arc::new(psyche_rs::store::embedding_store::NoopRetriever),
     };
     let (mouth, log) = DummyMouth::new();
     let mouth = Arc::new(mouth);

--- a/tests/voice_tests.rs
+++ b/tests/voice_tests.rs
@@ -3,6 +3,7 @@ use psyche_rs::{
     memory::{Impression, Memory, MemoryStore, Sensation},
     mouth::Mouth,
     narrator::Narrator,
+    store::NoopRetriever,
     voice::Voice,
 };
 use std::collections::HashMap;
@@ -146,6 +147,7 @@ async fn test_narrate_response() -> anyhow::Result<()> {
     let narrator = Narrator {
         store: store.clone(),
         llm,
+        retriever: Arc::new(NoopRetriever),
     };
     let (mouth, log) = LoggingMouth::new();
     let mouth = Arc::new(mouth);


### PR DESCRIPTION
## Summary
- embed retriever integration via `Narrator::recall_relevant`
- provide `NoopRetriever` for default/testing
- wire narrator in voice and psyche to include retriever
- expand narrator tests for embedding recall

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685c72d4d2008320b0a73470921c881e