### PR TITLE
Add streaming Mouth motor improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,18 +545,23 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "async-trait",
+ "bytes",
  "chrono",
  "clap",
  "futures",
+ "httpmock",
  "include_dir",
  "ollama-rs",
  "once_cell",
  "psyche-rs",
  "rand",
+ "reqwest",
+ "segtok",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
 ]
 
 [[package]]
@@ -610,6 +615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -852,6 +866,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1042,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1017,6 +1051,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1054,9 +1104,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1385,6 +1437,12 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1823,16 +1881,20 @@ checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -1855,6 +1917,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,12 +1950,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2133,6 +2233,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,6 +2278,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2302,6 +2429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -2450,6 +2587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2602,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -2689,6 +2838,17 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -21,6 +21,15 @@ ollama-rs = { version = "0.3.2", features = ["stream"] }
 once_cell = "1"
 serde_json = "1"
 include_dir = "0.7"
+reqwest = { version = "0.12", features = ["stream"] }
+segtok = "0.1.5"
+urlencoding = "2"
+bytes = "1"
+
+[dev-dependencies]
+httpmock = "0.7"
+tokio = { version = "1", features = ["macros", "rt"] }
+futures = "0.3"
 
 [features]
 moment-feedback = []

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod heartbeat;
 pub mod logging_motor;
+pub mod mouth;
 pub mod self_discovery;
 pub mod source_discovery;
 
 pub use heartbeat::{Heartbeat, heartbeat_message};
 pub use logging_motor::LoggingMotor;
+pub use mouth::Mouth;
 pub use self_discovery::SelfDiscovery;
 pub use source_discovery::SourceDiscovery;

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -19,7 +19,7 @@ use daringsby::{Heartbeat, LoggingMotor, SelfDiscovery, SourceDiscovery};
 
 const QUICK_PROMPT: &str = include_str!("quick_prompt.txt");
 const COMBO_PROMPT: &str = include_str!("combobulator_prompt.txt");
-const WILL_PROMPT: &str = include_str!("will_prompt.txt");
+const _WILL_PROMPT: &str = include_str!("will_prompt.txt");
 
 static INSTANT: Lazy<Arc<Mutex<Vec<Impression<String>>>>> =
     Lazy::new(|| Arc::new(Mutex::new(Vec::new())));

--- a/daringsby/src/mouth.rs
+++ b/daringsby/src/mouth.rs
@@ -1,0 +1,228 @@
+use bytes::Bytes;
+use futures::StreamExt;
+use segtok::segmenter::{SegmentConfig, split_single};
+use tokio::sync::broadcast::{self, Receiver, Sender};
+use tracing::{trace, warn};
+use urlencoding::encode;
+
+use psyche_rs::{Action, Motor, MotorError};
+
+/// Motor that streams text-to-speech audio via HTTP.
+///
+/// Sentences from the input body are sent to a TTS service and the
+/// resulting audio bytes are broadcast to subscribers.
+///
+/// # Example
+/// ```
+/// use daringsby::Mouth;
+/// let mouth = Mouth::default();
+/// let _ = mouth.subscribe();
+/// ```
+pub struct Mouth {
+    client: reqwest::Client,
+    base_url: String,
+    language_id: Option<String>,
+    tx: Sender<Bytes>,
+}
+
+impl Default for Mouth {
+    fn default() -> Self {
+        let (tx, _) = broadcast::channel(8);
+        Self {
+            client: reqwest::Client::new(),
+            base_url: "http://10.0.0.180:5002".into(),
+            language_id: None,
+            tx,
+        }
+    }
+}
+
+impl Mouth {
+    /// Creates a mouth with the given base URL and optional language.
+    pub fn new(base_url: impl Into<String>, language_id: Option<String>) -> Self {
+        let (tx, _) = broadcast::channel(8);
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.into(),
+            language_id,
+            tx,
+        }
+    }
+
+    /// Subscribes to the audio stream.
+    pub fn subscribe(&self) -> Receiver<Bytes> {
+        self.tx.subscribe()
+    }
+
+    fn tts_url(base: &str, text: &str, speaker_id: &str, language: &str) -> String {
+        format!(
+            "{}/api/tts?text={}&speaker_id={}&style_wav=&language_id={}",
+            base,
+            encode(text),
+            speaker_id,
+            language
+        )
+    }
+}
+
+impl Motor for Mouth {
+    fn description(&self) -> &'static str {
+        "Streams TTS audio from text via HTTP"
+    }
+
+    fn perform(&self, mut action: Action) -> Result<(), MotorError> {
+        if action.name != "speak" {
+            return Err(MotorError::Unrecognized);
+        }
+        let speaker_id = action
+            .params
+            .get("speaker_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| MotorError::Failed("speaker_id required".into()))?
+            .to_string();
+        let lang = action
+            .params
+            .get("language_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| self.language_id.clone())
+            .unwrap_or_default();
+        let client = self.client.clone();
+        let lang = lang.clone();
+        let base = self.base_url.clone();
+        let tx = self.tx.clone();
+        tokio::spawn(async move {
+            let mut buf = String::new();
+            while let Some(chunk) = action.body.next().await {
+                buf.push_str(&chunk);
+                let mut sents = split_single(&buf, SegmentConfig::default());
+                if let Some(last) = sents.last() {
+                    if !last.trim_end().ends_with(['.', '!', '?']) {
+                        buf = last.clone();
+                        sents.pop();
+                    } else {
+                        buf.clear();
+                    }
+                }
+                for sent in sents {
+                    trace!(%sent, "tts sentence");
+                    let url = Mouth::tts_url(&base, &sent, &speaker_id, &lang);
+                    match client.get(url).send().await {
+                        Ok(resp) => {
+                            let mut stream = resp.bytes_stream();
+                            while let Some(Ok(bytes)) = stream.next().await {
+                                let _ = tx.send(bytes);
+                            }
+                        }
+                        Err(e) => warn!(error = ?e, "tts request failed"),
+                    }
+                    let _ = tx.send(Bytes::new());
+                }
+            }
+            if !buf.trim().is_empty() {
+                trace!(sentence = %buf, "tts final sentence");
+                let url = Mouth::tts_url(&base, &buf, &speaker_id, &lang);
+                match client.get(url).send().await {
+                    Ok(resp) => {
+                        let mut stream = resp.bytes_stream();
+                        while let Some(Ok(bytes)) = stream.next().await {
+                            let _ = tx.send(bytes);
+                        }
+                    }
+                    Err(e) => warn!(error = ?e, "tts request failed"),
+                }
+            }
+            let _ = tx.send(Bytes::new());
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use httpmock::prelude::*;
+    use serde_json::Map;
+    use serde_json::Value;
+
+    /// Given a sentence stream, when performed, then audio is sent per sentence.
+    #[tokio::test]
+    async fn streams_audio_by_sentence() {
+        // Arrange
+        let server = MockServer::start_async().await;
+        let m1 = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/api/tts")
+                    .query_param("text", "Hello world.")
+                    .query_param("speaker_id", "p1")
+                    .query_param("style_wav", "")
+                    .query_param("language_id", "");
+                then.status(200).body("A");
+            })
+            .await;
+        let m2 = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/api/tts")
+                    .query_param("text", "How are you?")
+                    .query_param("speaker_id", "p1")
+                    .query_param("style_wav", "")
+                    .query_param("language_id", "");
+                then.status(200).body("B");
+            })
+            .await;
+        let mouth = Mouth::new(server.url(""), None);
+        let mut rx = mouth.subscribe();
+        let body = stream::once(async { "Hello world. How are you?".to_string() }).boxed();
+        let mut map = Map::new();
+        map.insert("speaker_id".into(), Value::String("p1".into()));
+        let action = Action::new("speak", Value::Object(map), body);
+
+        // Act
+        mouth.perform(action).unwrap();
+        let a = rx.recv().await.unwrap();
+        let delim = rx.recv().await.unwrap();
+        let b = rx.recv().await.unwrap();
+        let end = rx.recv().await.unwrap();
+
+        // Assert
+        assert_eq!(a.as_ref(), b"A");
+        assert!(delim.is_empty());
+        assert_eq!(b.as_ref(), b"B");
+        assert!(end.is_empty());
+        m1.assert();
+        m2.assert();
+    }
+
+    /// When language_id is set, it is passed to the TTS service.
+    #[tokio::test]
+    async fn includes_language_param() {
+        // Arrange
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/api/tts")
+                    .query_param("language_id", "en");
+                then.status(200);
+            })
+            .await;
+
+        let mouth = Mouth::new(server.url(""), Some("en".into()));
+        let mut rx = mouth.subscribe();
+        let body = stream::once(async { "Hi.".to_string() }).boxed();
+        let mut map = Map::new();
+        map.insert("speaker_id".into(), Value::String("p1".into()));
+        let action = Action::new("speak", Value::Object(map), body);
+
+        // Act
+        mouth.perform(action).unwrap();
+        let _ = rx.recv().await.unwrap();
+        let _ = rx.recv().await.unwrap();
+
+        // Assert
+        mock.assert();
+    }
+}

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info};
 
 #[cfg(test)]
 use crate::MotorError;
-use crate::{Action, Impression, Motor, Sensation, Sensor, Wit};
+use crate::{Action, Motor, Sensation, Sensor, Wit};
 use serde_json::Value;
 
 /// Sensor wrapper enabling shared ownership.


### PR DESCRIPTION
## Summary
- refine Mouth motor to send empty bytes between sentence audio chunks
- log failed TTS requests and always include `language_id` parameter
- test sentence boundary delimiters and language id handling
- silence unused constant warning and remove unused import

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685f23b69a34832098bf5a6e1941b02b