### PR TITLE
Add source discovery sensor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "include_dir",
  "ollama-rs",
  "once_cell",
  "psyche-rs",
@@ -1187,6 +1188,25 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -20,3 +20,4 @@ async-trait = "0.1"
 ollama-rs = { version = "0.3.2", features = ["stream"] }
 once_cell = "1"
 serde_json = "1"
+include_dir = "0.7"

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod heartbeat;
 pub mod logging_motor;
 pub mod self_discovery;
+pub mod source_discovery;
 
 pub use heartbeat::{Heartbeat, heartbeat_message};
 pub use logging_motor::LoggingMotor;
 pub use self_discovery::SelfDiscovery;
+pub use source_discovery::SourceDiscovery;

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -7,12 +7,12 @@ use futures::{StreamExt, stream};
 use ollama_rs::Ollama;
 use once_cell::sync::Lazy;
 use psyche_rs::{
-    Action, Combobulator, Impression, ImpressionSensor, Motor, OllamaLLM, Sensor, Wit, Witness,
-    Sensation, SensationSensor,
+    Action, Combobulator, Impression, ImpressionSensor, Motor, OllamaLLM, Sensation,
+    SensationSensor, Sensor, Wit, Witness,
 };
 use serde_json::Value;
 
-use daringsby::{Heartbeat, LoggingMotor, SelfDiscovery};
+use daringsby::{Heartbeat, LoggingMotor, SelfDiscovery, SourceDiscovery};
 
 const COMBO_PROMPT: &str = include_str!("combobulator_prompt.txt");
 
@@ -50,6 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .observe(vec![
             Box::new(Heartbeat) as Box<dyn Sensor<String> + Send>,
             Box::new(SelfDiscovery) as Box<dyn Sensor<String> + Send>,
+            Box::new(SourceDiscovery) as Box<dyn Sensor<String> + Send>,
             Box::new(SensationSensor::new(sens_rx)), // Senses the moment coming out of the combobulator (?)
         ])
         .await;

--- a/daringsby/src/source_discovery.rs
+++ b/daringsby/src/source_discovery.rs
@@ -1,0 +1,97 @@
+use async_stream::stream;
+use include_dir::{Dir, include_dir};
+use once_cell::sync::Lazy;
+use rand::Rng;
+use tracing::debug;
+
+use psyche_rs::{Sensation, Sensor};
+
+/// Directory containing the crate's source code packaged into the binary.
+static SRC_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src");
+
+/// The source code chunks that will be revealed sequentially.
+static CHUNKS: Lazy<Vec<&'static str>> = Lazy::new(|| {
+    SRC_DIR
+        .files()
+        .filter_map(|f| {
+            if f.path().extension().and_then(|e| e.to_str()) == Some("rs") {
+                f.contents_utf8()
+            } else {
+                None
+            }
+        })
+        .collect()
+});
+
+/// Sensor that emits large chunks of the crate's source code.
+///
+/// Each batch contains a single sensation with the text
+/// `"I know that this is from my own source code: {chunk}"` where `{chunk}`
+/// is the contents of a Rust source file. The sensor cycles through all
+/// `.rs` files in the crate, sleeping for one or two seconds (with jitter)
+/// between emissions.
+///
+/// # Examples
+/// ```
+/// use futures::StreamExt;
+/// use daringsby::source_discovery::SourceDiscovery;
+/// use psyche_rs::Sensor;
+/// use tokio::runtime::Runtime;
+///
+/// let rt = Runtime::new().unwrap();
+/// rt.block_on(async {
+///     let mut sensor = SourceDiscovery::default();
+///     let mut stream = sensor.stream();
+///     if let Some(batch) = stream.next().await {
+///         assert!(batch[0].what.starts_with("I know that this is from my own source code:"));
+///     }
+/// });
+/// ```
+#[derive(Default)]
+pub struct SourceDiscovery;
+
+impl Sensor<String> for SourceDiscovery {
+    fn stream(&mut self) -> futures::stream::BoxStream<'static, Vec<Sensation<String>>> {
+        let chunks = CHUNKS.clone();
+        let stream = stream! {
+            let mut index = 0usize;
+            loop {
+                let jitter = { let mut rng = rand::thread_rng(); rng.gen_range(0..2) };
+                tokio::time::sleep(std::time::Duration::from_secs(1 + jitter)).await;
+                let chunk = chunks[index];
+                index = (index + 1) % chunks.len();
+                debug!(?index, "self source sensed");
+                let msg = format!("I know that this is from my own source code:\n{}", chunk);
+                let s = Sensation {
+                    kind: "self_source".into(),
+                    when: chrono::Utc::now(),
+                    what: msg,
+                    source: None,
+                };
+                yield vec![s];
+            }
+        };
+        Box::pin(stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn emits_first_chunk() {
+        let mut sensor = SourceDiscovery::default();
+        let mut stream = sensor.stream();
+        if let Some(batch) = stream.next().await {
+            let expected = format!(
+                "I know that this is from my own source code:\n{}",
+                CHUNKS[0]
+            );
+            assert_eq!(batch[0].what, expected);
+        } else {
+            panic!("no chunk emitted");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- embed daringsby crate source into binary
- add SourceDiscovery sensor that emits source code chunks
- hook SourceDiscovery into the main app
- export the new sensor from the library

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685ef9b9d8c88320a985fa1e0d90e88b