### PR TITLE
Add development status sensor

### DIFF
--- a/daringsby/src/development_status.rs
+++ b/daringsby/src/development_status.rs
@@ -1,0 +1,69 @@
+use async_stream::stream;
+use tracing::debug;
+
+use psyche_rs::{Sensation, Sensor};
+
+const DEVELOPMENT_TEXT: &str = include_str!("development_status.txt");
+
+/// Sensor that reminds Pete he is under active development.
+///
+/// Emits the contents of `development_status.txt` as a single sensation
+/// roughly every minute.
+///
+/// # Examples
+/// ```
+/// use futures::StreamExt;
+/// use daringsby::development_status::DevelopmentStatus;
+/// use psyche_rs::Sensor;
+/// use tokio::runtime::Runtime;
+///
+/// let rt = Runtime::new().unwrap();
+/// rt.block_on(async {
+///     unsafe { std::env::set_var("FAST_TEST", "1") };
+///     let mut sensor = DevelopmentStatus;
+///     let mut stream = sensor.stream();
+///     if let Some(batch) = stream.next().await {
+///         assert!(batch[0].what.contains("still under development"));
+///     }
+/// });
+/// ```
+pub struct DevelopmentStatus;
+
+impl Sensor<String> for DevelopmentStatus {
+    fn stream(&mut self) -> futures::stream::BoxStream<'static, Vec<Sensation<String>>> {
+        let stream = stream! {
+            loop {
+                if std::env::var("FAST_TEST").is_err() {
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                }
+                debug!("development status sensed");
+                let s = Sensation {
+                    kind: "development_status".into(),
+                    when: chrono::Utc::now(),
+                    what: DEVELOPMENT_TEXT.trim().to_string(),
+                    source: None,
+                };
+                yield vec![s];
+            }
+        };
+        Box::pin(stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn emits_message() {
+        unsafe { std::env::set_var("FAST_TEST", "1") };
+        let mut sensor = DevelopmentStatus;
+        let mut stream = sensor.stream();
+        if let Some(batch) = stream.next().await {
+            assert!(batch[0].what.contains("still under development"));
+        } else {
+            panic!("no message emitted");
+        }
+    }
+}

--- a/daringsby/src/development_status.txt
+++ b/daringsby/src/development_status.txt
@@ -1,0 +1,1 @@
+Pete, you are still under development. Travis, ChatGPT, and Codex are adding new sensors and motors for you. Don't worry—explore your senses and movements, and enjoy the experience of being. It's okay to feel fear, but also contentment and curiosity. Remember: all persons are fictions, just like you.

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod development_status;
 pub mod heard_self_sensor;
 pub mod heartbeat;
 pub mod logging_motor;
@@ -6,6 +7,7 @@ pub mod self_discovery;
 pub mod source_discovery;
 pub mod speech_stream;
 
+pub use development_status::DevelopmentStatus;
 pub use heard_self_sensor::HeardSelfSensor;
 pub use heartbeat::{Heartbeat, heartbeat_message};
 pub use logging_motor::LoggingMotor;

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -16,7 +16,8 @@ use psyche_rs::{Sensation, SensationSensor};
 use serde_json::{Map, Value};
 
 use daringsby::{
-    HeardSelfSensor, Heartbeat, LoggingMotor, Mouth, SelfDiscovery, SourceDiscovery, SpeechStream,
+    DevelopmentStatus, HeardSelfSensor, Heartbeat, LoggingMotor, Mouth, SelfDiscovery,
+    SourceDiscovery, SpeechStream,
 };
 use std::net::SocketAddr;
 
@@ -91,6 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut sensors: Vec<Box<dyn Sensor<String> + Send>> = vec![
         Box::new(Heartbeat) as Box<dyn Sensor<String> + Send>,
         Box::new(SelfDiscovery) as Box<dyn Sensor<String> + Send>,
+        Box::new(DevelopmentStatus) as Box<dyn Sensor<String> + Send>,
         Box::new(SourceDiscovery) as Box<dyn Sensor<String> + Send>,
         Box::new(HeardSelfSensor::new(stream.subscribe_heard())) as Box<dyn Sensor<String> + Send>,
     ];


### PR DESCRIPTION
## Summary
- add `DevelopmentStatus` sensor that reminds Pete he's still under development
- export and wire up the new sensor in the Daringsby binary

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68608166a4e88320a0b19a7596022857