### PR TITLE
Integrate reactive Voice loop

### DIFF
--- a/psyche-rs/examples/full_cycle.rs
+++ b/psyche-rs/examples/full_cycle.rs
@@ -1,6 +1,6 @@
 use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
 use psyche_rs::memory::Sensation;
-use psyche_rs::{DummyCountenance, DummyMouth, DummyStore, Psyche};
+use psyche_rs::{DummyMouth, DummyStore, Psyche};
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -52,11 +52,15 @@ async fn main() {
         }
     }
 
-    let psyche = Psyche::new(Arc::new(DummyStore::new()), Arc::new(DummyLLM));
+    let psyche = Psyche::new(
+        Arc::new(DummyStore::new()),
+        Arc::new(DummyLLM),
+        Arc::new(DummyMouth),
+    );
     let local = LocalSet::new();
     local
         .run_until(async move {
-            tokio::spawn(async move {
+            tokio::task::spawn_local(async move {
                 while let Some(s) = rx.recv().await {
                     let _ = psyche.send_sensation(s).await;
                 }

--- a/psyche-rs/src/ear.rs
+++ b/psyche-rs/src/ear.rs
@@ -1,0 +1,25 @@
+use crate::memory::Sensation;
+use tokio::sync::mpsc;
+
+/// Pete's auditory feedback loop.
+///
+/// [`Ear`] feeds Pete's own speech back into the perception pipeline so it can
+/// be remembered like any other [`Sensation`].
+#[derive(Clone)]
+pub struct Ear {
+    sender: mpsc::Sender<Sensation>,
+}
+
+impl Ear {
+    /// Create a new [`Ear`] sending sensations to `sender`.
+    pub fn new(sender: mpsc::Sender<Sensation>) -> Self {
+        Self { sender }
+    }
+
+    /// Record Pete's own utterance.
+    pub async fn hear_self(&self, phrase: &str) {
+        // Errors are ignored here as hearing one's own voice is not critical for
+        // operation.
+        let _ = self.sender.send(Sensation::new_text(phrase, "pete")).await;
+    }
+}

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod codec;
 pub mod conversation;
 pub mod countenance;
+pub mod ear;
 pub mod llm;
 pub mod memory;
 pub mod motor;
@@ -17,6 +18,7 @@ pub mod wits;
 
 pub use conversation::*;
 pub use countenance::*;
+pub use ear::*;
 pub use llm::*;
 pub use memory::*;
 pub use motor::*;

--- a/psyche-rs/src/pete/mod.rs
+++ b/psyche-rs/src/pete/mod.rs
@@ -68,13 +68,13 @@ use tokio::task::LocalSet;
 pub fn build_pete(
     store: Arc<dyn MemoryStore>,
     llm: Arc<dyn ChatProvider>,
-    _mouth: Arc<dyn Mouth>,
+    mouth: Arc<dyn Mouth>,
     _countenance: Arc<dyn Countenance>,
 ) -> (Psyche, mpsc::Sender<Sensation>, oneshot::Receiver<()>) {
     let (tx, rx) = mpsc::channel(32);
     let (stop_tx, stop_rx) = oneshot::channel();
 
-    let psyche = Psyche::new(store, llm);
+    let psyche = Psyche::new(store, llm, mouth);
     // forward sensations from tx into psyche
     let sender = psyche.quick.sender.clone();
     tokio::task::spawn_local(async move {

--- a/psyche-rs/tests/psyche_build.rs
+++ b/psyche-rs/tests/psyche_build.rs
@@ -95,7 +95,7 @@ async fn psyche_construction() {
             let store = Arc::new(DummyStore);
             let llm = Arc::new(DummyLLM);
 
-            let psyche = Psyche::new(store, llm);
+            let psyche = Psyche::new(store, llm, Arc::new(psyche_rs::DummyMouth));
             psyche
                 .send_sensation(Sensation::new_text("hi", "test"))
                 .await

--- a/psyche-rs/tests/psyche_reactive.rs
+++ b/psyche-rs/tests/psyche_reactive.rs
@@ -109,13 +109,15 @@ async fn sensation_flows_to_intention() {
         .run_until(async {
             let store = Arc::new(MemStore::new());
             let llm = Arc::new(DummyLLM);
-            let psyche = Psyche::new(store, llm);
+            let psyche = Psyche::new(store, llm, Arc::new(psyche_rs::DummyMouth));
             let mut rx = psyche.will.receiver.resubscribe();
 
-            psyche
-                .send_sensation(Sensation::new_text("hi", "test"))
-                .await
-                .unwrap();
+            for i in 0..3 {
+                psyche
+                    .send_sensation(Sensation::new_text(format!("hi{}", i), "test"))
+                    .await
+                    .unwrap();
+            }
 
             let intent = rx.recv().await.unwrap();
             assert_eq!(intent.motor_name, "jump");

--- a/psyche-rs/tests/voice_reactive.rs
+++ b/psyche-rs/tests/voice_reactive.rs
@@ -1,0 +1,104 @@
+use async_trait::async_trait;
+use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
+use psyche_rs::{DummyStore, Psyche, memory::Sensation, mouth::Mouth};
+use std::sync::{Arc, Mutex};
+use tokio::task::LocalSet;
+
+struct LoggingMouth {
+    log: Arc<Mutex<Vec<String>>>,
+}
+
+impl LoggingMouth {
+    fn new() -> (Self, Arc<Mutex<Vec<String>>>) {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        (Self { log: log.clone() }, log)
+    }
+}
+
+#[async_trait(?Send)]
+impl Mouth for LoggingMouth {
+    async fn say(&self, phrase: &str) -> anyhow::Result<()> {
+        self.log.lock().unwrap().push(phrase.to_string());
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SimpleResp(String);
+impl ChatResponse for SimpleResp {
+    fn text(&self) -> Option<String> {
+        Some(self.0.clone())
+    }
+    fn tool_calls(&self) -> Option<Vec<llm::ToolCall>> {
+        None
+    }
+}
+impl std::fmt::Display for SimpleResp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+struct TestLLM;
+
+#[async_trait]
+impl ChatProvider for TestLLM {
+    async fn chat_with_tools(
+        &self,
+        _msgs: &[ChatMessage],
+        _tools: Option<&[llm::chat::Tool]>,
+    ) -> Result<Box<dyn ChatResponse>, llm::error::LLMError> {
+        Ok(Box::new(SimpleResp("".into())))
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<
+        std::pin::Pin<
+            Box<dyn futures_util::Stream<Item = Result<String, llm::error::LLMError>> + Send>,
+        >,
+        llm::error::LLMError,
+    > {
+        let prompt = messages.last().unwrap().content.clone();
+        let reply = if prompt.starts_with("List one") {
+            "speak".to_string()
+        } else if prompt.starts_with("Summarize") {
+            "summary".to_string()
+        } else {
+            "hello".to_string()
+        };
+        Ok(Box::pin(futures_util::stream::once(
+            async move { Ok(reply) },
+        )))
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn voice_speaks_after_intention() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            let (mouth, log) = LoggingMouth::new();
+            let psyche = Psyche::new(
+                Arc::new(DummyStore::new()),
+                Arc::new(TestLLM),
+                Arc::new(mouth),
+            );
+            let mut intents = psyche.will.receiver.resubscribe();
+
+            for i in 0..3 {
+                psyche
+                    .send_sensation(Sensation::new_text(format!("hi{}", i), "test"))
+                    .await
+                    .unwrap();
+            }
+
+            let _ = intents.recv().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            assert_eq!(log.lock().unwrap().len(), 1);
+            assert_eq!(log.lock().unwrap()[0], "hello");
+        })
+        .await;
+}


### PR DESCRIPTION
## Summary
- add an `Ear` component for feeding Pete's speech back into perception
- wire `Voice` and `Ear` into `Psyche` and react to intentions
- adjust `build_pete`/`launch_default_pete` to pass a mouth
- update examples and tests for new constructor
- add a new `voice_reactive` test exercising the loop

## Testing
- `cargo test --test psyche_reactive -- --nocapture`
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685d0863cfdc832096998b3ee2d99c41