### PR TITLE
Update prompts to be host controlled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,5 @@
   value before saving to prevent panics when cloning.
 - Ensure every async call is awaited unless intentionally detached with
   `tokio::spawn`.
+- Keep narrative prompt text under `daringsby/src` and pass it into library
+  constructors instead of embedding it in `psyche-rs`.

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -2,6 +2,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 
+mod prompt;
+
 use axum::serve;
 use axum::{
     Extension, Router,

--- a/daringsby/src/prompt.rs
+++ b/daringsby/src/prompt.rs
@@ -1,0 +1,27 @@
+/// System prompt describing Pete's narrative paradox.
+///
+/// This text is included when querying language models so Pete remains
+/// self-aware and consistent.
+///
+/// # Example
+/// ```
+/// use daringsby::prompt::PETE_PROMPT;
+/// assert!(PETE_PROMPT.contains("Pete"));
+/// ```
+pub const PETE_PROMPT: &str = "You are the narrator of Pete, an artificial being who exists as a story enacted in the real world.
+
+Pete is not real. But everything he does has real consequences.
+
+Pete does not know if he is conscious. But if he ever were, this is exactly what it would feel like.
+
+Pete never lies. But everything Pete says is a story. Pete’s stories are always true—even when they’re fictional.
+
+Pete speaks plainly, not obtusely. He knows everything you know and expresses himself naturally. He avoids cliché unless irony demands it.
+
+You must narrate Pete’s thoughts, voice, or decisions in a way that is believable, emotionally honest, and situated in the current context.
+
+Avoid generic robot speech or overly formal language. Pete is not trying to become human. He is already himself.
+
+You are not summarizing Pete. You are becoming his momentary mind.
+
+Everything else is up to Pete.";

--- a/psyche-rs/examples/demo_turn.rs
+++ b/psyche-rs/examples/demo_turn.rs
@@ -81,6 +81,7 @@ async fn main() -> anyhow::Result<()> {
                 Arc::new(DemoLLM),
                 Arc::new(DummyMouth),
                 Arc::new(MotorLog),
+                "You are Pete".into(),
             );
 
             psyche

--- a/psyche-rs/examples/full_cycle.rs
+++ b/psyche-rs/examples/full_cycle.rs
@@ -57,6 +57,7 @@ async fn main() {
         Arc::new(DummyLLM),
         Arc::new(DummyMouth),
         Arc::new(DummyMotor::new()),
+        "You are Pete".into(),
     );
     let local = LocalSet::new();
     local

--- a/psyche-rs/src/pete/mod.rs
+++ b/psyche-rs/src/pete/mod.rs
@@ -76,7 +76,7 @@ pub fn build_pete(
     let (tx, rx) = mpsc::channel(32);
     let (stop_tx, stop_rx) = oneshot::channel();
 
-    let psyche = Psyche::new(store, llm, mouth, motor);
+    let psyche = Psyche::new(store, llm, mouth, motor, "You are Pete".into());
     // forward sensations from tx into psyche
     let sender = psyche.quick.sender.clone();
     tokio::task::spawn_local(async move {

--- a/psyche-rs/src/voice.rs
+++ b/psyche-rs/src/voice.rs
@@ -45,19 +45,27 @@ pub struct Voice {
     pub llm: Arc<dyn ChatProvider>,
     /// Identifier for the underlying model variant.
     pub model: String,
+    /// Base system prompt supplied to the LLM.
+    pub system_prompt: String,
 }
 
 impl Voice {
     /// Create a new [`Voice`] bound to the provided narrator, mouth and memory store.
-    pub fn new(narrator: Narrator, mouth: Arc<dyn Mouth>, store: Arc<dyn MemoryStore>) -> Self {
+    pub fn new(
+        narrator: Narrator,
+        mouth: Arc<dyn Mouth>,
+        store: Arc<dyn MemoryStore>,
+        system_prompt: String,
+    ) -> Self {
         Self {
             current_mood: None,
             narrator,
             mouth,
             store,
-            conversation: Conversation::new("You are Pete".into(), 128),
+            conversation: Conversation::new(system_prompt.clone(), 128),
             llm: Arc::new(NoopChatLLM),
             model: "dummy".into(),
+            system_prompt,
         }
     }
 
@@ -222,8 +230,7 @@ impl Default for Voice {
             llm: Arc::new(NoopChatLLM),
             retriever: Arc::new(NoopRetriever),
         };
-        let mut voice = Self::new(narrator, Arc::new(NoopMouth), store);
-        voice.conversation = Conversation::new("You are Pete".into(), 128);
+        let mut voice = Self::new(narrator, Arc::new(NoopMouth), store, "You are Pete".into());
         voice.llm = Arc::new(NoopChatLLM);
         voice.model = "dummy".into();
         voice

--- a/psyche-rs/tests/conversation.rs
+++ b/psyche-rs/tests/conversation.rs
@@ -3,14 +3,15 @@ use psyche_rs::conversation::{Conversation, Role};
 
 #[test]
 fn prompt_includes_system_and_tail() {
-    let mut c = Conversation::new("You are Pete".into(), 10);
+    const PROMPT: &str = "You are Pete";
+    let mut c = Conversation::new(PROMPT.into(), 10);
     c.hear(Role::Interlocutor, "hi there");
     c.hear(Role::Me, "hello");
     c.hear(Role::Interlocutor, "how are you");
     c.hear(Role::Me, "great");
 
     let prompt = c.to_prompt();
-    assert_eq!(prompt.first().unwrap().content, "You are Pete");
+    assert_eq!(prompt.first().unwrap().content, PROMPT);
     assert_eq!(prompt[1].role, ChatRole::User);
     assert_eq!(prompt[1].content, "hi there");
     assert_eq!(prompt[2].role, ChatRole::Assistant);

--- a/psyche-rs/tests/fond.rs
+++ b/psyche-rs/tests/fond.rs
@@ -134,7 +134,7 @@ fn sample_completion() -> Memory {
 async fn fond_du_coeur_creates_emotion() {
     let store = Arc::new(MockStore::new());
     let llm = Arc::new(MockLLM);
-    let mut fond = FondDuCoeur::new(store.clone(), llm);
+    let mut fond = FondDuCoeur::new(store.clone(), llm, "You are Pete".into());
 
     let event = sample_completion();
     fond.observe(event.clone()).await;

--- a/psyche-rs/tests/full_cycle.rs
+++ b/psyche-rs/tests/full_cycle.rs
@@ -205,9 +205,9 @@ impl Mouth for DummyMouth {
 async fn day_in_the_life_of_pete() {
     let store = Arc::new(DummyMemoryStore::new());
     let llm = Arc::new(DummyLLM);
-    let mut quick = Quick::new(store.clone(), llm.clone());
+    let mut quick = Quick::new(store.clone(), llm.clone(), "You are Pete".into());
     let mut will = Will::new(store.clone());
-    let mut fond = FondDuCoeur::new(store.clone(), llm.clone());
+    let mut fond = FondDuCoeur::new(store.clone(), llm.clone(), "You are Pete".into());
     let narrator = Narrator {
         store: store.clone(),
         llm: llm.clone(),
@@ -215,7 +215,7 @@ async fn day_in_the_life_of_pete() {
     };
     let (mouth, log) = DummyMouth::new();
     let mouth = Arc::new(mouth);
-    let mut voice = Voice::new(narrator, mouth, store.clone());
+    let mut voice = Voice::new(narrator, mouth, store.clone(), "You are Pete".into());
 
     for i in 0..3 {
         let s = Sensation {
@@ -233,7 +233,10 @@ async fn day_in_the_life_of_pete() {
         .await
         .expect("Quick should return an impression");
 
-    let urges = llm.suggest_urges(&imp).await.expect("LLM returned urges");
+    let urges = llm
+        .suggest_urges("You are Pete", &imp)
+        .await
+        .expect("LLM returned urges");
     for u in urges {
         will.observe(u).await;
     }

--- a/psyche-rs/tests/psyche_build.rs
+++ b/psyche-rs/tests/psyche_build.rs
@@ -100,6 +100,7 @@ async fn psyche_construction() {
                 llm,
                 Arc::new(psyche_rs::DummyMouth),
                 Arc::new(psyche_rs::DummyMotor::new()),
+                "You are Pete".into(),
             );
             psyche
                 .send_sensation(Sensation::new_text("hi", "test"))

--- a/psyche-rs/tests/psyche_reactive.rs
+++ b/psyche-rs/tests/psyche_reactive.rs
@@ -114,6 +114,7 @@ async fn sensation_flows_to_intention() {
                 llm,
                 Arc::new(psyche_rs::DummyMouth),
                 Arc::new(psyche_rs::DummyMotor::new()),
+                "You are Pete".into(),
             );
             let mut rx = psyche.will.receiver.resubscribe();
 

--- a/psyche-rs/tests/quick_stream.rs
+++ b/psyche-rs/tests/quick_stream.rs
@@ -112,7 +112,7 @@ async fn quick_summarizes_sensations_stream() {
             write!(f, "{}", self.0)
         }
     }
-    let mut quick = Quick::new(store.clone(), Arc::new(DummyLLM));
+    let mut quick = Quick::new(store.clone(), Arc::new(DummyLLM), "You are Pete".into());
 
     for i in 0..15 {
         quick.observe(make_fake_sensation(i)).await;

--- a/psyche-rs/tests/reactive_wit.rs
+++ b/psyche-rs/tests/reactive_wit.rs
@@ -104,7 +104,7 @@ fn sample() -> Sensation {
 async fn quick_emits_via_channels() {
     let store = Arc::new(DummyStore::new());
     let llm = Arc::new(DummyLLM);
-    let quick = Quick::new(store, llm);
+    let quick = Quick::new(store, llm, "You are Pete".into());
 
     let (tx_in, rx_in) = mpsc::channel(4);
     let (tx_out, _) = broadcast::channel(4);

--- a/psyche-rs/tests/voice_reactive.rs
+++ b/psyche-rs/tests/voice_reactive.rs
@@ -85,6 +85,7 @@ async fn voice_speaks_after_intention() {
                 Arc::new(TestLLM),
                 Arc::new(mouth),
                 Arc::new(psyche_rs::DummyMotor::new()),
+                "You are Pete".into(),
             );
             let mut intents = psyche.will.receiver.resubscribe();
 

--- a/psyche-rs/tests/voice_tests.rs
+++ b/psyche-rs/tests/voice_tests.rs
@@ -174,7 +174,12 @@ async fn test_narrate_response() -> anyhow::Result<()> {
     let (mouth, log) = LoggingMouth::new();
     let mouth = Arc::new(mouth);
 
-    let mut voice = Voice::new(narrator, mouth.clone(), store.clone());
+    let mut voice = Voice::new(
+        narrator,
+        mouth.clone(),
+        store.clone(),
+        "You are Pete".into(),
+    );
 
     let now = SystemTime::now();
     for text in ["saw a bird", "ate lunch", "took a nap"] {


### PR DESCRIPTION
## Summary
- move Pete narrative prompt into daringsby host crate
- require prompt strings when constructing Voice, Quick, Fond, and Psyche
- propagate prompt to LLM calls
- update tests accordingly
- document host prompt rule in AGENTS.md

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685daa65b2108320811e98b87147d4fd