### PR TITLE
Switch Wit from queue to timed window

### DIFF
--- a/psyche-rs/src/combobulator.rs
+++ b/psyche-rs/src/combobulator.rs
@@ -31,9 +31,9 @@ impl<T> Combobulator<T> {
         self
     }
 
-    /// Sets queue thresholds before invoking the LLM.
-    pub fn queue(mut self, min: usize, max: usize) -> Self {
-        self.wit = self.wit.queue(min, max);
+    /// Sets the sensation window duration in milliseconds.
+    pub fn window_ms(mut self, ms: u64) -> Self {
+        self.wit = self.wit.window_ms(ms);
         self
     }
 


### PR DESCRIPTION
## Summary
- store sensations in a time-based window inside `Wit`
- expose `window_ms` for configuring the window duration
- update combobulator accordingly
- ensure duplicate LLM calls are avoided and old sensations expire
- add tests for the new behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685f0bc1eb608320945c814034bee40b