### PR TITLE
Add feature flag for moment feedback

### DIFF
--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -21,3 +21,6 @@ ollama-rs = { version = "0.3.2", features = ["stream"] }
 once_cell = "1"
 serde_json = "1"
 include_dir = "0.7"
+
+[features]
+moment-feedback = []

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -2,14 +2,17 @@ use clap::Parser;
 use std::sync::{Arc, Mutex};
 use tracing::Level;
 
+#[cfg(feature = "moment-feedback")]
 use chrono::Utc;
 use futures::{StreamExt, stream};
 use ollama_rs::Ollama;
 use once_cell::sync::Lazy;
 use psyche_rs::{
     Action, Combobulator, Impression, ImpressionSensor, LLMClient, LLMPool, Motor, OllamaLLM,
-    Sensation, SensationSensor, Sensor, Wit, Witness,
+    Sensor, Wit, Witness,
 };
+#[cfg(feature = "moment-feedback")]
+use psyche_rs::{Sensation, SensationSensor};
 use serde_json::Value;
 
 use daringsby::{Heartbeat, LoggingMotor, SelfDiscovery, SourceDiscovery};
@@ -18,6 +21,7 @@ const COMBO_PROMPT: &str = include_str!("combobulator_prompt.txt");
 
 static INSTANT: Lazy<Arc<Mutex<Vec<Impression<String>>>>> =
     Lazy::new(|| Arc::new(Mutex::new(Vec::new())));
+#[cfg(feature = "moment-feedback")]
 static MOMENT: Lazy<Arc<Mutex<Vec<Impression<Impression<String>>>>>> =
     Lazy::new(|| Arc::new(Mutex::new(Vec::new())));
 
@@ -51,16 +55,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut combob = Combobulator::new(llm).prompt(COMBO_PROMPT).delay_ms(1000);
 
     let (tx, rx) = unbounded_channel::<Vec<Impression<String>>>();
+    #[cfg(feature = "moment-feedback")]
     let (sens_tx, sens_rx) = unbounded_channel::<Vec<Sensation<String>>>();
 
-    let mut quick_stream = quick
-        .observe(vec![
-            Box::new(Heartbeat) as Box<dyn Sensor<String> + Send>,
-            Box::new(SelfDiscovery) as Box<dyn Sensor<String> + Send>,
-            Box::new(SourceDiscovery) as Box<dyn Sensor<String> + Send>,
-            Box::new(SensationSensor::new(sens_rx)), // Senses the moment coming out of the combobulator (?)
-        ])
-        .await;
+    let mut sensors: Vec<Box<dyn Sensor<String> + Send>> = vec![
+        Box::new(Heartbeat) as Box<dyn Sensor<String> + Send>,
+        Box::new(SelfDiscovery) as Box<dyn Sensor<String> + Send>,
+        Box::new(SourceDiscovery) as Box<dyn Sensor<String> + Send>,
+    ];
+    #[cfg(feature = "moment-feedback")]
+    sensors.push(Box::new(SensationSensor::new(sens_rx)));
+
+    let mut quick_stream = quick.observe(sensors).await;
     let sensor = ImpressionSensor::new(rx);
     let mut combo_stream = combob.observe(vec![sensor]).await;
     let motor = LoggingMotor;
@@ -73,6 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    #[cfg(feature = "moment-feedback")]
     tokio::spawn(async move {
         while let Some(imps) = combo_stream.next().await {
             *MOMENT.lock().unwrap() = imps.clone();
@@ -86,6 +93,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 })
                 .collect();
             let _ = sens_tx.send(sensed);
+            for imp in imps {
+                let text = imp.how.clone();
+                let body = stream::once(async move { text }).boxed();
+                let action = Action::new("log", Value::Null, body);
+                motor.perform(action).unwrap();
+            }
+        }
+    });
+
+    #[cfg(not(feature = "moment-feedback"))]
+    tokio::spawn(async move {
+        while let Some(imps) = combo_stream.next().await {
             for imp in imps {
                 let text = imp.how.clone();
                 let body = stream::once(async move { text }).boxed();


### PR DESCRIPTION
## Summary
- add `moment-feedback` feature to daringsby crate
- gate moment recycling logic behind the flag

## Testing
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_685f10565b588320979160fda47f7dde