### PR TITLE
Add Combobulator prompt and abort support

### DIFF
--- a/psyche-rs/src/combobulator.rs
+++ b/psyche-rs/src/combobulator.rs
@@ -4,18 +4,34 @@ use futures::stream::BoxStream;
 
 use crate::{Impression, LLMClient, Sensor, Wit};
 
+/// Default prompt text for [`Combobulator`].
+const DEFAULT_PROMPT: &str = include_str!("combobulator_prompt.txt");
+
 /// Second order wit that summarizes impressions from another wit.
 ///
 /// `Combobulator` simply wraps [`Wit`] with an input type of
 /// [`Impression`].
+///
+/// # Example
+/// ```ignore
+/// let comb = Combobulator::new(llm).prompt("my prompt").delay_ms(1000);
+/// let stream = comb.observe(sensors).await;
+/// ```
 pub struct Combobulator<T = serde_json::Value> {
     wit: Wit<Impression<T>>,
 }
 
 impl<T> Combobulator<T> {
+    /// Returns the default prompt text.
+    pub fn default_prompt() -> &'static str {
+        DEFAULT_PROMPT
+    }
+
     /// Creates a new [`Combobulator`] backed by the given LLM client.
     pub fn new(llm: Arc<dyn LLMClient>) -> Self {
-        Self { wit: Wit::new(llm) }
+        Self {
+            wit: Wit::new(llm).prompt(Self::default_prompt()),
+        }
     }
 
     /// Overrides the prompt template.
@@ -58,6 +74,18 @@ where
         S: Sensor<Impression<T>> + Send + 'static,
     {
         self.wit.observe(sensors).await
+    }
+
+    /// Observe sensors with the ability to abort processing.
+    pub async fn observe_with_abort<S>(
+        &mut self,
+        sensors: Vec<S>,
+        abort: tokio::sync::oneshot::Receiver<()>,
+    ) -> BoxStream<'static, Vec<Impression<Impression<T>>>>
+    where
+        S: Sensor<Impression<T>> + Send + 'static,
+    {
+        self.wit.observe_with_abort(sensors, abort).await
     }
 }
 
@@ -118,5 +146,43 @@ mod tests {
         let impressions = stream.next().await.unwrap();
         assert_eq!(impressions.len(), 1);
         assert_eq!(impressions[0].how.trim(), "meta");
+    }
+
+    #[tokio::test]
+    async fn timeline_collects_inputs() {
+        use async_stream::stream;
+        struct TwoBatch;
+
+        impl Sensor<Impression<String>> for TwoBatch {
+            fn stream(&mut self) -> BoxStream<'static, Vec<crate::Sensation<Impression<String>>>> {
+                let s = stream! {
+                    yield vec![crate::Sensation {
+                        kind: "impression".into(),
+                        when: chrono::Local::now(),
+                        what: Impression { how: "a".into(), what: Vec::new() },
+                        source: None,
+                    }];
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    yield vec![crate::Sensation {
+                        kind: "impression".into(),
+                        when: chrono::Local::now(),
+                        what: Impression { how: "b".into(), what: Vec::new() },
+                        source: None,
+                    }];
+                };
+                Box::pin(s)
+            }
+        }
+
+        let llm = Arc::new(StaticLLM { reply: "ok".into() });
+        let mut comb = Combobulator::new(llm).delay_ms(10);
+        let sensor = TwoBatch;
+        let mut stream = comb.observe(vec![sensor]).await;
+        let _ = stream.next().await;
+        let _ = stream.next().await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let tl = comb.timeline();
+        let lines: Vec<_> = tl.lines().collect();
+        assert_eq!(lines.len(), 2);
     }
 }

--- a/psyche-rs/src/combobulator_prompt.txt
+++ b/psyche-rs/src/combobulator_prompt.txt
@@ -1,0 +1,6 @@
+These are the recent experiences of a character. They tell a story when taken together--or, rather, a frame in an ongoing story.
+In the last moment, this was happening:
+{last_frame}
+In the past instant, these things have taken place:
+{template}
+Narrate that story in natural language. Concisely in about one sentence, in the first person (from the perspective of the character), based on the timeline above, what's happening?


### PR DESCRIPTION
## Summary
- add a default prompt for `Combobulator`
- document basic usage of `Combobulator`
- provide optional abort channel for `observe`
- test `timeline()` to ensure entries are collected

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6860beaf01a08320b6be1a8e60c3b2c6