### PR TITLE
Refactor source discovery

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -154,14 +154,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 async fn drive_combo_stream(
     mut combo_stream: impl futures::Stream<Item = Vec<Impression<Impression<String>>>>
-        + Unpin
-        + Send
-        + 'static,
+    + Unpin
+    + Send
+    + 'static,
     logger: Arc<LoggingMotor>,
     mouth: Arc<Mouth>,
     looker: Arc<LookMotor>,
     speaker_id: String,
-    #[cfg(feature = "moment-feedback")] sens_tx: tokio::sync::mpsc::UnboundedSender<Vec<Sensation<String>>>,
+    #[cfg(feature = "moment-feedback")] sens_tx: tokio::sync::mpsc::UnboundedSender<
+        Vec<Sensation<String>>,
+    >,
     #[cfg(feature = "moment-feedback")] moment: Arc<Mutex<Vec<Impression<Impression<String>>>>>,
 ) {
     use futures::{StreamExt, stream};


### PR DESCRIPTION
## Summary
- panic if embedded source is missing
- document binary size impact for `SourceDiscovery`
- allow abort or finite cycles via env vars
- remove explicit `unsafe` in tests using helper
- rustfmt untouched files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860bdae486c8320b7accbd3fc205c1e