### PR TITLE
Introduce Action object for urges

### DIFF
--- a/psyche-rs/src/action.rs
+++ b/psyche-rs/src/action.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+use crate::memory::IntentionStatus;
+
+/// Describes a potential act Pete might perform.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Action {
+    /// Name of the action, typically matching a motor command.
+    pub name: String,
+    /// Arbitrary attributes parsed from motor XML or other sources.
+    pub attributes: Value,
+}
+
+impl Action {
+    /// Create a new [`Action`] with the provided name and attributes.
+    pub fn new(name: impl Into<String>, attributes: impl Into<Value>) -> Self {
+        Self {
+            name: name.into(),
+            attributes: attributes.into(),
+        }
+    }
+}
+
+/// Full record of an issued action from urge through completion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Enactment {
+    pub uuid: Uuid,
+    /// UUID of the originating [`Impression`].
+    pub source: Uuid,
+    pub action: Action,
+    pub issued_at: SystemTime,
+    pub resolved_at: Option<SystemTime>,
+    pub status: IntentionStatus,
+}
+
+/// Convenience builders for [`Action`].
+pub mod action {
+    use super::Action;
+    use serde_json::json;
+
+    /// Create an [`Action`] with no attributes.
+    pub fn of(name: &str) -> Action {
+        Action::new(name, json!({}))
+    }
+
+    /// Create an [`Action`] using the supplied attributes.
+    pub fn with(name: &str, attributes: impl Into<serde_json::Value>) -> Action {
+        Action::new(name, attributes)
+    }
+}
+
+/// Convenience builders for [`Urge`].
+pub mod urge {
+    use super::Action;
+    use crate::memory::Urge;
+    use std::time::SystemTime;
+    use uuid::Uuid;
+
+    /// Construct a new [`Urge`] targeting the given action.
+    pub fn to(action: Action, source: Uuid) -> Urge {
+        Urge {
+            uuid: Uuid::new_v4(),
+            source,
+            action,
+            intensity: 1.0,
+            timestamp: SystemTime::now(),
+        }
+    }
+}

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod action;
 pub mod codec;
 pub mod conversation;
 pub mod countenance;
@@ -16,6 +17,7 @@ pub mod voice;
 pub mod wit;
 pub mod wits;
 
+pub use action::*;
 pub use conversation::*;
 pub use countenance::*;
 pub use ear::*;

--- a/psyche-rs/src/llm.rs
+++ b/psyche-rs/src/llm.rs
@@ -92,8 +92,7 @@ pub trait LLMExt: ChatProvider + Send + Sync {
         Ok(vec![Urge {
             uuid: Uuid::new_v4(),
             source: impression.uuid,
-            motor_name: text.trim().to_string(),
-            parameters: serde_json::json!({}),
+            action: crate::action::Action::new(text.trim(), serde_json::json!({})),
             intensity: 1.0,
             timestamp: impression.timestamp,
         }])

--- a/psyche-rs/src/memory.rs
+++ b/psyche-rs/src/memory.rs
@@ -3,6 +3,8 @@ use std::any::Any;
 use std::time::SystemTime;
 use uuid::Uuid;
 
+use crate::action::Action;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Sensation {
     pub uuid: Uuid,
@@ -44,8 +46,8 @@ pub struct Impression {
 pub struct Urge {
     pub uuid: Uuid,
     pub source: Uuid,
-    pub motor_name: String,
-    pub parameters: serde_json::Value,
+    /// The action Pete feels compelled to perform.
+    pub action: Action,
     pub intensity: f32,
     pub timestamp: SystemTime,
 }
@@ -63,8 +65,8 @@ pub enum IntentionStatus {
 pub struct Intention {
     pub uuid: Uuid,
     pub urge: Uuid,
-    pub motor_name: String,
-    pub parameters: serde_json::Value,
+    /// The action Pete intends to enact.
+    pub action: Action,
     pub issued_at: SystemTime,
     pub resolved_at: Option<SystemTime>,
     pub status: IntentionStatus,

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -115,7 +115,7 @@ impl Psyche {
         let llm_clone2 = llm.clone();
         spawn_local(async move {
             while let Ok(intent) = intent_sub.recv().await {
-                info!("🎤 Voice reacting to intent: {}", intent.motor_name);
+                info!("🎤 Voice reacting to intent: {}", intent.action.name);
 
                 // motor event stream
                 let tx = motor_sender.clone();
@@ -125,7 +125,7 @@ impl Psyche {
                     let _ = tx.send(MotorEvent::Begin(intent_clone.clone())).await;
                     if let Ok(mut stream) = llm_inner
                         .chat_stream(&[ChatMessage::user()
-                            .content(intent_clone.motor_name.clone())
+                            .content(intent_clone.action.name.clone())
                             .build()])
                         .await
                     {

--- a/psyche-rs/src/wits/will.rs
+++ b/psyche-rs/src/wits/will.rs
@@ -41,8 +41,7 @@ impl Wit<Urge, Intention> for Will {
         let intent = Intention {
             uuid: Uuid::new_v4(),
             urge: urge.uuid,
-            motor_name: urge.motor_name,
-            parameters: urge.parameters,
+            action: urge.action,
             issued_at: SystemTime::now(),
             resolved_at: None,
             status: IntentionStatus::Pending,
@@ -50,7 +49,7 @@ impl Wit<Urge, Intention> for Will {
 
         let _ = self.store.save(&Memory::Intention(intent.clone())).await;
 
-        info!("🎯 Pete intends: {}", intent.motor_name);
+        info!("🎯 Pete intends: {}", intent.action.name);
 
         Some(intent)
     }

--- a/psyche-rs/tests/motor_tests.rs
+++ b/psyche-rs/tests/motor_tests.rs
@@ -1,6 +1,6 @@
+use psyche_rs::action::action;
 use psyche_rs::memory::{Intention, IntentionStatus};
 use psyche_rs::motor::{DummyMotor, Motor, MotorEvent};
-use serde_json::json;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -17,8 +17,7 @@ async fn motor_receives_event_stream() {
     let intention = Intention {
         uuid: Uuid::new_v4(),
         urge: Uuid::new_v4(),
-        motor_name: "doit".into(),
-        parameters: json!({}),
+        action: action::of("doit"),
         issued_at: std::time::SystemTime::now(),
         resolved_at: None,
         status: IntentionStatus::Pending,

--- a/psyche-rs/tests/psyche_reactive.rs
+++ b/psyche-rs/tests/psyche_reactive.rs
@@ -125,7 +125,7 @@ async fn sensation_flows_to_intention() {
             }
 
             let intent = rx.recv().await.unwrap();
-            assert_eq!(intent.motor_name, "jump");
+            assert_eq!(intent.action.name, "jump");
         })
         .await;
 }

--- a/psyche-rs/tests/store_tests.rs
+++ b/psyche-rs/tests/store_tests.rs
@@ -1,3 +1,4 @@
+use psyche_rs::action::action;
 use psyche_rs::{Completion, Intention, IntentionStatus, Interruption, Memory, MemoryStore, Urge};
 use serde_json::json;
 use std::collections::HashMap;
@@ -130,8 +131,7 @@ fn example_urge(ts: SystemTime) -> Urge {
     Urge {
         uuid: Uuid::new_v4(),
         source: Uuid::new_v4(),
-        motor_name: "test".into(),
-        parameters: json!({"x": 1}),
+        action: action::with("test", json!({"x": 1})),
         intensity: 0.7,
         timestamp: ts,
     }
@@ -148,8 +148,7 @@ async fn save_and_get_urge_roundtrip() -> anyhow::Result<()> {
         Memory::Urge(u) => {
             assert_eq!(u.uuid, urge.uuid);
             assert_eq!(u.source, urge.source);
-            assert_eq!(u.motor_name, urge.motor_name);
-            assert_eq!(u.parameters, urge.parameters);
+            assert_eq!(u.action, urge.action);
             assert_eq!(u.intensity, urge.intensity);
         }
         other => panic!("expected Urge, got {:?}", other),
@@ -183,8 +182,7 @@ async fn completing_an_intention_updates_status() -> anyhow::Result<()> {
     let intention = Intention {
         uuid: Uuid::new_v4(),
         urge: urge.uuid,
-        motor_name: urge.motor_name.clone(),
-        parameters: urge.parameters.clone(),
+        action: urge.action.clone(),
         issued_at: SystemTime::now(),
         resolved_at: None,
         status: IntentionStatus::Pending,
@@ -225,8 +223,7 @@ async fn interrupting_an_intention_updates_status() -> anyhow::Result<()> {
     let intention = Intention {
         uuid: Uuid::new_v4(),
         urge: urge.uuid,
-        motor_name: urge.motor_name.clone(),
-        parameters: urge.parameters.clone(),
+        action: urge.action.clone(),
         issued_at: SystemTime::now(),
         resolved_at: None,
         status: IntentionStatus::Pending,

--- a/psyche-rs/tests/variants.rs
+++ b/psyche-rs/tests/variants.rs
@@ -1,3 +1,4 @@
+use psyche_rs::action::action;
 use psyche_rs::codec::serialize_memory;
 use psyche_rs::{
     Completion, Impression, Intention, IntentionStatus, Interruption, Memory, Sensation, Urge,
@@ -30,8 +31,7 @@ fn sample_urge(source: &Sensation) -> Urge {
     Urge {
         uuid: Uuid::new_v4(),
         source: source.uuid,
-        motor_name: "move".into(),
-        parameters: json!({"dir":"forward"}),
+        action: action::with("move", json!({"dir":"forward"})),
         intensity: 0.5,
         timestamp: UNIX_EPOCH,
     }
@@ -41,8 +41,7 @@ fn sample_intention(urge: &Urge) -> Intention {
     Intention {
         uuid: Uuid::new_v4(),
         urge: urge.uuid,
-        motor_name: urge.motor_name.clone(),
-        parameters: urge.parameters.clone(),
+        action: urge.action.clone(),
         issued_at: UNIX_EPOCH,
         resolved_at: None,
         status: IntentionStatus::Pending,


### PR DESCRIPTION
## Summary
- add new `Action` and `Enactment` types with helpers
- update `Urge` and `Intention` to use `Action`
- adjust codec, LLM helpers and `Will` implementation
- revise tests for new API

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685d854b3e4c8320a9a4d2983c892cdc