### PR TITLE
Add tracing logs across cognition

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
     let uri = std::env::var("NEO4J_URI").unwrap_or_else(|_| "127.0.0.1:7687".into());
     let user = std::env::var("NEO4J_USER").unwrap_or_else(|_| "neo4j".into());
     let pass = std::env::var("NEO4J_PASS").unwrap_or_else(|_| "neo4j".into());

--- a/src/psyche.rs
+++ b/src/psyche.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tokio::sync::{Mutex, mpsc, oneshot};
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use crate::{
     conversation::Conversation,
@@ -91,7 +91,7 @@ impl Psyche {
     /// Run the processing loop until the input channel closes.
     pub async fn tick(mut self) {
         while let Some(sensation) = self.input_rx.recv().await {
-            info!("Received sensation: {:?}", sensation.kind);
+            info!("📥 Received sensation: {}", sensation.kind);
             let quick = self.quick.clone();
             let will = self.will.clone();
             let fond = self.fond.clone();
@@ -102,12 +102,14 @@ impl Psyche {
             // Perception first
             let instant = {
                 let mut q = quick.lock().await;
+                trace!("↪ calling Quick.observe(...)");
                 q.observe(sensation).await;
+                trace!("↪ calling Quick.distill(...)");
                 q.distill().await
             };
 
             if let Some(instant) = instant {
-                info!("Distilling new Instant...");
+                info!("🧠 Pete thought: {}", instant.how);
                 store.save(&Memory::Impression(instant.clone())).await.ok();
 
                 // Suggest urges using the shared LLM then feed them into Will.

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -27,6 +27,7 @@ use crate::narrator::Narrator;
 use crate::store::NoopRetriever;
 
 use crate::mouth::Mouth;
+use tracing::info;
 
 pub struct Voice {
     /// Latest emotional tone to express with the next prompt.
@@ -80,6 +81,7 @@ impl Voice {
         let response = self.llm.chat(&prompt).await?;
         let reply = response.text().unwrap_or_default();
         self.mouth.say(&reply).await?;
+        info!("🗣 Pete says: {}", reply);
         self.conversation.hear(Role::Me, &reply);
         Ok(reply)
     }

--- a/src/wits/fond.rs
+++ b/src/wits/fond.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use crate::llm::LLMClient;
 use crate::memory::{Emotion, Memory, MemoryStore};
 use crate::wit::Wit;
+use tracing::info;
 
 /// `FondDuCoeur` observes completed or interrupted intentions and records
 /// Pete's emotional response to them.
@@ -59,6 +60,7 @@ impl Wit<Memory, Memory> for FondDuCoeur {
             timestamp: SystemTime::now(),
         };
 
+        info!("💓 Pete feels: {}", emotion.reason);
         let mem = Memory::Of(Box::new(emotion));
         let _ = self.store.save(&mem).await;
         Some(mem)

--- a/src/wits/quick.rs
+++ b/src/wits/quick.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 use crate::llm::LLMClient;
 use crate::memory::{Impression, Memory, MemoryStore, Sensation};
 use crate::wit::Wit;
+use tracing::debug;
 
 /// `Quick` buffers recent [`Sensation`]s and periodically summarizes them into
 /// [`Impression`]s representing short instants.
@@ -46,6 +47,8 @@ impl Wit<Sensation, Impression> for Quick {
         if self.buffer.is_empty() {
             return None;
         }
+
+        debug!("🧩 Instant composed of {} sensations", self.buffer.len());
 
         // Generate a natural language summary using the provided LLM. Any
         // failure to obtain a summary results in no impression being produced.

--- a/src/wits/will.rs
+++ b/src/wits/will.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use crate::memory::{Intention, IntentionStatus, Memory, MemoryStore, Urge};
 use crate::motor::{MotorFeedback, MotorSystem};
 use crate::wit::Wit;
+use tracing::info;
 
 /// `Will` consumes [`Urge`]s and issues [`Intention`]s to the provided
 /// [`MotorSystem`]. Observed urges are persisted via the supplied
@@ -51,6 +52,8 @@ impl Wit<Urge, Intention> for Will {
         };
 
         let _ = self.store.save(&Memory::Intention(intent.clone())).await;
+
+        info!("🎯 Pete intends: {}", intent.motor_name);
 
         // Invoke the motor and persist any feedback.
         match self.motor.invoke(&intent).await {


### PR DESCRIPTION
## Summary
- instrument Pete's psyche tick loop with rich tracing events
- log instant composition in Quick
- log intention creation in Will
- log spoken replies in Voice
- log Pete's emotions in FondDuCoeur
- enable tracing subscriber in `main`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685c8af417f88320ba974eb85426abb0