### PR TITLE
Add demo turn example with MotorLog

### DIFF
--- a/psyche-rs/examples/demo_turn.rs
+++ b/psyche-rs/examples/demo_turn.rs
@@ -1,0 +1,97 @@
+//! Minimal end-to-end demo showing a single perception \u2192 cognition \u2192
+//! action loop.
+//!
+//! This example feeds a text [`Sensation`] into [`Psyche`] and prints the
+//! resulting [`MotorEvent`] stream using [`MotorLog`].
+
+use psyche_rs::*;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::task::LocalSet;
+
+use ::llm::ToolCall;
+use ::llm::chat::{ChatMessage, ChatProvider, ChatResponse};
+use ::llm::error::LLMError;
+
+/// Very small LLM implementation used for the demo.
+///
+/// When asked for an action suggestion (prompts starting with "List one"), it
+/// replies with `say`. All other prompts yield a small XML snippet instructing
+/// Pete to greet the user.
+struct DemoLLM;
+
+#[async_trait::async_trait]
+impl ChatProvider for DemoLLM {
+    async fn chat_with_tools(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: Option<&[::llm::chat::Tool]>,
+    ) -> Result<Box<dyn ChatResponse>, LLMError> {
+        Ok(Box::new(SimpleResp(String::new())))
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<Pin<Box<dyn futures_util::Stream<Item = Result<String, LLMError>> + Send>>, LLMError>
+    {
+        let prompt = messages
+            .last()
+            .map(|m| m.content.clone())
+            .unwrap_or_default();
+        let reply = if prompt.starts_with("List one") {
+            "say".to_string()
+        } else {
+            "<say pitch=\"gentle\">Hello human</say>".to_string()
+        };
+        Ok(Box::pin(futures_util::stream::once(
+            async move { Ok(reply) },
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct SimpleResp(String);
+
+impl ChatResponse for SimpleResp {
+    fn text(&self) -> Option<String> {
+        Some(self.0.clone())
+    }
+
+    fn tool_calls(&self) -> Option<Vec<ToolCall>> {
+        None
+    }
+}
+
+impl std::fmt::Display for SimpleResp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let local = LocalSet::new();
+    local
+        .run_until(async move {
+            let psyche = Psyche::new(
+                Arc::new(DummyStore::new()),
+                Arc::new(DemoLLM),
+                Arc::new(DummyMouth),
+                Arc::new(MotorLog),
+            );
+
+            psyche
+                .send_sensation(Sensation::new_text("Hello Pete, please say hi.", "demo"))
+                .await
+                .unwrap();
+
+            // Allow some time for the async pipeline to process the input.
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        })
+        .await;
+
+    Ok(())
+}

--- a/psyche-rs/src/motor.rs
+++ b/psyche-rs/src/motor.rs
@@ -61,3 +61,29 @@ impl Motor for DummyMotor {
         Ok(())
     }
 }
+
+/// Simple [`Motor`] implementation that logs events to stdout.
+///
+/// This is useful for examples where we want to see the action stream
+/// produced by `Psyche` without integrating a real motor backend.
+pub struct MotorLog;
+
+#[async_trait::async_trait]
+impl Motor for MotorLog {
+    async fn handle(&self, mut rx: mpsc::Receiver<MotorEvent>) -> anyhow::Result<()> {
+        while let Some(event) = rx.recv().await {
+            match event {
+                MotorEvent::Begin(intent) => {
+                    println!("\u{1F528} [Motor] Begin: {:?}", intent.action);
+                }
+                MotorEvent::Chunk(text) => {
+                    println!("\u{1F5E3}\u{FE0F} [Motor] Chunk: {}", text);
+                }
+                MotorEvent::End => {
+                    println!("\u{2705} [Motor] End");
+                }
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add a `MotorLog` motor that logs motor events
- create `examples/demo_turn.rs` showcasing a single perception→cognition→action loop

## Testing
- `cargo test -p psyche-rs --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685da49d2cd08320b6b82a9b90b96d87