### PR TITLE
Fix Coqui TTS streaming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,5 @@
   large modules like `lib.rs` into smaller pieces.
 - Use the `LLMClient` trait for streaming LLM interactions.
 - Avoid streaming silence frames when audio is not playing.
+- Stream HTTP responses using `bytes_stream` to avoid blocking when servers
+  stream data chunked.


### PR DESCRIPTION
## Summary
- stream HTTP response bytes from Coqui TTS before decoding
- document the streaming requirement in AGENTS

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860878610f08320ae90a25c8a887fa8