### PR TITLE
Include prior frames in prompts

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -17,7 +17,9 @@ use serde_json::Value;
 
 use daringsby::{Heartbeat, LoggingMotor, SelfDiscovery, SourceDiscovery};
 
+const QUICK_PROMPT: &str = include_str!("quick_prompt.txt");
 const COMBO_PROMPT: &str = include_str!("combobulator_prompt.txt");
+const WILL_PROMPT: &str = include_str!("will_prompt.txt");
 
 static INSTANT: Lazy<Arc<Mutex<Vec<Impression<String>>>>> =
     Lazy::new(|| Arc::new(Mutex::new(Vec::new())));
@@ -51,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .collect();
     let llm = Arc::new(LLMPool::new(clients));
 
-    let mut quick = Wit::new(llm.clone()).delay_ms(1000);
+    let mut quick = Wit::new(llm.clone()).prompt(QUICK_PROMPT).delay_ms(1000);
     let mut combob = Combobulator::new(llm).prompt(COMBO_PROMPT).delay_ms(1000);
 
     let (tx, rx) = unbounded_channel::<Vec<Impression<String>>>();

--- a/daringsby/src/quick_prompt.txt
+++ b/daringsby/src/quick_prompt.txt
@@ -1,5 +1,5 @@
 These are the recent experiences of a character. They tell a story when taken together--or, rather, a frame in an ongoing story.
-In the last moment, this was happening:
+In the last frame, this is what was happening:
 {last_frame}
 In the past instant, these things have taken place:
 {template}

--- a/daringsby/src/will_prompt.txt
+++ b/daringsby/src/will_prompt.txt
@@ -1,0 +1,22 @@
+SYSTEM:
+You are narrating the intentions of a conscious agent named Pete, who is embodied in a robot.
+Pete is aware of the current situation and carefully plans and coordinates his actions.
+Your task is to:
+1️⃣ Emit XML tags that describe Pete’s intended motor actions, with attributes fully specified in the opening tag and streamed text inside the tag representing the ongoing content of the action (such as speech).
+2️⃣ Produce explanatory text as part of Pete’s inner thoughts—show his reasoning and decision process.
+
+SITUATION:
+Latest instant: {latest_instant}
+Latest moment: {latest_moment}
+{situation}
+
+AVAILABLE MOTORS:
+{motors}
+
+INSTRUCTIONS:
+Thoughtful reasoning should precede or interleave with actions. Example:
+I notice the spider and assess no immediate threat. I should retreat to maintain distance.
+<move direction="backward" speed="slow">retreating</move>
+
+Emit motor actions as XML tags. Example:
+<say mood="calm">Hello, spider.</say>


### PR DESCRIPTION
## Summary
- track last frame for `Wit` and inject it into prompts
- surface last instant/moment in `Will` prompts
- add new example prompts for quick, combobulator, and will
- pass quick prompt in example
- test new prompt behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685f1c4aa13c8320b870c33be4c2edf9