### PR TITLE
Switch to streaming MotorEvent API

### DIFF
--- a/psyche-rs/examples/full_cycle.rs
+++ b/psyche-rs/examples/full_cycle.rs
@@ -1,6 +1,6 @@
 use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
 use psyche_rs::memory::Sensation;
-use psyche_rs::{DummyMouth, DummyStore, Psyche};
+use psyche_rs::{DummyMotor, DummyMouth, DummyStore, Psyche};
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -56,6 +56,7 @@ async fn main() {
         Arc::new(DummyStore::new()),
         Arc::new(DummyLLM),
         Arc::new(DummyMouth),
+        Arc::new(DummyMotor::new()),
     );
     let local = LocalSet::new();
     local

--- a/psyche-rs/src/motor.rs
+++ b/psyche-rs/src/motor.rs
@@ -1,33 +1,63 @@
-use crate::memory::{Completion, Intention, Interruption};
+use crate::memory::Intention;
+use tokio::sync::mpsc;
 
-#[async_trait::async_trait]
-pub trait MotorSystem: Send + Sync {
-    async fn invoke(&self, intention: &Intention) -> anyhow::Result<MotorFeedback>;
+/// Events sent to a [`Motor`] instance.
+#[derive(Debug, Clone)]
+pub enum MotorEvent {
+    /// Begin executing the given [`Intention`].
+    Begin(Intention),
+    /// Streaming chunk of output or feedback.
+    Chunk(String),
+    /// Signal that processing has finished.
+    End,
 }
 
-/// Feedback returned from a [`MotorSystem`] invocation.
-pub enum MotorFeedback {
-    /// The intention completed successfully with the given result.
-    Completed(Completion),
-    /// The intention was interrupted and did not complete.
-    Interrupted(Interruption),
+impl PartialEq for MotorEvent {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (MotorEvent::Begin(_), MotorEvent::Begin(_)) => true,
+            (MotorEvent::Chunk(a), MotorEvent::Chunk(b)) => a == b,
+            (MotorEvent::End, MotorEvent::End) => true,
+            _ => false,
+        }
+    }
 }
 
-/// A basic motor implementation used for testing. It simply prints the intended
-/// command in an XML-like format.
-pub struct DummyMotor;
+impl Eq for MotorEvent {}
 
 #[async_trait::async_trait]
-impl MotorSystem for DummyMotor {
-    async fn invoke(&self, intention: &Intention) -> anyhow::Result<MotorFeedback> {
-        println!("<{} {:?}/>", intention.motor_name, intention.parameters);
-        let comp = Completion {
-            uuid: uuid::Uuid::new_v4(),
-            intention: intention.uuid,
-            outcome: "success".to_string(),
-            transcript: Some(format!("Executed: {}", intention.motor_name)),
-            timestamp: std::time::SystemTime::now(),
-        };
-        Ok(MotorFeedback::Completed(comp))
+pub trait Motor: Send + Sync {
+    async fn handle(&self, mut rx: mpsc::Receiver<MotorEvent>) -> anyhow::Result<()>;
+}
+
+/// A basic motor implementation used for testing. It simply logs all received
+/// [`MotorEvent`]s.
+pub struct DummyMotor {
+    pub log: std::sync::Arc<tokio::sync::Mutex<Vec<MotorEvent>>>,
+}
+
+impl DummyMotor {
+    pub fn new() -> Self {
+        Self {
+            log: std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl Clone for DummyMotor {
+    fn clone(&self) -> Self {
+        Self {
+            log: self.log.clone(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Motor for DummyMotor {
+    async fn handle(&self, mut rx: mpsc::Receiver<MotorEvent>) -> anyhow::Result<()> {
+        while let Some(evt) = rx.recv().await {
+            self.log.lock().await.push(evt);
+        }
+        Ok(())
     }
 }

--- a/psyche-rs/tests/full_cycle.rs
+++ b/psyche-rs/tests/full_cycle.rs
@@ -2,7 +2,6 @@ use llm::chat::{ChatMessage, ChatProvider, ChatResponse};
 use psyche_rs::LLMExt;
 use psyche_rs::{
     memory::{Completion, Emotion, Impression, IntentionStatus, Memory, MemoryStore, Sensation},
-    motor::DummyMotor,
     mouth::Mouth,
     narrator::Narrator,
     voice::Voice,
@@ -206,10 +205,8 @@ impl Mouth for DummyMouth {
 async fn day_in_the_life_of_pete() {
     let store = Arc::new(DummyMemoryStore::new());
     let llm = Arc::new(DummyLLM);
-    let motor = Arc::new(DummyMotor);
-
     let mut quick = Quick::new(store.clone(), llm.clone());
-    let mut will = Will::new(store.clone(), motor);
+    let mut will = Will::new(store.clone());
     let mut fond = FondDuCoeur::new(store.clone(), llm.clone());
     let narrator = Narrator {
         store: store.clone(),

--- a/psyche-rs/tests/motor_tests.rs
+++ b/psyche-rs/tests/motor_tests.rs
@@ -1,162 +1,40 @@
-use psyche_rs::{
-    Completion, Intention, IntentionStatus, Interruption, Memory, MemoryStore, Urge,
-    motor::{DummyMotor, MotorFeedback, MotorSystem},
-    wit::Wit,
-    wits::will::Will,
-};
+use psyche_rs::memory::{Intention, IntentionStatus};
+use psyche_rs::motor::{DummyMotor, Motor, MotorEvent};
 use serde_json::json;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::SystemTime;
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::mpsc;
 use uuid::Uuid;
 
-struct MockStore {
-    data: Arc<AsyncMutex<HashMap<Uuid, Memory>>>,
-}
-
-impl MockStore {
-    fn new() -> Self {
-        Self {
-            data: Arc::new(AsyncMutex::new(HashMap::new())),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl MemoryStore for MockStore {
-    async fn save(&self, memory: &Memory) -> anyhow::Result<()> {
-        self.data.lock().await.insert(memory.uuid(), memory.clone());
-        Ok(())
-    }
-
-    async fn get_by_uuid(&self, uuid: Uuid) -> anyhow::Result<Option<Memory>> {
-        Ok(self.data.lock().await.get(&uuid).cloned())
-    }
-
-    async fn recent(&self, _limit: usize) -> anyhow::Result<Vec<Memory>> {
-        Ok(Vec::new())
-    }
-
-    async fn of_type(&self, _type_name: &str, _limit: usize) -> anyhow::Result<Vec<Memory>> {
-        Ok(Vec::new())
-    }
-
-    async fn recent_since(&self, _: SystemTime) -> anyhow::Result<Vec<Memory>> {
-        Ok(Vec::new())
-    }
-
-    async fn impressions_containing(&self, _: &str) -> anyhow::Result<Vec<psyche_rs::Impression>> {
-        Ok(Vec::new())
-    }
-
-    async fn complete_intention(
-        &self,
-        intention_id: Uuid,
-        completion: Completion,
-    ) -> anyhow::Result<()> {
-        self.save(&Memory::Completion(completion.clone())).await?;
-        if let Some(Memory::Intention(i)) = self.data.lock().await.get_mut(&intention_id) {
-            i.status = IntentionStatus::Completed;
-            i.resolved_at = Some(completion.timestamp);
-        }
-        Ok(())
-    }
-
-    async fn interrupt_intention(
-        &self,
-        intention_id: Uuid,
-        interruption: Interruption,
-    ) -> anyhow::Result<()> {
-        self.save(&Memory::Interruption(interruption.clone()))
-            .await?;
-        if let Some(Memory::Intention(i)) = self.data.lock().await.get_mut(&intention_id) {
-            i.status = IntentionStatus::Interrupted;
-            i.resolved_at = Some(interruption.timestamp);
-        }
-        Ok(())
-    }
-}
-
-fn example_urge() -> Urge {
-    Urge {
-        uuid: Uuid::new_v4(),
-        source: Uuid::new_v4(),
-        motor_name: "move_forward".into(),
-        parameters: json!({"speed":0.5,"duration":3.0}),
-        intensity: 1.0,
-        timestamp: SystemTime::now(),
-    }
-}
-
 #[tokio::test]
-async fn will_invokes_dummy_motor() {
-    let store = Arc::new(MockStore::new());
-    struct RecordingMotor {
-        inner: DummyMotor,
-        log: Arc<AsyncMutex<Vec<String>>>,
-    }
-
-    #[async_trait::async_trait]
-    impl MotorSystem for RecordingMotor {
-        async fn invoke(&self, intention: &Intention) -> anyhow::Result<MotorFeedback> {
-            let feedback = self.inner.invoke(intention).await?;
-            let msg = format!("<{} {:?}/>", intention.motor_name, intention.parameters);
-            self.log.lock().await.push(msg);
-            Ok(feedback)
-        }
-    }
-
-    let log = Arc::new(AsyncMutex::new(Vec::new()));
-    let motor = Arc::new(RecordingMotor {
-        inner: DummyMotor,
-        log: log.clone(),
+async fn motor_receives_event_stream() {
+    let motor = DummyMotor::new();
+    let log = motor.log.clone();
+    let (tx, rx) = mpsc::channel(8);
+    let motor_clone = motor.clone();
+    tokio::spawn(async move {
+        motor_clone.handle(rx).await.unwrap();
     });
-    let mut will = Will::new(store, motor);
 
-    let urge = example_urge();
-    will.observe(urge.clone()).await;
+    let intention = Intention {
+        uuid: Uuid::new_v4(),
+        urge: Uuid::new_v4(),
+        motor_name: "doit".into(),
+        parameters: json!({}),
+        issued_at: std::time::SystemTime::now(),
+        resolved_at: None,
+        status: IntentionStatus::Pending,
+    };
 
-    let intent = will.distill().await.expect("should produce intention");
-    drop(will);
-    let logged = log.lock().await.pop().expect("motor not invoked");
-    assert_eq!(
-        logged,
-        format!("<{} {:?}/>", intent.motor_name, intent.parameters)
-    );
-}
+    tx.send(MotorEvent::Begin(intention.clone())).await.unwrap();
+    tx.send(MotorEvent::Chunk("a".into())).await.unwrap();
+    tx.send(MotorEvent::Chunk("b".into())).await.unwrap();
+    tx.send(MotorEvent::End).await.unwrap();
+    drop(tx);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-#[tokio::test]
-async fn completion_is_persisted() {
-    let store = Arc::new(MockStore::new());
-    let motor = Arc::new(DummyMotor);
-    let mut will = Will::new(store.clone(), motor);
-
-    let urge = example_urge();
-    will.observe(urge.clone()).await;
-
-    let intent = will.distill().await.expect("intent not produced");
-
-    // Fetch updated intention to verify completion status.
-    let saved = store.get_by_uuid(intent.uuid).await.unwrap().unwrap();
-    match saved {
-        Memory::Intention(ref i) => {
-            assert!(matches!(i.status, IntentionStatus::Completed));
-            assert!(i.resolved_at.is_some());
-        }
-        _ => panic!("expected Intention"),
-    }
-
-    // Ensure a Completion exists referencing the intention.
-    let completions: Vec<Completion> = store
-        .data
-        .lock()
-        .await
-        .values()
-        .filter_map(|m| match m {
-            Memory::Completion(c) if c.intention == intent.uuid => Some(c.clone()),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(completions.len(), 1);
+    let events = log.lock().await.clone();
+    assert_eq!(events.len(), 4);
+    matches!(events[0], MotorEvent::Begin(_));
+    assert_eq!(events[1], MotorEvent::Chunk("a".into()));
+    assert_eq!(events[2], MotorEvent::Chunk("b".into()));
+    assert_eq!(events[3], MotorEvent::End);
 }

--- a/psyche-rs/tests/psyche_build.rs
+++ b/psyche-rs/tests/psyche_build.rs
@@ -95,7 +95,12 @@ async fn psyche_construction() {
             let store = Arc::new(DummyStore);
             let llm = Arc::new(DummyLLM);
 
-            let psyche = Psyche::new(store, llm, Arc::new(psyche_rs::DummyMouth));
+            let psyche = Psyche::new(
+                store,
+                llm,
+                Arc::new(psyche_rs::DummyMouth),
+                Arc::new(psyche_rs::DummyMotor::new()),
+            );
             psyche
                 .send_sensation(Sensation::new_text("hi", "test"))
                 .await

--- a/psyche-rs/tests/psyche_reactive.rs
+++ b/psyche-rs/tests/psyche_reactive.rs
@@ -109,7 +109,12 @@ async fn sensation_flows_to_intention() {
         .run_until(async {
             let store = Arc::new(MemStore::new());
             let llm = Arc::new(DummyLLM);
-            let psyche = Psyche::new(store, llm, Arc::new(psyche_rs::DummyMouth));
+            let psyche = Psyche::new(
+                store,
+                llm,
+                Arc::new(psyche_rs::DummyMouth),
+                Arc::new(psyche_rs::DummyMotor::new()),
+            );
             let mut rx = psyche.will.receiver.resubscribe();
 
             for i in 0..3 {

--- a/psyche-rs/tests/voice_reactive.rs
+++ b/psyche-rs/tests/voice_reactive.rs
@@ -84,6 +84,7 @@ async fn voice_speaks_after_intention() {
                 Arc::new(DummyStore::new()),
                 Arc::new(TestLLM),
                 Arc::new(mouth),
+                Arc::new(psyche_rs::DummyMotor::new()),
             );
             let mut intents = psyche.will.receiver.resubscribe();
 


### PR DESCRIPTION
## Summary
- introduce `MotorEvent` enum and async `Motor` trait
- log events in `DummyMotor`
- update `Will` to just emit `Intention`
- route `Intention` events to the motor in `Psyche`
- adapt examples and tests to new streaming API
- add regression test for motor event flow

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685d80714a9c832080ee138dec0cb095