### PR TITLE
Fix TTS URL generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
- "urlencoding",
+ "url",
 ]
 
 [[package]]
@@ -2876,12 +2876,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1"
 include_dir = "0.7"
 reqwest = { version = "0.12", features = ["stream"] }
 segtok = "0.1.5"
-urlencoding = "2"
+url = "2"
 bytes = "1"
 axum = { version = "0.7", features = ["macros", "ws"] }
 hound = "3"


### PR DESCRIPTION
## Summary
- avoid panic in mouth URL formation
- add `url` crate
- remove unused urlencoding

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68607453cb1c83209823842faf52945b