### PR TITLE
Add heartbeat CLI with logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - When adding async traits that don't need `Send`, annotate with `#[async_trait(?Send)]`.
 - If running `rustfmt` touches unrelated files, it's fine to keep those changes.
 - Run `cargo fmt` before committing changes.
+- Instrument code with tracing logs at appropriate levels.
 - When implementing test memory stores that persist `Memory::Of`, clone the inner
   value before saving to prevent panics when cloning.
 - Ensure every async call is awaited unless intentionally detached with

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -3,6 +3,9 @@ name = "daringsby"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 psyche-rs = { path = "../psyche-rs" }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod heartbeat;
+pub mod logging_motor;
+
+pub use heartbeat::{Heartbeat, heartbeat_message};
+pub use logging_motor::LoggingMotor;

--- a/daringsby/src/logging_motor.rs
+++ b/daringsby/src/logging_motor.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+use tracing::info;
+
+use psyche_rs::{Motor, MotorCommand};
+
+/// Simple motor that logs every received command.
+#[derive(Default)]
+pub struct LoggingMotor;
+
+#[async_trait(?Send)]
+impl Motor<String> for LoggingMotor {
+    async fn execute(&mut self, command: MotorCommand<String>) {
+        info!(?command.content, "motor log");
+    }
+}

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -1,42 +1,11 @@
-use async_stream::stream;
-use async_trait::async_trait;
 use clap::Parser;
-use rand::Rng;
 use std::sync::Arc;
-use tracing::{Level, info};
+use tracing::Level;
 
 use llm::builder::{LLMBackend, LLMBuilder};
-use psyche_rs::{Motor, MotorCommand, Psyche, Sensation, Sensor, Wit};
+use psyche_rs::{Psyche, Wit};
 
-struct Heartbeat;
-
-impl Sensor<String> for Heartbeat {
-    fn stream(&mut self) -> futures::stream::BoxStream<'static, Vec<Sensation<String>>> {
-        let stream = stream! {
-            loop {
-                let jitter = {
-                    let mut rng = rand::thread_rng();
-                    rng.gen_range(0..15)
-                };
-                tokio::time::sleep(std::time::Duration::from_secs(60 + jitter)).await;
-                let now = chrono::Local::now();
-                let msg = format!("It's {} o'clock, and I felt my heart beat, so I know I'm alive.", now.format("%H"));
-                let s = Sensation { kind: "heartbeat".into(), when: chrono::Utc::now(), what: msg, source: None };
-                yield vec![s];
-            }
-        };
-        Box::pin(stream)
-    }
-}
-
-struct LoggingMotor;
-
-#[async_trait(?Send)]
-impl Motor<String> for LoggingMotor {
-    async fn execute(&mut self, command: MotorCommand<String>) {
-        info!(?command.content, "motor log");
-    }
-}
+use daringsby::{Heartbeat, LoggingMotor};
 
 #[derive(Parser)]
 struct Args {


### PR DESCRIPTION
## Summary
- implement heartbeat sensor and logging motor modules
- expose modules via daringsby library
- add CLI using these modules with configurable LLM
- trace LLM witness workflow
- note tracing guidance in AGENTS instructions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685eae842b8083209803806de5e3d051