### PR TITLE
Use MP3 for speech stream

### DIFF
--- a/daringsby/src/speech_stream.rs
+++ b/daringsby/src/speech_stream.rs
@@ -14,7 +14,7 @@ const SILENCE: &[u8] = &[0u8; 2];
 ///
 /// This type exposes a router serving two routes:
 /// - `/` an HTML page with an `<audio>` element.
-/// - `/speech.wav` streaming WAV bytes as they arrive from a TTS backend.
+/// - `/speech.wav` streaming MP3 bytes as they arrive from a TTS backend.
 ///
 /// A [`Receiver`] is provided at construction and any bytes received are
 /// forwarded directly to the HTTP client.
@@ -42,7 +42,7 @@ impl SpeechStream {
 <html lang=\"en\">
 <body>
 <audio controls autoplay>
-  <source src=\"/speech.wav\" type=\"audio/wav\">
+  <source src=\"/speech.wav\" type=\"audio/mpeg\">
   Your browser does not support the audio element.
 </audio>
 </body>
@@ -71,7 +71,7 @@ impl SpeechStream {
             }
         };
         Response::builder()
-            .header("Content-Type", "audio/wav")
+            .header("Content-Type", "audio/mpeg")
             .body(Body::from_stream(stream))
             .unwrap()
     }

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -228,7 +228,7 @@ mod tests {
                     sensations: vec![Sensation {
                         kind: match self.0 {
                             "look" => "image/jpeg",
-                            "listen" => "audio/wav",
+                            "listen" => "audio/mpeg",
                             "sniff" => "chemical/smell",
                             _ => "unknown",
                         }
@@ -262,7 +262,7 @@ mod tests {
                     args: HashMap::new(),
                     body: None,
                 },
-                "audio/wav",
+                "audio/mpeg",
             ),
             (
                 Urge {


### PR DESCRIPTION
## Summary
- stream mouth audio as `audio/mpeg` instead of `audio/wav`
- update tests for new MIME type

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685f7798e1b0832083316302d0be7086