### PR TITLE
Add self-audio feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "segtok",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite 0.21.0",
  "tower 0.4.13",
  "tracing",
@@ -2641,6 +2642,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -15,6 +15,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 chrono = "0.4"
 futures = "0.3"
+tokio-stream = { version = "0.1", features = ["sync"] }
 async-stream = "0.3"
 async-trait = "0.1"
 ollama-rs = { version = "0.3.2", features = ["stream"] }

--- a/daringsby/src/heard_self_sensor.rs
+++ b/daringsby/src/heard_self_sensor.rs
@@ -1,0 +1,54 @@
+use chrono::Utc;
+use futures::{StreamExt, stream::BoxStream};
+use tokio::sync::broadcast::Receiver;
+use tokio_stream::wrappers::BroadcastStream;
+
+use psyche_rs::{Sensation, Sensor};
+
+/// Sensor emitting sensations when the agent hears its own speech.
+/// Each text received is wrapped in a sentence describing the event.
+pub struct HeardSelfSensor {
+    rx: Option<Receiver<String>>,
+}
+
+impl HeardSelfSensor {
+    /// Create a new sensor from the given broadcast receiver.
+    pub fn new(rx: Receiver<String>) -> Self {
+        Self { rx: Some(rx) }
+    }
+}
+
+impl Sensor<String> for HeardSelfSensor {
+    fn stream(&mut self) -> BoxStream<'static, Vec<Sensation<String>>> {
+        let rx = self.rx.take().expect("stream may only be called once");
+        BroadcastStream::new(rx)
+            .filter_map(|msg| async move { msg.ok() })
+            .map(|text| {
+                vec![Sensation {
+                    kind: "self_audio".into(),
+                    when: Utc::now(),
+                    what: format!("I just heard myself say out loud: '{}'", text),
+                    source: None,
+                }]
+            })
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use tokio::sync::broadcast;
+
+    #[tokio::test]
+    async fn emits_sensation_per_message() {
+        let (tx, rx) = broadcast::channel(4);
+        let mut sensor = HeardSelfSensor::new(rx);
+        tx.send("Hello".into()).unwrap();
+        drop(tx);
+        let mut stream = sensor.stream();
+        let batch = stream.next().await.unwrap();
+        assert_eq!(batch[0].what, "I just heard myself say out loud: 'Hello'");
+    }
+}

--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -6,13 +6,27 @@
 const SAMPLE_RATE = 22050;
 const ctx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: SAMPLE_RATE });
 let ws;
+let textWs;
+let heardWs;
 let queue = [];
+let texts = [];
 let playing = false;
+
+function segmentDone() {
+  const text = texts.shift();
+  if (heardWs && text) heardWs.send(text);
+}
 
 function play() {
   if (playing || !queue.length) return;
   playing = true;
   const pcm = queue.shift();
+  if (pcm.length === 0) {
+    playing = false;
+    segmentDone();
+    play();
+    return;
+  }
   const buf = ctx.createBuffer(1, pcm.length, SAMPLE_RATE);
   const chan = buf.getChannelData(0);
   for (let i = 0; i < pcm.length; i++) chan[i] = pcm[i] / 32768;
@@ -32,6 +46,9 @@ function start() {
     if (ctx.state === 'suspended') ctx.resume();
     play();
   };
+  textWs = new WebSocket(`ws://${location.host}/ws/audio/text/out`);
+  textWs.onmessage = ev => texts.push(ev.data);
+  heardWs = new WebSocket(`ws://${location.host}/ws/audio/self/in`);
   document.getElementById('start').style.display = 'none';
 }
 

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod heard_self_sensor;
 pub mod heartbeat;
 pub mod logging_motor;
 pub mod mouth;
@@ -5,6 +6,7 @@ pub mod self_discovery;
 pub mod source_discovery;
 pub mod speech_stream;
 
+pub use heard_self_sensor::HeardSelfSensor;
 pub use heartbeat::{Heartbeat, heartbeat_message};
 pub use logging_motor::LoggingMotor;
 pub use mouth::Mouth;


### PR DESCRIPTION
## Summary
- stream spoken text alongside PCM data
- send playback acknowledgements from the browser to `/ws/audio/self/in`
- sense heard speech via `HeardSelfSensor`
- wire up new sensor in the main app
- expose additional websocket routes and update HTML player

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68607f448cc4832089a3f91307f8ab35