### PR TITLE
Implement Urge→Intention→Action flow

### DIFF
--- a/daringsby/src/logging_motor.rs
+++ b/daringsby/src/logging_motor.rs
@@ -1,24 +1,29 @@
 use futures::StreamExt;
 use tracing::info;
 
-use psyche_rs::{Action, Motor, MotorError};
+use psyche_rs::{Action, ActionResult, Motor, MotorError};
 
 /// Simple motor that logs every received command.
 #[derive(Default)]
 pub struct LoggingMotor;
 
+#[async_trait::async_trait]
 impl Motor for LoggingMotor {
     fn description(&self) -> &'static str {
         "Prints received actions to the log"
     }
-    fn perform(&self, mut action: Action) -> Result<(), MotorError> {
-        futures::executor::block_on(async {
-            let mut text = String::new();
-            while let Some(chunk) = action.body.next().await {
-                text.push_str(&chunk);
-            }
-            info!(body = %text, name = %action.name, "motor log");
-        });
-        Ok(())
+    fn name(&self) -> &'static str {
+        "log"
+    }
+    async fn perform(&self, mut action: Action) -> Result<ActionResult, MotorError> {
+        let mut text = String::new();
+        while let Some(chunk) = action.body.next().await {
+            text.push_str(&chunk);
+        }
+        info!(body = %text, name = %action.intention.urge.name, "motor log");
+        Ok(ActionResult {
+            sensations: Vec::new(),
+            completed: true,
+        })
     }
 }

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -127,15 +127,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let text = imp.how.clone();
                     let log_text = text.clone();
                     let body = stream::once(async move { log_text }).boxed();
-                    let action = Action::new("log", Value::Null, body);
-                    logger_task.perform(action).unwrap();
+                    let mut action = Action::new("log", Value::Null, body);
+                    action.intention.assigned_motor = "log".into();
+                    logger_task.perform(action).await.unwrap();
 
                     let mut map = Map::new();
                     map.insert("speaker_id".into(), Value::String("p1".into()));
                     let speak_text = text;
                     let speak_body = stream::once(async move { speak_text }).boxed();
-                    let speak = Action::new("speak", Value::Object(map), speak_body);
-                    mouth_task.perform(speak).unwrap();
+                    let mut speak = Action::new("speak", Value::Object(map), speak_body);
+                    speak.intention.assigned_motor = "speak".into();
+                    mouth_task.perform(speak).await.unwrap();
                 }
             }
         });
@@ -151,15 +153,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let text = imp.how.clone();
                     let log_text = text.clone();
                     let body = stream::once(async move { log_text }).boxed();
-                    let action = Action::new("log", Value::Null, body);
-                    logger_task.perform(action).unwrap();
+                    let mut action = Action::new("log", Value::Null, body);
+                    action.intention.assigned_motor = "log".into();
+                    logger_task.perform(action).await.unwrap();
 
                     let mut map = Map::new();
                     map.insert("speaker_id".into(), Value::String("p1".into()));
                     let speak_text = text;
                     let speak_body = stream::once(async move { speak_text }).boxed();
-                    let speak = Action::new("speak", Value::Object(map), speak_body);
-                    mouth_task.perform(speak).unwrap();
+                    let mut speak = Action::new("speak", Value::Object(map), speak_body);
+                    speak.intention.assigned_motor = "speak".into();
+                    mouth_task.perform(speak).await.unwrap();
                 }
             }
         });

--- a/psyche-rs/src/motor.rs
+++ b/psyche-rs/src/motor.rs
@@ -1,13 +1,15 @@
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::sensation::Sensation;
+use async_trait::async_trait;
 
 /// Represents an action request with streaming body content.
 pub struct Action {
-    /// Name of the action to perform.
-    pub name: String,
-    /// Structured parameters for the action.
-    pub params: Value,
+    /// Desired intention to be fulfilled by the motor.
+    pub intention: Intention,
     /// Live body stream associated with the action.
     pub body: BoxStream<'static, String>,
 }
@@ -15,31 +17,30 @@ pub struct Action {
 impl std::fmt::Debug for Action {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Action")
-            .field("name", &self.name)
-            .field("params", &self.params)
+            .field("intention", &self.intention)
             .finish_non_exhaustive()
     }
 }
 
 impl Action {
     /// Helper to create an [`Action`] from parts.
-    pub fn new(name: impl Into<String>, params: Value, body: BoxStream<'static, String>) -> Self {
+    pub fn new(name: impl Into<String>, args: Value, body: BoxStream<'static, String>) -> Self {
         Self {
-            name: name.into(),
-            params,
+            intention: Intention::to(name, args),
             body,
         }
     }
 }
 
 /// A motor capable of performing an action.
-pub trait Motor {
+#[async_trait::async_trait]
+pub trait Motor: Send + Sync {
     /// Returns a brief description of the motor's purpose.
     fn description(&self) -> &'static str;
     /// Attempt to perform the provided action.
-    ///
-    /// The implementor may consume the action body stream as desired.
-    fn perform(&self, action: Action) -> Result<(), MotorError>;
+    async fn perform(&self, action: Action) -> Result<ActionResult, MotorError>;
+    /// Name of the motor action handled.
+    fn name(&self) -> &'static str;
 }
 
 /// Errors that may occur while executing a motor action.
@@ -59,16 +60,19 @@ pub enum MotorError {
 pub struct Urge {
     /// Action name.
     pub name: String,
-    /// Parameters for the action.
-    pub params: Value,
+    /// Named arguments for the action.
+    pub args: HashMap<String, String>,
+    /// Optional body text included with the urge.
+    pub body: Option<String>,
 }
 
 impl Urge {
     /// Convenience constructor.
-    pub fn to(name: impl Into<String>, params: Value) -> Self {
+    pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
-            params,
+            args: HashMap::new(),
+            body: None,
         }
     }
 }
@@ -76,18 +80,36 @@ impl Urge {
 /// Metadata stating the intent to perform an action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Intention {
-    /// Action name.
-    pub name: String,
-    /// Parameters for the action.
-    pub params: Value,
+    /// Original urge that led to this intention.
+    pub urge: Urge,
+    /// Name of the motor assigned to satisfy the urge.
+    pub assigned_motor: String,
 }
 
 impl Intention {
     /// Convenience constructor.
     pub fn to(name: impl Into<String>, params: Value) -> Self {
+        let mut urge = Urge::new(name);
+        // back-compat with legacy params when converting from actions
+        for (k, v) in params.as_object().cloned().unwrap_or_default() {
+            let val = if let Some(s) = v.as_str() {
+                s.to_string()
+            } else {
+                v.to_string()
+            };
+            urge.args.insert(k, val);
+        }
         Self {
-            name: name.into(),
-            params,
+            urge,
+            assigned_motor: String::new(),
+        }
+    }
+
+    /// Create a new intention from an urge and motor name.
+    pub fn assign(urge: Urge, motor: impl Into<String>) -> Self {
+        Self {
+            urge,
+            assigned_motor: motor.into(),
         }
     }
 }
@@ -136,6 +158,15 @@ impl Completion {
     }
 }
 
+/// Outcome from executing a motor action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionResult<T = serde_json::Value> {
+    /// Sensations produced by the motor.
+    pub sensations: Vec<Sensation<T>>,
+    /// Whether the action fully completed.
+    pub completed: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,7 +176,7 @@ mod tests {
     fn action_new_sets_fields() {
         let body = stream::empty().boxed();
         let mut action = Action::new("test", Value::Null, body);
-        assert_eq!(action.name, "test");
+        assert_eq!(action.intention.urge.name, "test");
         let none = futures::executor::block_on(async { action.body.next().await });
         assert!(none.is_none());
     }

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -199,7 +199,8 @@ impl<T> Will<T> {
                                                     let closing = format!("</{}>", tag);
                                                     let _ = buf.drain(..caps.get(0).unwrap().end());
                                                     let (btx, brx) = unbounded_channel();
-                                                    let action = Action::new(tag.clone(), Value::Object(map), UnboundedReceiverStream::new(brx).boxed());
+                                                    let mut action = Action::new(tag.clone(), Value::Object(map), UnboundedReceiverStream::new(brx).boxed());
+                                                    action.intention.assigned_motor = tag.clone();
                                                     let _ = tx.send(vec![action]);
                                                     state = Some((tag, closing, btx));
                                                 } else {
@@ -277,7 +278,7 @@ mod tests {
         let mut stream = will.observe(vec![sensor]).await;
         let mut actions = stream.next().await.unwrap();
         let action = actions.pop().unwrap();
-        assert_eq!(action.name, "say");
+        assert_eq!(action.intention.urge.name, "say");
         let chunks: Vec<String> = action.body.collect().await;
         let body: String = chunks.concat();
         assert_eq!(body, "Hello world");


### PR DESCRIPTION
## Summary
- integrate Urge struct with args and body
- wrap Intention inside Action
- switch Motor trait to async and return ActionResult
- support processing urges in Psyche
- update motors, mouth and logger for async API
- adjust tests for new lifecycle

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685f626832e88320ace68305cac182ff