### PR TITLE
Add Psyche orchestrator and heartbeat CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,7 +622,17 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 name = "daringsby"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
+ "async-trait",
+ "chrono",
+ "clap",
+ "futures",
+ "llm",
  "psyche-rs",
+ "rand",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1588,6 +1620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1708,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -1787,6 +1835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1872,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -1840,6 +1898,36 @@ checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
  "endian-type",
  "nibble_vec",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2141,6 +2229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,6 +2450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,7 +2610,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2514,6 +2632,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2591,6 +2735,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -3014,6 +3164,26 @@ dependencies = [
  "quote",
  "syn 2.0.104",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -5,3 +5,13 @@ edition = "2024"
 
 [dependencies]
 psyche-rs = { path = "../psyche-rs" }
+tokio = { version = "1", features = ["macros", "rt"] }
+clap = { version = "4", features = ["derive"] }
+rand = "0.8"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+chrono = "0.4"
+futures = "0.3"
+async-stream = "0.3"
+async-trait = "0.1"
+llm = "1.3.1"

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -1,3 +1,67 @@
-fn main() {
-    println!("daringsby example");
+use async_stream::stream;
+use async_trait::async_trait;
+use clap::Parser;
+use rand::Rng;
+use std::sync::Arc;
+use tracing::{Level, info};
+
+use llm::builder::{LLMBackend, LLMBuilder};
+use psyche_rs::{Motor, MotorCommand, Psyche, Sensation, Sensor, Wit};
+
+struct Heartbeat;
+
+impl Sensor<String> for Heartbeat {
+    fn stream(&mut self) -> futures::stream::BoxStream<'static, Vec<Sensation<String>>> {
+        let stream = stream! {
+            loop {
+                let jitter = {
+                    let mut rng = rand::thread_rng();
+                    rng.gen_range(0..15)
+                };
+                tokio::time::sleep(std::time::Duration::from_secs(60 + jitter)).await;
+                let now = chrono::Local::now();
+                let msg = format!("It's {} o'clock, and I felt my heart beat, so I know I'm alive.", now.format("%H"));
+                let s = Sensation { kind: "heartbeat".into(), when: chrono::Utc::now(), what: msg, source: None };
+                yield vec![s];
+            }
+        };
+        Box::pin(stream)
+    }
+}
+
+struct LoggingMotor;
+
+#[async_trait(?Send)]
+impl Motor<String> for LoggingMotor {
+    async fn execute(&mut self, command: MotorCommand<String>) {
+        info!(?command.content, "motor log");
+    }
+}
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long, default_value = "http://localhost:14434")]
+    base_url: String,
+    #[arg(long, default_value = "gemma3:27b")]
+    model: String,
+    #[arg(long, default_value = "ollama")]
+    backend: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::DEBUG)
+        .init();
+    let args = Args::parse();
+    let backend = args.backend.parse::<LLMBackend>()?;
+    let llm = LLMBuilder::new()
+        .backend(backend)
+        .base_url(args.base_url)
+        .model(args.model)
+        .build()?;
+    let wit = Wit::new(Arc::from(llm));
+    let psyche = Psyche::new().sensor(Heartbeat).motor(LoggingMotor).wit(wit);
+    psyche.run().await;
+    Ok(())
 }

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -16,6 +16,7 @@ llm = "1.3.1"
 tokio = { version = "1", features = ["rt", "macros"] }
 tokio-stream = "0.1.17"
 segtok = "0.1.5"
+tracing = "0.1"
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod impression;
 mod motor;
+mod psyche;
 mod sensation;
 mod sensor;
 mod wit;
@@ -12,6 +13,7 @@ mod witness;
 
 pub use impression::Impression;
 pub use motor::{Motor, MotorCommand, MotorExecutor};
+pub use psyche::Psyche;
 pub use sensation::Sensation;
 pub use sensor::Sensor;
 pub use wit::Wit;

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -1,0 +1,228 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use futures::{
+    StreamExt,
+    stream::{self, BoxStream},
+};
+use tracing::{debug, info};
+
+use crate::{Impression, Motor, MotorCommand, Sensation, Sensor, Witness};
+
+#[async_trait(?Send)]
+trait WitnessRunner<T> {
+    async fn observe_boxed(
+        &mut self,
+        sensors: Vec<SharedSensor<T>>,
+    ) -> BoxStream<'static, Vec<Impression<T>>>;
+}
+
+struct BoxedWitness<T, W: Witness<T> + Send> {
+    inner: W,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T, W> BoxedWitness<T, W>
+where
+    W: Witness<T> + Send,
+{
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl<T, W> WitnessRunner<T> for BoxedWitness<T, W>
+where
+    T: Clone + Default + Send + 'static + serde::Serialize,
+    W: Witness<T> + Send,
+{
+    async fn observe_boxed(
+        &mut self,
+        sensors: Vec<SharedSensor<T>>,
+    ) -> BoxStream<'static, Vec<Impression<T>>> {
+        self.inner.observe(sensors).await
+    }
+}
+
+/// Sensor wrapper enabling shared ownership.
+struct SharedSensor<T> {
+    inner: Arc<Mutex<dyn Sensor<T> + Send>>,
+}
+
+impl<T> Clone for SharedSensor<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> SharedSensor<T> {
+    fn new(inner: Arc<Mutex<dyn Sensor<T> + Send>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T> Sensor<T> for SharedSensor<T> {
+    fn stream(&mut self) -> BoxStream<'static, Vec<Sensation<T>>> {
+        let mut sensor = self.inner.lock().expect("lock");
+        sensor.stream()
+    }
+}
+
+/// Core orchestrator coordinating sensors, wits and motors.
+pub struct Psyche<T = serde_json::Value> {
+    sensors: Vec<Arc<Mutex<dyn Sensor<T> + Send>>>,
+    motors: Vec<Box<dyn Motor<T> + Send>>,
+    wits: Vec<Box<dyn WitnessRunner<T> + Send>>,
+}
+
+impl<T> Psyche<T>
+where
+    T: Clone + Default + Send + 'static + serde::Serialize,
+{
+    /// Create an empty [`Psyche`].
+    pub fn new() -> Self {
+        Self {
+            sensors: Vec::new(),
+            motors: Vec::new(),
+            wits: Vec::new(),
+        }
+    }
+
+    /// Add a sensor to the psyche.
+    pub fn sensor(mut self, sensor: impl Sensor<T> + Send + 'static) -> Self {
+        self.sensors.push(Arc::new(Mutex::new(sensor)));
+        self
+    }
+
+    /// Add a motor to the psyche.
+    pub fn motor(mut self, motor: impl Motor<T> + Send + 'static) -> Self {
+        self.motors.push(Box::new(motor));
+        self
+    }
+
+    /// Add a wit to the psyche.
+    pub fn wit<W>(mut self, wit: W) -> Self
+    where
+        W: Witness<T> + Send + 'static,
+    {
+        self.wits.push(Box::new(BoxedWitness::new(wit)));
+        self
+    }
+}
+
+impl<T> Default for Psyche<T>
+where
+    T: Clone + Default + Send + 'static + serde::Serialize,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Psyche<T>
+where
+    T: Clone + Default + Send + 'static + serde::Serialize,
+{
+    /// Run the psyche until interrupted.
+    pub async fn run(mut self) {
+        debug!("starting psyche");
+        let mut streams = Vec::new();
+        for wit in self.wits.iter_mut() {
+            let sensors_for_wit: Vec<_> = self
+                .sensors
+                .iter()
+                .map(|s| SharedSensor::new(s.clone()))
+                .collect();
+            let stream = wit.observe_boxed(sensors_for_wit).await;
+            streams.push(stream);
+        }
+        let mut merged = stream::select_all(streams);
+        loop {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    info!("psyche shutting down");
+                    break;
+                }
+                Some(batch) = merged.next() => {
+                    for impression in batch {
+                        debug!(?impression.how, "impression received");
+                        for motor in self.motors.iter_mut() {
+                            let cmd = MotorCommand::<T> { name: "log".into(), args: T::default(), content: Some(impression.how.clone()) };
+                            motor.execute(cmd).await;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use futures::StreamExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct TestSensor;
+    impl Sensor<String> for TestSensor {
+        fn stream(&mut self) -> BoxStream<'static, Vec<Sensation<String>>> {
+            let s = Sensation {
+                kind: "t".into(),
+                when: chrono::Utc::now(),
+                what: "hi".into(),
+                source: None,
+            };
+            stream::once(async move { vec![s] }).boxed()
+        }
+    }
+
+    struct TestWit;
+    #[async_trait(?Send)]
+    impl Witness<String> for TestWit {
+        async fn observe<S>(
+            &mut self,
+            mut sensors: Vec<S>,
+        ) -> BoxStream<'static, Vec<Impression<String>>>
+        where
+            S: Sensor<String> + Send + 'static,
+        {
+            sensors
+                .pop()
+                .unwrap()
+                .stream()
+                .map(|s| {
+                    vec![Impression {
+                        how: s[0].what.clone(),
+                        what: s,
+                    }]
+                })
+                .boxed()
+        }
+    }
+
+    struct CountMotor(Arc<AtomicUsize>);
+    #[async_trait(?Send)]
+    impl Motor<String> for CountMotor {
+        async fn execute(&mut self, _cmd: MotorCommand<String>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn psyche_runs() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let psyche = Psyche::new()
+            .sensor(TestSensor)
+            .wit(TestWit)
+            .motor(CountMotor(count.clone()));
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(50), psyche.run()).await;
+        assert!(count.load(Ordering::SeqCst) > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- create Psyche orchestrator to coordinate sensors, wits and motors
- add logging motor and heartbeat sensor in CLI
- connect CLI to configurable LLM backend
- wire new module into library exports

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685e69220aa08320964c1855978094a1