### PR TITLE
refactor pete setup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,14 @@
 use neo4rs::Graph;
-use psyche_rs::pete;
-use psyche_rs::{MemoryStore, Neo4jStore, Will};
+use psyche_rs::{
+    MemoryStore, Neo4jStore, countenance::DummyCountenance, llm::DummyLLM, memory::Sensation,
+    mouth::DummyMouth, pete,
+};
 use std::sync::Arc;
+use tokio::task::LocalSet;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-<<<<<<< codex/add-tracing-logs-to-pete-s-cognitive-pipeline
-=======
-
->>>>>>> main
     let uri = std::env::var("NEO4J_URI").unwrap_or_else(|_| "127.0.0.1:7687".into());
     let user = std::env::var("NEO4J_USER").unwrap_or_else(|_| "neo4j".into());
     let pass = std::env::var("NEO4J_PASS").unwrap_or_else(|_| "neo4j".into());
@@ -18,6 +17,25 @@ async fn main() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?;
     let store: Arc<dyn MemoryStore> = Arc::new(Neo4jStore { client: graph });
-    let _will = Will::new(store);
-    pete::launch_default_pete().await
+    let llm = Arc::new(DummyLLM);
+    let mouth = Arc::new(DummyMouth);
+    let face = Arc::new(DummyCountenance);
+
+    let (psyche, tx, _stop_rx) = pete::build_pete(store, llm, mouth, face);
+
+    let local = LocalSet::new();
+    local.spawn_local(async move { psyche.tick().await });
+
+    local
+        .run_until(async move {
+            for i in 0..3 {
+                tx.send(Sensation::new_text(format!("This is test {}", i), "cli"))
+                    .await?;
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+            Ok::<(), anyhow::Error>(())
+        })
+        .await?;
+
+    Ok(())
 }

--- a/src/pete/mod.rs
+++ b/src/pete/mod.rs
@@ -1,5 +1,8 @@
-use crate::memory::Sensation;
-use crate::{DummyCountenance, DummyLLM, DummyMouth, DummyStore, Psyche};
+use crate::memory::{MemoryStore, Sensation};
+use crate::{
+    DummyCountenance, DummyLLM, DummyMouth, DummyStore, Psyche, countenance::Countenance,
+    llm::LLMClient, mouth::Mouth,
+};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::LocalSet;
@@ -16,20 +19,38 @@ use tokio::task::LocalSet;
 ///     pete::launch_default_pete().await
 /// }
 /// ```
-pub async fn launch_default_pete() -> anyhow::Result<()> {
+///
+/// Build a [`Psyche`] using the provided dependencies.
+pub fn build_pete(
+    store: Arc<dyn MemoryStore>,
+    llm: Arc<dyn LLMClient>,
+    mouth: Arc<dyn Mouth>,
+    countenance: Arc<dyn Countenance>,
+) -> (Psyche, mpsc::Sender<Sensation>, oneshot::Receiver<()>) {
     let (tx, rx) = mpsc::channel(32);
-    let (stop_tx, _stop_rx) = oneshot::channel();
+    let (stop_tx, stop_rx) = oneshot::channel();
 
     let psyche = Psyche::new(
-        Arc::new(DummyStore::new()),
-        Arc::new(DummyLLM),
-        Arc::new(DummyMouth),
-        Arc::new(DummyCountenance),
+        store,
+        llm,
+        mouth,
+        countenance,
         rx,
         stop_tx,
         "gemma".into(),
         "You are Pete.".into(),
         2048,
+    );
+
+    (psyche, tx, stop_rx)
+}
+
+pub async fn launch_default_pete() -> anyhow::Result<()> {
+    let (psyche, tx, _stop_rx) = build_pete(
+        Arc::new(DummyStore::new()),
+        Arc::new(DummyLLM),
+        Arc::new(DummyMouth),
+        Arc::new(DummyCountenance),
     );
 
     let local = LocalSet::new();


### PR DESCRIPTION
## Summary
- expose `build_pete` for dependency injection
- use new builder from `main.rs` and pass dummy llm

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685c92e670f48320bcd9099824d59bdf