### PR TITLE
Require click before speech streaming

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <body>
+<button id="start">Start</button>
 <script>
 const SAMPLE_RATE = 16000;
-const ws = new WebSocket(`ws://${location.host}/ws/audio/out`);
-ws.binaryType = 'arraybuffer';
 const ctx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: SAMPLE_RATE });
+let ws;
 let queue = [];
 let playing = false;
 
@@ -23,11 +23,19 @@ function play() {
   src.start();
 }
 
-ws.onmessage = ev => {
-  queue.push(new Int16Array(ev.data));
-  if (ctx.state === 'suspended') ctx.resume();
-  play();
-};
+function start() {
+  if (ws) return;
+  ws = new WebSocket(`ws://${location.host}/ws/audio/out`);
+  ws.binaryType = 'arraybuffer';
+  ws.onmessage = ev => {
+    queue.push(new Int16Array(ev.data));
+    if (ctx.state === 'suspended') ctx.resume();
+    play();
+  };
+  document.getElementById('start').style.display = 'none';
+}
+
+document.getElementById('start').addEventListener('click', start);
 </script>
 </body>
 </html>

--- a/daringsby/src/speech_stream.rs
+++ b/daringsby/src/speech_stream.rs
@@ -127,6 +127,7 @@ mod tests {
         let html = std::str::from_utf8(&body).unwrap();
         assert!(html.contains("ws://"));
         assert!(html.contains("/ws/audio/out"));
+        assert!(html.contains("id=\"start\""));
     }
 
     /// The router upgrades connections to WebSocket.


### PR DESCRIPTION
## Summary
- add start button that initializes WebSocket on click
- check for the start button in SpeechStream tests

## Testing
- `cargo test --all --tests`

------
https://chatgpt.com/codex/tasks/task_e_6860627544048320a28be29b83e1630f