### PR TITLE
Switch speech stream to websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -354,8 +355,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -469,6 +472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +498,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -595,6 +613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +632,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "daringsby"
@@ -630,10 +667,27 @@ dependencies = [
  "segtok",
  "serde_json",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -894,6 +948,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2260,6 +2324,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,6 +2644,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +2806,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +2918,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { version = "0.12", features = ["stream"] }
 segtok = "0.1.5"
 urlencoding = "2"
 bytes = "1"
-axum = { version = "0.7", features = ["macros"] }
+axum = { version = "0.7", features = ["macros", "ws"] }
 hound = "3"
 
 [dev-dependencies]
@@ -35,6 +35,7 @@ futures = "0.3"
 hyper = "1"
 http-body-util = "0.1"
 tower = { version = "0.4", features = ["util"] }
+tokio-tungstenite = "0.21"
 
 [features]
 moment-feedback = []

--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<script>
+const SAMPLE_RATE = 16000;
+const ws = new WebSocket(`ws://${location.host}/ws/audio/out`);
+ws.binaryType = 'arraybuffer';
+const ctx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: SAMPLE_RATE });
+let queue = [];
+let playing = false;
+
+function play() {
+  if (playing || !queue.length) return;
+  playing = true;
+  const pcm = queue.shift();
+  const buf = ctx.createBuffer(1, pcm.length, SAMPLE_RATE);
+  const chan = buf.getChannelData(0);
+  for (let i = 0; i < pcm.length; i++) chan[i] = pcm[i] / 32768;
+  const src = ctx.createBufferSource();
+  src.buffer = buf;
+  src.connect(ctx.destination);
+  src.onended = () => { playing = false; play(); };
+  src.start();
+}
+
+ws.onmessage = ev => {
+  queue.push(new Int16Array(ev.data));
+  if (ctx.state === 'suspended') ctx.resume();
+  play();
+};
+</script>
+</body>
+</html>

--- a/daringsby/src/speech_stream.rs
+++ b/daringsby/src/speech_stream.rs
@@ -1,7 +1,6 @@
 use axum::{
     Router,
-    body::Body,
-    response::{IntoResponse, Response},
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
     routing::get,
 };
 use bytes::Bytes;
@@ -14,14 +13,11 @@ const FRAME_MS: usize = 10;
 const SILENCE_BYTES: usize = (SAMPLE_RATE as usize / 1000 * FRAME_MS) * 2;
 static SILENCE: Lazy<[u8; SILENCE_BYTES]> = Lazy::new(|| [0u8; SILENCE_BYTES]);
 
-/// HTTP streamer for mouth audio.
+/// WebSocket streamer for mouth audio.
 ///
-/// This type exposes a router serving two routes:
-/// - `/` an HTML page with an `<audio>` element.
-/// - `/speech.opus` streaming Opus bytes as they arrive from a TTS backend.
-///
-/// A [`Receiver`] is provided at construction and any bytes received are
-/// forwarded directly to the HTTP client.
+/// Exposes a single `/` route which upgrades to a WebSocket connection.
+/// Bytes received from the provided [`Receiver`] are forwarded to connected
+/// clients as binary messages. Silence frames are emitted when idle.
 pub struct SpeechStream {
     tts_rx: Arc<tokio::sync::Mutex<Receiver<Bytes>>>,
 }
@@ -34,99 +30,83 @@ impl SpeechStream {
         }
     }
 
-    /// Build an [`axum::Router`] exposing the streaming and index routes.
+    /// Build an [`axum::Router`] exposing the WebSocket streaming route.
     pub fn router(self: Arc<Self>) -> Router {
-        Router::new()
-            .route("/", get(Self::index))
-            .route("/speech.opus", get(move || self.clone().stream_audio()))
+        Router::new().route(
+            "/",
+            get({
+                let stream = self.clone();
+                move |ws: WebSocketUpgrade| async move {
+                    ws.on_upgrade(move |sock| stream.clone().stream_audio(sock))
+                }
+            }),
+        )
     }
 
-    async fn index() -> impl IntoResponse {
-        const INDEX: &str = r#"<!DOCTYPE html>
-<html lang="en">
-<body>
-<audio controls autoplay>
-  <source src="/speech.opus" type="audio/ogg">
-  Your browser does not support the audio element.
-</audio>
-</body>
-</html>
-"#;
-        axum::response::Html(INDEX)
-    }
-
-    async fn stream_audio(self: Arc<Self>) -> Response {
+    async fn stream_audio(self: Arc<Self>, mut socket: WebSocket) {
         let rx = self.tts_rx.clone();
-        let stream = async_stream::stream! {
-            let mut rx = rx.lock().await;
-            loop {
-                match tokio::time::timeout(
-                    std::time::Duration::from_millis(100),
-                    rx.recv(),
-                ).await {
-                    Ok(Ok(bytes)) => {
-                        if !bytes.is_empty() {
-                            yield Ok::<Bytes, std::io::Error>(bytes);
-                        }
+        let mut rx = rx.lock().await;
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await {
+                Ok(Ok(bytes)) => {
+                    if !bytes.is_empty()
+                        && socket.send(Message::Binary(bytes.to_vec())).await.is_err()
+                    {
+                        break;
                     }
-                    Ok(Err(_)) => break,
-                    Err(_) => {
-                        yield Ok::<Bytes, std::io::Error>(Bytes::from_static(&SILENCE[..]));
+                }
+                Ok(Err(_)) => break,
+                Err(_) => {
+                    if socket
+                        .send(Message::Binary(SILENCE.to_vec()))
+                        .await
+                        .is_err()
+                    {
+                        break;
                     }
                 }
             }
-        };
-        Response::builder()
-            .header("Content-Type", "audio/ogg")
-            .body(Body::from_stream(stream))
-            .unwrap()
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::http::Request;
-    use http_body_util::BodyExt;
+    use futures::StreamExt;
     use tokio::sync::broadcast;
-    use tower::ServiceExt;
+    use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
+
+    async fn start_server(stream: Arc<SpeechStream>) -> std::net::SocketAddr {
+        let app = stream.router();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        addr
+    }
 
     /// When bytes are sent on the channel they stream to the client.
     #[tokio::test]
     async fn streams_bytes_to_client() {
         let (tx, rx) = broadcast::channel(4);
         let stream = Arc::new(SpeechStream::new(rx));
-        let app = stream.router();
-
-        let handle = tokio::spawn(async move {
-            let req = Request::builder()
-                .uri("/speech.opus")
-                .body(Body::empty())
-                .unwrap();
-            let resp = app.oneshot(req).await.unwrap();
-            assert_eq!(resp.status(), axum::http::StatusCode::OK);
-            let body = resp.into_body().collect().await.unwrap().to_bytes();
-            assert_eq!(body.as_ref(), b"A");
-        });
-
+        let addr = start_server(stream.clone()).await;
+        let url = format!("ws://{addr}");
+        let (mut ws, _) = connect_async(url).await.unwrap();
         tx.send(Bytes::from_static(b"A")).unwrap();
         drop(tx);
-        handle.await.unwrap();
+        let msg = ws.next().await.unwrap().unwrap();
+        assert_eq!(msg, WsMessage::Binary(b"A".to_vec()));
     }
 
-    /// The index route serves an HTML page with an audio element.
+    /// The router upgrades connections to WebSocket.
     #[tokio::test]
-    async fn serves_index_html() {
+    async fn upgrades_via_router() {
         let (_tx, rx) = broadcast::channel(1);
         let stream = Arc::new(SpeechStream::new(rx));
-        let app = stream.router();
-        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let html = std::str::from_utf8(&body).unwrap();
-        assert!(html.contains("<audio"));
-        assert!(html.contains("/speech.opus"));
+        let addr = start_server(stream).await;
+        let url = format!("ws://{addr}");
+        let (_ws, _) = connect_async(url).await.unwrap();
     }
 
     /// When idle the stream emits silence bytes.
@@ -134,22 +114,16 @@ mod tests {
     async fn emits_silence_when_idle() {
         let (_tx, rx) = broadcast::channel(1);
         let stream = Arc::new(SpeechStream::new(rx));
-        let app = stream.router();
-        let req = Request::builder()
-            .uri("/speech.opus")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::OK);
-        use futures::StreamExt;
-        let mut stream = resp.into_body().into_data_stream();
-        // first chunk is silence when nothing is playing
-        let _first = stream.next().await.unwrap().unwrap();
-        let chunk = tokio::time::timeout(std::time::Duration::from_millis(150), stream.next())
+        let addr = start_server(stream.clone()).await;
+        let url = format!("ws://{addr}");
+        let (mut ws, _) = connect_async(url).await.unwrap();
+        let first = ws.next().await.unwrap().unwrap();
+        assert_eq!(first, WsMessage::Binary(SILENCE.to_vec()));
+        let chunk = tokio::time::timeout(std::time::Duration::from_millis(150), ws.next())
             .await
             .unwrap()
             .unwrap()
             .unwrap();
-        assert_eq!(chunk.as_ref(), &SILENCE[..]);
+        assert_eq!(chunk, WsMessage::Binary(SILENCE.to_vec()));
     }
 }


### PR DESCRIPTION
## Summary
- expose `/` as a websocket endpoint for streaming PCM
- drop the old `/speech.opus` route
- enable ws feature in axum
- update audio streaming tests for websocket

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6860165d9e648320a0be4598974d7f88