### PR TITLE
Integrate llm streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures-util",
  "gag",
  "llm",
  "neo4rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 neo4rs = "0.5"
 tokio = { version = "1", features = ["rt", "macros"] }
+futures-util = "0.3"
 llm = "1.3"
 tracing = "0.1"
 qdrant-client = "1.14.0"

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,6 +1,10 @@
 use crate::memory::{Impression, Memory, Sensation, Urge};
 use anyhow::Result;
 use async_trait::async_trait;
+use llm::LLMProvider;
+use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
+use std::sync::Arc;
+use uuid::Uuid;
 
 /// Abstract interface for language model interactions used by cognitive wits.
 #[async_trait]
@@ -21,6 +25,34 @@ pub trait LLMClient: Send + Sync {
 /// Trivial implementation used for testing.
 pub struct DummyLLM;
 
+/// Adapter type wrapping a [`ChatProvider`] for use where an [`LLMClient`] is
+/// expected.
+#[derive(Clone)]
+pub struct ChatLLM(pub Arc<dyn LLMProvider>);
+
+#[async_trait]
+impl ChatProvider for ChatLLM {
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[llm::chat::Tool]>,
+    ) -> Result<Box<dyn ChatResponse>, llm::error::LLMError> {
+        self.0.chat_with_tools(messages, tools).await
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<
+        std::pin::Pin<
+            Box<dyn futures_util::Stream<Item = Result<String, llm::error::LLMError>> + Send>,
+        >,
+        llm::error::LLMError,
+    > {
+        self.0.chat_stream(messages).await
+    }
+}
+
 #[async_trait]
 impl LLMClient for DummyLLM {
     async fn summarize(&self, input: &[Sensation]) -> Result<String> {
@@ -37,5 +69,68 @@ impl LLMClient for DummyLLM {
 
     async fn summarize_impressions(&self, items: &[Impression]) -> Result<String> {
         Ok(format!("I'm recalling {} impressions.", items.len()))
+    }
+}
+
+#[async_trait]
+impl<T> LLMClient for T
+where
+    T: ChatProvider + Send + Sync + ?Sized,
+{
+    async fn summarize(&self, input: &[Sensation]) -> Result<String> {
+        let mut prompt = String::from("Summarize the following observations in one sentence:\n");
+        for s in input {
+            let text = s
+                .payload
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            prompt.push_str("- ");
+            prompt.push_str(text);
+            prompt.push('\n');
+        }
+        let req = vec![ChatMessage::user().content(prompt).build()];
+        let resp = self.chat(&req).await?;
+        Ok(resp.text().unwrap_or_default())
+    }
+
+    async fn summarize_impressions(&self, items: &[Impression]) -> Result<String> {
+        let mut prompt = String::from("Summarize the following impressions:\n");
+        for i in items {
+            prompt.push_str("- ");
+            prompt.push_str(&i.how);
+            prompt.push('\n');
+        }
+        let req = vec![ChatMessage::user().content(prompt).build()];
+        let resp = self.chat(&req).await?;
+        Ok(resp.text().unwrap_or_default())
+    }
+
+    async fn suggest_urges(&self, impression: &Impression) -> Result<Vec<Urge>> {
+        let prompt = format!(
+            "List one suggested motor action for: {}. Respond with just the action name.",
+            impression.how
+        );
+        let req = vec![ChatMessage::user().content(prompt).build()];
+        let resp = self.chat(&req).await?;
+        let text = resp.text().unwrap_or_default();
+        if text.is_empty() {
+            return Ok(vec![]);
+        }
+        Ok(vec![Urge {
+            uuid: Uuid::new_v4(),
+            source: impression.uuid,
+            motor_name: text,
+            parameters: serde_json::json!({}),
+            intensity: 1.0,
+            timestamp: impression.timestamp,
+        }])
+    }
+
+    async fn evaluate_emotion(&self, event: &Memory) -> Result<String> {
+        let prompt = format!("How should Pete feel about this event? {:?}", event);
+        let req = vec![ChatMessage::user().content(prompt).build()];
+        let resp = self.chat(&req).await?;
+        Ok(resp.text().unwrap_or_default())
     }
 }

--- a/tests/voice_turn.rs
+++ b/tests/voice_turn.rs
@@ -52,6 +52,20 @@ impl ChatProvider for EchoLLM {
     ) -> Result<Box<dyn ChatResponse>, llm::error::LLMError> {
         Ok(Box::new(SimpleResponse("Hello!".into())))
     }
+
+    async fn chat_stream(
+        &self,
+        _messages: &[ChatMessage],
+    ) -> Result<
+        std::pin::Pin<
+            Box<dyn futures_util::Stream<Item = Result<String, llm::error::LLMError>> + Send>,
+        >,
+        llm::error::LLMError,
+    > {
+        Ok(Box::pin(futures_util::stream::once(async {
+            Ok("Hello!".to_string())
+        })))
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- switch voice interactions to use `chat_stream`
- wrap `LLMProvider` in `ChatLLM` adapter implementing `ChatProvider`
- build runtime LLM via `LLMBuilder` using env vars
- extend tests for streaming
- add futures-util dependency

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685c958689908320a09ae573ca1b5faf