### PR TITLE
Improve streaming action parser

### DIFF
--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -131,14 +131,14 @@ impl Psyche {
                             .build()])
                         .await
                     {
-                        let mut acc = String::new();
+                        let mut raw_xml = String::new();
                         while let Some(chunk) = stream.next().await {
                             if let Ok(text) = chunk {
-                                acc.push_str(&text);
+                                raw_xml.push_str(&text);
                             }
                         }
 
-                        if let Some(parsed) = parse_streamed_action(&acc) {
+                        if let Some(parsed) = parse_streamed_action(&raw_xml) {
                             let _ = tx
                                 .send(MotorEvent::Begin(Intention {
                                     uuid: Uuid::new_v4(),

--- a/psyche-rs/src/stream_parser.rs
+++ b/psyche-rs/src/stream_parser.rs
@@ -1,6 +1,7 @@
 use quick_xml::Reader;
 use quick_xml::events::Event;
 use serde_json::{Map, Value};
+use tracing::{debug, error};
 
 use crate::action::Action;
 
@@ -14,7 +15,12 @@ pub struct ParsedAction {
     pub body: String,
 }
 
-/// Parse a single streamed action represented as XML.
+/// Parses a streamed action in XML format into a [`ParsedAction`].
+///
+/// Logs suspicious input structure and any parsing errors. Returns `None`
+/// if parsing fails or the input is malformed.
+///
+/// Example input: `<say pitch="low">hi</say>`
 ///
 /// # Examples
 ///
@@ -37,24 +43,56 @@ pub fn parse_streamed_action(xml: &str) -> Option<ParsedAction> {
     let mut attributes = Map::new();
     let mut body = String::new();
 
+    // Detect malformed or suspiciously complex input (e.g., multiple roots)
+    if xml.matches('<').count() > 1 && !xml.contains("</") {
+        debug!(%xml, "Input may contain multiple root elements or malformed structure");
+    }
+
+    let mut closed = false;
+    let mut depth = 0usize;
+
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) => {
-                action_name = Some(String::from_utf8_lossy(e.name().as_ref()).into_owned());
-                for attr in e.attributes().flatten() {
-                    let key = String::from_utf8_lossy(attr.key.as_ref()).into_owned();
-                    let value = attr.unescape_value().unwrap_or_default().to_string();
-                    attributes.insert(key, Value::String(value));
+                if depth == 0 {
+                    action_name = Some(String::from_utf8_lossy(e.name().as_ref()).into_owned());
+                    for attr in e.attributes().flatten() {
+                        let key = String::from_utf8_lossy(attr.key.as_ref()).into_owned();
+                        let value = attr.unescape_value().unwrap_or_default().to_string();
+                        attributes.insert(key, Value::String(value));
+                    }
                 }
+                depth += 1;
             }
             Ok(Event::Text(e)) => {
                 body.push_str(&e.unescape().unwrap_or_default());
             }
-            Ok(Event::Eof) | Ok(Event::End(_)) => break,
-            Err(_) => return None,
+            Ok(Event::End(_)) => {
+                if depth == 0 {
+                    error!(%xml, "Unexpected closing tag while parsing streamed action");
+                    return None;
+                }
+                depth -= 1;
+                if depth == 0 {
+                    closed = true;
+                    break;
+                }
+            }
+            Ok(Event::Eof) => {
+                error!(%xml, "Unexpected EOF while parsing streamed action");
+                return None;
+            }
+            Err(e) => {
+                error!(%xml, ?e, "Failed to parse streamed action");
+                return None;
+            }
             _ => {}
         }
         buf.clear();
+    }
+
+    if !closed {
+        return None;
     }
 
     Some(ParsedAction {
@@ -64,4 +102,16 @@ pub fn parse_streamed_action(xml: &str) -> Option<ParsedAction> {
         },
         body,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_malformed_stream_logs_and_fails() {
+        let xml = r#"<say pitch="high">Hello<do>Oops</do>"#;
+        let result = parse_streamed_action(xml);
+        assert!(result.is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- scope tracing imports to the parser module
- enhance `parse_streamed_action` documentation
- add sanity checks and return `None` on malformed input
- include regression test for malformed XML

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685d947d01448320ad6cae4edf25df75