### PR TITLE
Refactor to ChatProvider

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,36 +1,18 @@
 use crate::memory::{Impression, Memory, Sensation, Urge};
 use anyhow::Result;
-use async_trait::async_trait;
+use futures_util::StreamExt;
 use llm::LLMProvider;
 use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
+use serde_json;
 use std::sync::Arc;
 use uuid::Uuid;
 
-/// Abstract interface for language model interactions used by cognitive wits.
-#[async_trait]
-pub trait LLMClient: Send + Sync {
-    /// Summarize a slice of [`Sensation`]s into a natural language description.
-    async fn summarize(&self, input: &[Sensation]) -> Result<String>;
-
-    /// Summarize a sequence of [`Impression`]s into a higher-level summary.
-    async fn summarize_impressions(&self, items: &[Impression]) -> Result<String>;
-
-    /// Suggest potential [`Urge`]s based on the given [`Impression`].
-    async fn suggest_urges(&self, impression: &Impression) -> Result<Vec<Urge>>;
-
-    /// Evaluate an emotional reaction to a completed or interrupted intention.
-    async fn evaluate_emotion(&self, event: &Memory) -> Result<String>;
-}
-
-/// Trivial implementation used for testing.
-pub struct DummyLLM;
-
-/// Adapter type wrapping a [`ChatProvider`] for use where an [`LLMClient`] is
-/// expected.
+/// Adapter type wrapping an [`LLMProvider`] so it can be used as a
+/// [`ChatProvider`].
 #[derive(Clone)]
 pub struct ChatLLM(pub Arc<dyn LLMProvider>);
 
-#[async_trait]
+#[async_trait::async_trait]
 impl ChatProvider for ChatLLM {
     async fn chat_with_tools(
         &self,
@@ -53,30 +35,12 @@ impl ChatProvider for ChatLLM {
     }
 }
 
-#[async_trait]
-impl LLMClient for DummyLLM {
-    async fn summarize(&self, input: &[Sensation]) -> Result<String> {
-        Ok(format!("I'm seeing {} sensations.", input.len()))
-    }
-
-    async fn suggest_urges(&self, _impression: &Impression) -> Result<Vec<Urge>> {
-        Ok(vec![])
-    }
-
-    async fn evaluate_emotion(&self, _event: &Memory) -> Result<String> {
-        Ok("I feel indifferent.".to_string())
-    }
-
-    async fn summarize_impressions(&self, items: &[Impression]) -> Result<String> {
-        Ok(format!("I'm recalling {} impressions.", items.len()))
-    }
-}
-
-#[async_trait]
-impl<T> LLMClient for T
-where
-    T: ChatProvider + Send + Sync + ?Sized,
-{
+/// Convenience extension providing higher level operations on top of
+/// [`ChatProvider`]. All methods consume model output via streaming to
+/// avoid unnecessary latency.
+#[async_trait::async_trait(?Send)]
+pub trait LLMExt: ChatProvider + Send + Sync {
+    /// Summarize a slice of [`Sensation`]s.
     async fn summarize(&self, input: &[Sensation]) -> Result<String> {
         let mut prompt = String::from("Summarize the following observations in one sentence:\n");
         for s in input {
@@ -89,11 +53,14 @@ where
             prompt.push_str(text);
             prompt.push('\n');
         }
-        let req = vec![ChatMessage::user().content(prompt).build()];
-        let resp = self.chat(&req).await?;
-        Ok(resp.text().unwrap_or_default())
+        collect_stream(
+            self.chat_stream(&[ChatMessage::user().content(prompt).build()])
+                .await?,
+        )
+        .await
     }
 
+    /// Summarize several [`Impression`]s into a single statement.
     async fn summarize_impressions(&self, items: &[Impression]) -> Result<String> {
         let mut prompt = String::from("Summarize the following impressions:\n");
         for i in items {
@@ -101,36 +68,57 @@ where
             prompt.push_str(&i.how);
             prompt.push('\n');
         }
-        let req = vec![ChatMessage::user().content(prompt).build()];
-        let resp = self.chat(&req).await?;
-        Ok(resp.text().unwrap_or_default())
+        collect_stream(
+            self.chat_stream(&[ChatMessage::user().content(prompt).build()])
+                .await?,
+        )
+        .await
     }
 
+    /// Suggest a set of [`Urge`]s based on the provided [`Impression`].
     async fn suggest_urges(&self, impression: &Impression) -> Result<Vec<Urge>> {
         let prompt = format!(
             "List one suggested motor action for: {}. Respond with just the action name.",
             impression.how
         );
-        let req = vec![ChatMessage::user().content(prompt).build()];
-        let resp = self.chat(&req).await?;
-        let text = resp.text().unwrap_or_default();
-        if text.is_empty() {
-            return Ok(vec![]);
+        let text = collect_stream(
+            self.chat_stream(&[ChatMessage::user().content(prompt).build()])
+                .await?,
+        )
+        .await?;
+        if text.trim().is_empty() {
+            return Ok(Vec::new());
         }
         Ok(vec![Urge {
             uuid: Uuid::new_v4(),
             source: impression.uuid,
-            motor_name: text,
+            motor_name: text.trim().to_string(),
             parameters: serde_json::json!({}),
             intensity: 1.0,
             timestamp: impression.timestamp,
         }])
     }
 
+    /// Evaluate an emotional response to a given [`Memory`].
     async fn evaluate_emotion(&self, event: &Memory) -> Result<String> {
         let prompt = format!("How should Pete feel about this event? {:?}", event);
-        let req = vec![ChatMessage::user().content(prompt).build()];
-        let resp = self.chat(&req).await?;
-        Ok(resp.text().unwrap_or_default())
+        collect_stream(
+            self.chat_stream(&[ChatMessage::user().content(prompt).build()])
+                .await?,
+        )
+        .await
     }
+}
+
+#[async_trait::async_trait(?Send)]
+impl<T> LLMExt for T where T: ChatProvider + Send + Sync + ?Sized {}
+
+async fn collect_stream(
+    mut stream: impl futures_util::Stream<Item = Result<String, llm::error::LLMError>> + Unpin,
+) -> Result<String> {
+    let mut out = String::new();
+    while let Some(part) = stream.next().await {
+        out.push_str(&part?);
+    }
+    Ok(out)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use llm::LLMProvider;
 use llm::builder::{LLMBackend, LLMBuilder};
+use llm::chat::ChatProvider;
 use neo4rs::Graph;
-use psyche_rs::llm::LLMClient;
+use psyche_rs::llm::ChatLLM;
 use psyche_rs::{
     MemoryStore, Neo4jStore, countenance::DummyCountenance, memory::Sensation, mouth::DummyMouth,
     pete,
@@ -31,9 +32,8 @@ async fn main() -> anyhow::Result<()> {
         .model(model)
         .stream(true)
         .build()?;
-    let llm = Arc::new(psyche_rs::llm::ChatLLM(Arc::<dyn LLMProvider>::from(
-        llm_provider,
-    ))) as Arc<dyn LLMClient>;
+    let llm =
+        Arc::new(ChatLLM(Arc::<dyn LLMProvider>::from(llm_provider))) as Arc<dyn ChatProvider>;
     let mouth = Arc::new(DummyMouth);
     let face = Arc::new(DummyCountenance);
 

--- a/src/psyche.rs
+++ b/src/psyche.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
+use llm::chat::ChatProvider;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tracing::{debug, info, trace};
 
 use crate::{
     conversation::Conversation,
     countenance::Countenance,
-    llm::LLMClient,
+    llm::LLMExt,
     memory::{Memory, MemoryStore, Sensation},
     motor::DummyMotor,
     mouth::Mouth,
@@ -40,7 +41,7 @@ pub struct Psyche {
     /// Shared memory store used by all components.
     pub store: Arc<dyn MemoryStore>,
     /// Language model used for generating urges.
-    pub llm: Arc<dyn LLMClient>,
+    pub llm: Arc<dyn ChatProvider>,
     /// Incoming sensations to process.
     pub input_rx: mpsc::Receiver<Sensation>,
     /// Notifies the runtime once processing is complete.
@@ -51,7 +52,7 @@ impl Psyche {
     /// Create a new [`Psyche`] with freshly constructed cognitive wits.
     pub fn new(
         store: Arc<dyn MemoryStore>,
-        llm: Arc<dyn LLMClient>,
+        llm: Arc<dyn ChatProvider>,
         mouth: Arc<dyn Mouth>,
         countenance: Arc<dyn Countenance>,
         input_rx: mpsc::Receiver<Sensation>,

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -217,10 +217,9 @@ impl std::fmt::Display for NoopChatResponse {
 impl Default for Voice {
     fn default() -> Self {
         let store = Arc::new(NoopStore);
-        let llm = Arc::new(crate::llm::DummyLLM);
         let narrator = Narrator {
             store: store.clone(),
-            llm,
+            llm: Arc::new(NoopChatLLM),
             retriever: Arc::new(NoopRetriever),
         };
         let mut voice = Self::new(narrator, Arc::new(NoopMouth), store);

--- a/src/wits/fond.rs
+++ b/src/wits/fond.rs
@@ -4,9 +4,10 @@ use std::time::SystemTime;
 
 use uuid::Uuid;
 
-use crate::llm::LLMClient;
+use crate::llm::LLMExt;
 use crate::memory::{Emotion, Memory, MemoryStore};
 use crate::wit::Wit;
+use llm::chat::ChatProvider;
 use tracing::info;
 
 /// `FondDuCoeur` observes completed or interrupted intentions and records
@@ -14,12 +15,12 @@ use tracing::info;
 pub struct FondDuCoeur {
     events: VecDeque<Memory>,
     pub store: Arc<dyn MemoryStore>,
-    pub llm: Arc<dyn LLMClient>,
+    pub llm: Arc<dyn ChatProvider>,
 }
 
 impl FondDuCoeur {
     /// Create a new [`FondDuCoeur`] wit.
-    pub fn new(store: Arc<dyn MemoryStore>, llm: Arc<dyn LLMClient>) -> Self {
+    pub fn new(store: Arc<dyn MemoryStore>, llm: Arc<dyn ChatProvider>) -> Self {
         Self {
             events: VecDeque::new(),
             store,
@@ -40,7 +41,7 @@ impl Wit<Memory, Memory> for FondDuCoeur {
     }
 
     /// Produce an [`Emotion`] based on the next buffered event using the
-    /// provided [`LLMClient`]. The resulting emotion is persisted via the
+    /// provided [`ChatProvider`]. The resulting emotion is persisted via the
     /// [`MemoryStore`].
     async fn distill(&mut self) -> Option<Memory> {
         let event = self.events.pop_front()?;

--- a/tests/psyche_build.rs
+++ b/tests/psyche_build.rs
@@ -6,8 +6,7 @@ use uuid::Uuid;
 use psyche_rs::{
     Psyche,
     countenance::Countenance,
-    llm::LLMClient,
-    memory::{Impression, Memory, MemoryStore, Sensation, Urge},
+    memory::{Impression, Memory, MemoryStore},
     mouth::Mouth,
 };
 
@@ -45,21 +44,48 @@ impl MemoryStore for DummyStore {
     }
 }
 
+use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
+
 struct DummyLLM;
 
 #[async_trait]
-impl LLMClient for DummyLLM {
-    async fn summarize(&self, _input: &[Sensation]) -> anyhow::Result<String> {
-        Ok(String::new())
+impl ChatProvider for DummyLLM {
+    async fn chat_with_tools(
+        &self,
+        _m: &[ChatMessage],
+        _t: Option<&[llm::chat::Tool]>,
+    ) -> Result<Box<dyn ChatResponse>, llm::error::LLMError> {
+        Ok(Box::new(SimpleResp("".into())))
     }
-    async fn summarize_impressions(&self, _items: &[Impression]) -> anyhow::Result<String> {
-        Ok(String::new())
+
+    async fn chat_stream(
+        &self,
+        _m: &[ChatMessage],
+    ) -> Result<
+        std::pin::Pin<
+            Box<dyn futures_util::Stream<Item = Result<String, llm::error::LLMError>> + Send>,
+        >,
+        llm::error::LLMError,
+    > {
+        Ok(Box::pin(futures_util::stream::once(async {
+            Ok("".into())
+        })))
     }
-    async fn suggest_urges(&self, _imp: &Impression) -> anyhow::Result<Vec<Urge>> {
-        Ok(vec![])
+}
+
+#[derive(Debug)]
+struct SimpleResp(String);
+impl ChatResponse for SimpleResp {
+    fn text(&self) -> Option<String> {
+        Some(self.0.clone())
     }
-    async fn evaluate_emotion(&self, _event: &Memory) -> anyhow::Result<String> {
-        Ok(String::new())
+    fn tool_calls(&self) -> Option<Vec<llm::ToolCall>> {
+        None
+    }
+}
+impl std::fmt::Display for SimpleResp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/tests/voice_tests.rs
+++ b/tests/voice_tests.rs
@@ -1,6 +1,6 @@
+use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
 use psyche_rs::{
-    llm::LLMClient,
-    memory::{Impression, Memory, MemoryStore, Sensation},
+    memory::{Impression, Memory, MemoryStore},
     mouth::Mouth,
     narrator::Narrator,
     store::NoopRetriever,
@@ -89,25 +89,47 @@ impl MemoryStore for MockStore {
 struct EchoLLM;
 
 #[async_trait::async_trait]
-impl LLMClient for EchoLLM {
-    async fn summarize(&self, _input: &[Sensation]) -> anyhow::Result<String> {
-        Ok(String::new())
+impl ChatProvider for EchoLLM {
+    async fn chat_with_tools(
+        &self,
+        _msgs: &[ChatMessage],
+        _tools: Option<&[llm::chat::Tool]>,
+    ) -> Result<Box<dyn ChatResponse>, llm::error::LLMError> {
+        Ok(Box::new(SimpleResp("".into())))
     }
 
-    async fn summarize_impressions(&self, items: &[Impression]) -> anyhow::Result<String> {
-        Ok(items
-            .iter()
-            .map(|i| i.how.clone())
-            .collect::<Vec<_>>()
-            .join(" "))
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<
+        std::pin::Pin<
+            Box<dyn futures_util::Stream<Item = Result<String, llm::error::LLMError>> + Send>,
+        >,
+        llm::error::LLMError,
+    > {
+        let reply = messages
+            .last()
+            .map(|m| m.content.clone())
+            .unwrap_or_default();
+        Ok(Box::pin(futures_util::stream::once(
+            async move { Ok(reply) },
+        )))
     }
+}
 
-    async fn suggest_urges(&self, _imp: &Impression) -> anyhow::Result<Vec<psyche_rs::Urge>> {
-        Ok(vec![])
+#[derive(Debug)]
+struct SimpleResp(String);
+impl ChatResponse for SimpleResp {
+    fn text(&self) -> Option<String> {
+        Some(self.0.clone())
     }
-
-    async fn evaluate_emotion(&self, _event: &Memory) -> anyhow::Result<String> {
-        Ok(String::new())
+    fn tool_calls(&self) -> Option<Vec<llm::ToolCall>> {
+        None
+    }
+}
+impl std::fmt::Display for SimpleResp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the `LLMClient` trait
- implement `LLMExt` extension trait for any `ChatProvider`
- switch wits and `Psyche` to depend on `ChatProvider`
- update narrator, voice, and pete modules
- adjust tests and examples for new API

## Testing
- `cargo test --quiet`
- `cargo test --doc --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685c9bbfafd883208ff4087dfe1b6bad