### PR TITLE
Integrate urge lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Run `cargo fmt` before committing changes.
 - Instrument code with tracing logs at appropriate levels.
 - Emit `trace` level logs for all LLM prompts and streaming token events.
+- Log the full urge→intention→action→result lifecycle with trace level events.
 - When implementing test memory stores that persist `Memory::Of`, clone the inner
   value before saving to prevent panics when cloning.
 - Ensure every async call is awaited unless intentionally detached with

--- a/daringsby/src/logging_motor.rs
+++ b/daringsby/src/logging_motor.rs
@@ -1,24 +1,31 @@
 use futures::StreamExt;
 use tracing::info;
 
-use psyche_rs::{Action, Motor, MotorError};
+use psyche_rs::{Action, ActionResult, Motor, MotorError};
 
 /// Simple motor that logs every received command.
 #[derive(Default)]
 pub struct LoggingMotor;
 
+#[async_trait::async_trait]
 impl Motor for LoggingMotor {
+    fn name(&self) -> &'static str {
+        "log"
+    }
     fn description(&self) -> &'static str {
         "Prints received actions to the log"
     }
-    fn perform(&self, mut action: Action) -> Result<(), MotorError> {
+    async fn perform(&self, mut action: Action) -> Result<ActionResult, MotorError> {
         futures::executor::block_on(async {
             let mut text = String::new();
             while let Some(chunk) = action.body.next().await {
                 text.push_str(&chunk);
             }
-            info!(body = %text, name = %action.name, "motor log");
+            info!(body = %text, name = %action.intention.urge.name, "motor log");
         });
-        Ok(())
+        Ok(ActionResult {
+            sensations: Vec::new(),
+            completed: true,
+        })
     }
 }

--- a/daringsby/src/speech_stream.rs
+++ b/daringsby/src/speech_stream.rs
@@ -67,7 +67,7 @@ impl SpeechStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{Router, http::Request};
+    use axum::http::Request;
     use http_body_util::BodyExt;
     use tokio::sync::broadcast;
     use tower::ServiceExt;

--- a/psyche-rs/src/motor.rs
+++ b/psyche-rs/src/motor.rs
@@ -1,13 +1,12 @@
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 /// Represents an action request with streaming body content.
 pub struct Action {
-    /// Name of the action to perform.
-    pub name: String,
-    /// Structured parameters for the action.
-    pub params: Value,
+    /// Metadata describing what is intended.
+    pub intention: Intention,
     /// Live body stream associated with the action.
     pub body: BoxStream<'static, String>,
 }
@@ -15,31 +14,29 @@ pub struct Action {
 impl std::fmt::Debug for Action {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Action")
-            .field("name", &self.name)
-            .field("params", &self.params)
+            .field("intention", &self.intention)
             .finish_non_exhaustive()
     }
 }
 
 impl Action {
-    /// Helper to create an [`Action`] from parts.
-    pub fn new(name: impl Into<String>, params: Value, body: BoxStream<'static, String>) -> Self {
-        Self {
-            name: name.into(),
-            params,
-            body,
-        }
+    /// Helper to create an [`Action`] from an [`Intention`].
+    pub fn from_intention(intention: Intention, body: BoxStream<'static, String>) -> Self {
+        Self { intention, body }
     }
 }
 
 /// A motor capable of performing an action.
+#[async_trait::async_trait]
 pub trait Motor {
+    /// Name of the motor command this handler performs.
+    fn name(&self) -> &'static str;
     /// Returns a brief description of the motor's purpose.
     fn description(&self) -> &'static str;
     /// Attempt to perform the provided action.
     ///
     /// The implementor may consume the action body stream as desired.
-    fn perform(&self, action: Action) -> Result<(), MotorError>;
+    async fn perform(&self, action: Action) -> Result<ActionResult, MotorError>;
 }
 
 /// Errors that may occur while executing a motor action.
@@ -54,21 +51,33 @@ pub enum MotorError {
     Failed(String),
 }
 
+/// Result of performing an action.
+#[derive(Debug, Clone)]
+pub struct ActionResult {
+    /// Sensations produced by the motor.
+    pub sensations: Vec<crate::Sensation>,
+    /// Whether the action completed successfully.
+    pub completed: bool,
+}
+
 /// Metadata describing an intended action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Urge {
-    /// Action name.
+    /// Action name, e.g. `"look"`.
     pub name: String,
-    /// Parameters for the action.
-    pub params: Value,
+    /// Structured arguments for the urge.
+    pub args: HashMap<String, String>,
+    /// Optional body content for streaming motors.
+    pub body: Option<String>,
 }
 
 impl Urge {
     /// Convenience constructor.
-    pub fn to(name: impl Into<String>, params: Value) -> Self {
+    pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
-            params,
+            args: HashMap::new(),
+            body: None,
         }
     }
 }
@@ -76,18 +85,18 @@ impl Urge {
 /// Metadata stating the intent to perform an action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Intention {
-    /// Action name.
-    pub name: String,
-    /// Parameters for the action.
-    pub params: Value,
+    /// Originating urge.
+    pub urge: Urge,
+    /// Motor selected to fulfill the urge.
+    pub assigned_motor: String,
 }
 
 impl Intention {
-    /// Convenience constructor.
-    pub fn to(name: impl Into<String>, params: Value) -> Self {
+    /// Creates a new intention for the given motor.
+    pub fn new(urge: Urge, motor: impl Into<String>) -> Self {
         Self {
-            name: name.into(),
-            params,
+            urge,
+            assigned_motor: motor.into(),
         }
     }
 }
@@ -142,10 +151,12 @@ mod tests {
     use futures::{StreamExt, stream};
 
     #[test]
-    fn action_new_sets_fields() {
+    fn action_from_intention_sets_fields() {
         let body = stream::empty().boxed();
-        let mut action = Action::new("test", Value::Null, body);
-        assert_eq!(action.name, "test");
+        let urge = Urge::new("test");
+        let intention = Intention::new(urge, "m");
+        let mut action = Action::from_intention(intention, body);
+        assert_eq!(action.intention.urge.name, "test");
         let none = futures::executor::block_on(async { action.body.next().await });
         assert!(none.is_none());
     }


### PR DESCRIPTION
## Summary
- refactor core motor types with Urge → Intention → Action flow
- implement `process_urge` on `Psyche`
- update motors and tests for async lifecycle
- add unit tests ensuring `process_urge` emits correct sensations
- add trace logs for urge lifecycle and fix compile warnings

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_685f3a56a2cc832099fdf962d52eb38c