### PR TITLE
Add browser mic streaming debug page

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -51,6 +51,10 @@ async fn asr_view() -> Html<&'static str> {
     Html(include_str!("../static/asr_view.html"))
 }
 
+async fn audio_test() -> Html<&'static str> {
+    Html(include_str!("../static/audio_test.html"))
+}
+
 async fn audio_in(
     ws: WebSocketUpgrade,
     Extension(recognizer): Extension<Arc<dyn SpeechRecognizer>>,
@@ -139,6 +143,7 @@ async fn main() {
         .route("/audio/in", get(audio_in))
         .route("/debug/asr", get(asr_ws))
         .route("/debug/asr/view", get(asr_view))
+        .route("/debug/audio/test", get(audio_test))
         .route("/", get(|| async { "ok" }))
         .layer(Extension(recognizer))
         .layer(Extension(tx));

--- a/daringsby/static/audio_test.html
+++ b/daringsby/static/audio_test.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Audio Debug Test</title>
+<style>
+  body { font-family: sans-serif; margin: 2em; }
+  #status { font-weight: bold; }
+</style>
+</head>
+<body>
+<button id="start">Start Streaming</button>
+<p>Status: <span id="status">idle</span></p>
+<p>Chunk info: <span id="info">-</span></p>
+<script>
+const startBtn = document.getElementById('start');
+const statusEl = document.getElementById('status');
+const infoEl = document.getElementById('info');
+let ws;
+let audioCtx;
+let lastChunk = 0;
+function frameChunk(int16array) {
+  const len = int16array.length * 2;
+  const buf = new ArrayBuffer(4 + len);
+  const view = new DataView(buf);
+  view.setUint32(0, len, false); // big endian
+  new Int16Array(buf, 4).set(int16array);
+  return buf;
+}
+function floatTo16BitPCM(input) {
+  const output = new Int16Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const s = Math.max(-1, Math.min(1, input[i]));
+    output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+  }
+  return output;
+}
+function downsampleBuffer(buffer, sampleRate, outRate) {
+  if (outRate === sampleRate) return buffer;
+  const ratio = sampleRate / outRate;
+  const newLen = Math.round(buffer.length / ratio);
+  const result = new Float32Array(newLen);
+  let offset = 0;
+  for (let i = 0; i < newLen; i++) {
+    const next = Math.round((i + 1) * ratio);
+    let sum = 0, count = 0;
+    for (; offset < next && offset < buffer.length; offset++) {
+      sum += buffer[offset];
+      count++;
+    }
+    result[i] = sum / count;
+  }
+  return result;
+}
+function handleAudio(data) {
+  const down = downsampleBuffer(data, audioCtx.sampleRate, 16000);
+  const pcm = floatTo16BitPCM(down);
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(frameChunk(pcm));
+    const now = performance.now();
+    if (lastChunk) {
+      infoEl.textContent = `${pcm.length} samples; ${(now - lastChunk).toFixed(0)} ms`;
+    }
+    lastChunk = now;
+  }
+}
+async function start() {
+  startBtn.disabled = true;
+  statusEl.textContent = 'requesting mic...';
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  statusEl.textContent = 'mic granted';
+  const AC = window.AudioContext || window.webkitAudioContext;
+  audioCtx = new AC();
+  const source = audioCtx.createMediaStreamSource(stream);
+  ws = new WebSocket((location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/audio/in');
+  ws.binaryType = 'arraybuffer';
+  if (audioCtx.audioWorklet && audioCtx.audioWorklet.addModule) {
+    const code = `class PCMProcessor extends AudioWorkletProcessor { process(inputs) { const input = inputs[0][0]; if (input) this.port.postMessage(input); return true; } } registerProcessor('pcm-processor', PCMProcessor);`;
+    const blobUrl = URL.createObjectURL(new Blob([code], {type: 'text/javascript'}));
+    await audioCtx.audioWorklet.addModule(blobUrl);
+    const node = new AudioWorkletNode(audioCtx, 'pcm-processor');
+    node.port.onmessage = e => handleAudio(e.data);
+    source.connect(node).connect(audioCtx.destination);
+  } else {
+    const node = audioCtx.createScriptProcessor(4096, 1, 1);
+    node.onaudioprocess = e => handleAudio(e.inputBuffer.getChannelData(0));
+    source.connect(node).connect(audioCtx.destination);
+  }
+  statusEl.textContent = 'streaming';
+}
+startBtn.addEventListener('click', () => start().catch(e => { statusEl.textContent = 'error'; console.error(e); }));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve a new debug page for streaming microphone audio
- implement AudioWorklet-based capture with ScriptProcessor fallback
- expose new route `/debug/audio/test` from `daringsby`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685ccb5dac5c83208300f8a32b7fee58