### PR TITLE
Implement cancellable incremental whisper transcription

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -147,7 +147,7 @@ async fn main() {
 
     let recognizer: Arc<dyn SpeechRecognizer> = if let Ok(path) = std::env::var("WHISPER_MODEL") {
         match WhisperRecognizer::new(&path) {
-            Ok(r) => Arc::new(r),
+            Ok(r) => r,
             Err(e) => {
                 error!("failed to init whisper: {:?}", e);
                 Arc::new(DummyRecognizer)


### PR DESCRIPTION
## Summary
- add debounce/cancellation job handling to `WhisperRecognizer`
- shrink audio buffer to 4 seconds and start background jobs on new audio
- adjust main entry to use returned `Arc` from `WhisperRecognizer::new`

## Testing
- `cargo test --no-run`
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_685cd07beba083209741462dd4c560d2