### PR TITLE
Add speech streaming HTTP endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,11 +612,14 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "async-trait",
+ "axum",
  "bytes",
  "chrono",
  "clap",
  "futures",
+ "http-body-util",
  "httpmock",
+ "hyper 1.6.0",
  "include_dir",
  "ollama-rs",
  "once_cell",
@@ -559,6 +629,7 @@ dependencies = [
  "segtok",
  "serde_json",
  "tokio",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
@@ -1046,6 +1117,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1433,6 +1505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c6ed90dceac899d670024e99486140739a14a1bda2bd05604689b8979a2894"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1739,26 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1906,7 +2004,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -2119,6 +2217,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2468,6 +2576,21 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -2479,6 +2602,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2494,7 +2618,7 @@ dependencies = [
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -2517,6 +2641,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -25,11 +25,15 @@ reqwest = { version = "0.12", features = ["stream"] }
 segtok = "0.1.5"
 urlencoding = "2"
 bytes = "1"
+axum = { version = "0.7", features = ["macros"] }
 
 [dev-dependencies]
 httpmock = "0.7"
 tokio = { version = "1", features = ["macros", "rt"] }
 futures = "0.3"
+hyper = "1"
+http-body-util = "0.1"
+tower = { version = "0.4", features = ["util"] }
 
 [features]
 moment-feedback = []

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -3,9 +3,11 @@ pub mod logging_motor;
 pub mod mouth;
 pub mod self_discovery;
 pub mod source_discovery;
+pub mod speech_stream;
 
 pub use heartbeat::{Heartbeat, heartbeat_message};
 pub use logging_motor::LoggingMotor;
 pub use mouth::Mouth;
 pub use self_discovery::SelfDiscovery;
 pub use source_discovery::SourceDiscovery;
+pub use speech_stream::SpeechStream;

--- a/daringsby/src/speech_stream.rs
+++ b/daringsby/src/speech_stream.rs
@@ -1,0 +1,110 @@
+use axum::{
+    Router,
+    body::Body,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use bytes::Bytes;
+use std::sync::Arc;
+use tokio::sync::broadcast::Receiver;
+
+/// HTTP streamer for mouth audio.
+///
+/// This type exposes a router serving two routes:
+/// - `/` an HTML page with an `<audio>` element.
+/// - `/speech.wav` streaming WAV bytes as they arrive from a TTS backend.
+///
+/// A [`Receiver`] is provided at construction and any bytes received are
+/// forwarded directly to the HTTP client.
+pub struct SpeechStream {
+    tts_rx: Arc<tokio::sync::Mutex<Receiver<Bytes>>>,
+}
+
+impl SpeechStream {
+    /// Create a new streamer from the given broadcast receiver.
+    pub fn new(rx: Receiver<Bytes>) -> Self {
+        Self {
+            tts_rx: Arc::new(tokio::sync::Mutex::new(rx)),
+        }
+    }
+
+    /// Build an [`axum::Router`] exposing the streaming and index routes.
+    pub fn router(self: Arc<Self>) -> Router {
+        Router::new()
+            .route("/", get(Self::index))
+            .route("/speech.wav", get(move || self.clone().stream_audio()))
+    }
+
+    async fn index() -> impl IntoResponse {
+        const INDEX: &str = r#"<!DOCTYPE html>
+<html lang=\"en\">
+<body>
+<audio controls autoplay>
+  <source src=\"/speech.wav\" type=\"audio/wav\">
+  Your browser does not support the audio element.
+</audio>
+</body>
+</html>
+"#;
+        axum::response::Html(INDEX)
+    }
+
+    async fn stream_audio(self: Arc<Self>) -> Response {
+        let rx = self.tts_rx.clone();
+        let stream = async_stream::stream! {
+            let mut rx = rx.lock().await;
+            while let Ok(bytes) = rx.recv().await {
+                yield Ok::<Bytes, std::io::Error>(bytes);
+            }
+        };
+        Response::builder()
+            .header("Content-Type", "audio/wav")
+            .body(Body::from_stream(stream))
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, http::Request};
+    use http_body_util::BodyExt;
+    use tokio::sync::broadcast;
+    use tower::ServiceExt;
+
+    /// When bytes are sent on the channel they stream to the client.
+    #[tokio::test]
+    async fn streams_bytes_to_client() {
+        let (tx, rx) = broadcast::channel(4);
+        let stream = Arc::new(SpeechStream::new(rx));
+        let app = stream.router();
+
+        let handle = tokio::spawn(async move {
+            let req = Request::builder()
+                .uri("/speech.wav")
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), axum::http::StatusCode::OK);
+            let body = resp.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body.as_ref(), b"A");
+        });
+
+        tx.send(Bytes::from_static(b"A")).unwrap();
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    /// The index route serves an HTML page with an audio element.
+    #[tokio::test]
+    async fn serves_index_html() {
+        let (_tx, rx) = broadcast::channel(1);
+        let stream = Arc::new(SpeechStream::new(rx));
+        let app = stream.router();
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(std::str::from_utf8(&body).unwrap().contains("<audio"));
+    }
+}


### PR DESCRIPTION
## Summary
- serve audio stream via `/speech.wav`
- expose HTML page that plays streaming audio
- wire new `SpeechStream` module into library
- depend on `axum` and testing crates for streaming integration

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685f2fbde08483208f758b2c36606160