### PR TITLE
Fix audio streaming format

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -3,7 +3,7 @@
 <body>
 <button id="start">Start</button>
 <script>
-const SAMPLE_RATE = 16000;
+const SAMPLE_RATE = 22050;
 const ctx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: SAMPLE_RATE });
 let ws;
 let queue = [];

--- a/daringsby/src/speech_stream.rs
+++ b/daringsby/src/speech_stream.rs
@@ -9,7 +9,7 @@ use once_cell::sync::Lazy;
 use std::sync::Arc;
 use tokio::sync::broadcast::{self, Receiver};
 
-const SAMPLE_RATE: u32 = 16_000;
+const SAMPLE_RATE: u32 = 22_050;
 const FRAME_MS: usize = 10;
 const SILENCE_BYTES: usize = (SAMPLE_RATE as usize / 1000 * FRAME_MS) * 2;
 static SILENCE: Lazy<[u8; SILENCE_BYTES]> = Lazy::new(|| [0u8; SILENCE_BYTES]);


### PR DESCRIPTION
## Summary
- decode WAV responses into raw PCM
- use 22.05kHz sample rate everywhere
- adjust tests for WAV data and add new test for header stripping

## Testing
- `cargo test streams_audio_by_sentence -- --nocapture`
- `cargo test strips_wav_header -- --nocapture`
- `cargo test --all-features --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_68606574cfc08320b4bac6a637a5ff96