### PR TITLE
Add stable/fuzzy transcript handling

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -67,7 +67,12 @@ async fn handle_socket(socket: WebSocket, recognizer: Arc<dyn SpeechRecognizer>)
                     error!("recognize error: {:?}", e);
                 }
                 match recognizer.try_transcribe().await {
-                    Ok(Some(text)) => info!("transcript = {}", text),
+                    Ok(Some(tr)) => {
+                        info!("stable = {}", tr.stable);
+                        if let Some(f) = tr.fuzzy {
+                            info!("fuzzy = {}", f);
+                        }
+                    }
                     Ok(None) => {}
                     Err(e) => error!("transcribe error: {:?}", e),
                 }

--- a/daringsby/src/whisper_recognizer.rs
+++ b/daringsby/src/whisper_recognizer.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
-use psyche_rs::speech::SpeechRecognizer;
+use psyche_rs::speech::{SpeechRecognizer, TranscriptResult};
 
 /// Speech recognizer powered by `whisper-rs`.
 ///
@@ -12,7 +12,41 @@ use psyche_rs::speech::SpeechRecognizer;
 /// the resulting transcript is returned.
 pub struct WhisperRecognizer {
     ctx: WhisperContext,
+    /// Rolling audio buffer in PCM samples.
     buffer: Mutex<Vec<i16>>, // collected PCM samples
+    /// Tokens that have been emitted as stable.
+    stable_tokens: Mutex<Vec<String>>,
+    /// Tokens from the last transcription (stable + fuzzy).
+    last_tokens: Mutex<Vec<String>>,
+}
+
+const SAMPLE_RATE: usize = 16_000;
+const MAX_DURATION_SECS: usize = 6;
+const MAX_SAMPLES: usize = SAMPLE_RATE * MAX_DURATION_SECS;
+
+fn diff_tokens(
+    stable: &mut Vec<String>,
+    last: &mut Vec<String>,
+    new_tokens: &[String],
+) -> (usize, Option<String>) {
+    let prefix_len = last
+        .iter()
+        .zip(new_tokens)
+        .take_while(|(a, b)| a == b)
+        .count();
+    let stable_len = stable.len();
+    let mut new_stable = 0;
+    if prefix_len > stable_len {
+        stable.extend_from_slice(&new_tokens[stable_len..prefix_len]);
+        new_stable = prefix_len - stable_len;
+    }
+    *last = new_tokens.to_vec();
+    let fuzzy = if new_tokens.len() > prefix_len {
+        Some(new_tokens[prefix_len..].join(" "))
+    } else {
+        None
+    };
+    (new_stable, fuzzy)
 }
 
 impl WhisperRecognizer {
@@ -23,18 +57,23 @@ impl WhisperRecognizer {
         Ok(Self {
             ctx,
             buffer: Mutex::new(Vec::new()),
+            stable_tokens: Mutex::new(Vec::new()),
+            last_tokens: Mutex::new(Vec::new()),
         })
     }
 
     /// Attempt to transcribe the buffered audio.
-    pub fn transcribe(&self) -> anyhow::Result<Option<String>> {
-        let mut buf = self.buffer.lock().unwrap();
-        if buf.is_empty() {
-            return Ok(None);
-        }
+    pub fn transcribe(&self) -> anyhow::Result<Option<TranscriptResult>> {
+        let buf_snapshot = {
+            let buf = self.buffer.lock().unwrap();
+            if buf.is_empty() {
+                return Ok(None);
+            }
+            buf.clone()
+        };
 
-        let mut float_buf = vec![0.0f32; buf.len()];
-        whisper_rs::convert_integer_to_float_audio(&buf, &mut float_buf)
+        let mut float_buf = vec![0.0f32; buf_snapshot.len()];
+        whisper_rs::convert_integer_to_float_audio(&buf_snapshot, &mut float_buf)
             .map_err(|e| anyhow::anyhow!(e))?;
 
         let mut state = self.ctx.create_state().map_err(|e| anyhow::anyhow!(e))?;
@@ -56,19 +95,53 @@ impl WhisperRecognizer {
                     .map_err(|e| anyhow::anyhow!(e))?,
             );
         }
-        buf.clear();
-        Ok(Some(out))
+
+        let new_tokens: Vec<String> = out.split_whitespace().map(|s| s.to_string()).collect();
+
+        let mut stable = self.stable_tokens.lock().unwrap();
+        let mut last = self.last_tokens.lock().unwrap();
+
+        let (new_stable, fuzzy) = diff_tokens(&mut stable, &mut last, &new_tokens);
+
+        if new_stable > 0 {
+            let remove = buf_snapshot.len() * new_stable / new_tokens.len().max(1);
+            let mut buf = self.buffer.lock().unwrap();
+            let n = remove.min(buf.len());
+            buf.drain(0..n);
+            tracing::info!(
+                "stable_emitted = {}",
+                stable[stable.len() - new_stable..].join(" ")
+            );
+        }
+
+        tracing::debug!(
+            fuzzy_tokens = fuzzy
+                .as_ref()
+                .map(|f| f.split_whitespace().count())
+                .unwrap_or(0),
+            buffer_ms = (buf_snapshot.len() as f32 / SAMPLE_RATE as f32) * 1000.0,
+        );
+
+        Ok(Some(TranscriptResult {
+            stable: stable.join(" "),
+            fuzzy,
+        }))
     }
 }
 
 #[async_trait]
 impl SpeechRecognizer for WhisperRecognizer {
     async fn recognize(&self, samples: &[i16]) -> anyhow::Result<()> {
-        self.buffer.lock().unwrap().extend_from_slice(samples);
+        let mut buf = self.buffer.lock().unwrap();
+        buf.extend_from_slice(samples);
+        if buf.len() > MAX_SAMPLES {
+            let excess = buf.len() - MAX_SAMPLES;
+            buf.drain(0..excess);
+        }
         Ok(())
     }
 
-    async fn try_transcribe(&self) -> anyhow::Result<Option<String>> {
+    async fn try_transcribe(&self) -> anyhow::Result<Option<TranscriptResult>> {
         self.transcribe()
     }
 }
@@ -80,5 +153,27 @@ mod tests {
     #[test]
     fn invalid_model_path_fails() {
         assert!(WhisperRecognizer::new("/no/model/here").is_err());
+    }
+
+    #[test]
+    fn diff_tokens_tracks_stable_prefix() {
+        let mut stable = vec!["hello".into()];
+        let mut last = vec!["hello".into(), "world".into()];
+        let new = vec!["hello".into(), "there".into()];
+        let (added, fuzzy) = diff_tokens(&mut stable, &mut last, &new);
+        assert_eq!(added, 0);
+        assert_eq!(stable, vec!["hello".to_string()]);
+        assert_eq!(fuzzy, Some("there".into()));
+    }
+
+    #[test]
+    fn diff_tokens_emits_new_stable() {
+        let mut stable = Vec::new();
+        let mut last = Vec::new();
+        let new = vec!["one".into(), "two".into()];
+        let (added, fuzzy) = diff_tokens(&mut stable, &mut last, &new);
+        assert_eq!(added, 0);
+        assert_eq!(stable, Vec::<String>::new());
+        assert_eq!(fuzzy, Some("one two".into()));
     }
 }

--- a/psyche-rs/src/speech.rs
+++ b/psyche-rs/src/speech.rs
@@ -1,5 +1,17 @@
 use async_trait::async_trait;
 
+/// Result of a transcription pass.
+///
+/// The [`stable`] portion is safe to commit to the conversation while the
+/// [`fuzzy`] tail may still change as more audio is processed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptResult {
+    /// Tokens that are considered temporally stable.
+    pub stable: String,
+    /// Most recent tokens that may still change.
+    pub fuzzy: Option<String>,
+}
+
 /// Speech recognition interface.
 #[async_trait]
 pub trait SpeechRecognizer: Send + Sync {
@@ -7,7 +19,7 @@ pub trait SpeechRecognizer: Send + Sync {
     async fn recognize(&self, samples: &[i16]) -> anyhow::Result<()>;
 
     /// Attempt to transcribe any buffered audio into text.
-    async fn try_transcribe(&self) -> anyhow::Result<Option<String>>;
+    async fn try_transcribe(&self) -> anyhow::Result<Option<TranscriptResult>>;
 }
 
 /// [`SpeechRecognizer`] implementation that just logs incoming audio.
@@ -20,7 +32,7 @@ impl SpeechRecognizer for DummyRecognizer {
         Ok(())
     }
 
-    async fn try_transcribe(&self) -> anyhow::Result<Option<String>> {
+    async fn try_transcribe(&self) -> anyhow::Result<Option<TranscriptResult>> {
         Ok(None)
     }
 }


### PR DESCRIPTION
## Summary
- enrich `SpeechRecognizer` with `TranscriptResult`
- track stable and fuzzy segments in `WhisperRecognizer`
- expose stable/fuzzy info in the server logs
- add unit tests for diff logic

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685cc33f72408320bd0115102ccedc82