### PR TITLE
Fix missing TTS speaker default

### DIFF
--- a/daringsby/src/mouth.rs
+++ b/daringsby/src/mouth.rs
@@ -125,7 +125,7 @@ impl Motor for Mouth {
             .get("speaker_id")
             .map(|v| v.as_str())
             .map(|s| s.to_string())
-            .or_else(|| "p330".into())
+            .or_else(|| Some("p330".to_string()))
             .unwrap_or_default();
         let lang = action
             .intention


### PR DESCRIPTION
## Summary
- fix `Mouth` so missing `speaker_id` defaults to `p330`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68605dab0ad48320af44996cc16b2e69