### PR TITLE
Improve LoggingMotor

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{Level, error};
 
+#[cfg(feature = "moment-feedback")]
 use chrono::Local;
+#[allow(unused_imports)]
 use futures::{StreamExt, stream};
 use ollama_rs::Ollama;
 use once_cell::sync::Lazy;
@@ -154,14 +156,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 async fn drive_combo_stream(
     mut combo_stream: impl futures::Stream<Item = Vec<Impression<Impression<String>>>>
-        + Unpin
-        + Send
-        + 'static,
+    + Unpin
+    + Send
+    + 'static,
     logger: Arc<LoggingMotor>,
     mouth: Arc<Mouth>,
     looker: Arc<LookMotor>,
     speaker_id: String,
-    #[cfg(feature = "moment-feedback")] sens_tx: tokio::sync::mpsc::UnboundedSender<Vec<Sensation<String>>>,
+    #[cfg(feature = "moment-feedback")] sens_tx: tokio::sync::mpsc::UnboundedSender<
+        Vec<Sensation<String>>,
+    >,
     #[cfg(feature = "moment-feedback")] moment: Arc<Mutex<Vec<Impression<Impression<String>>>>>,
 ) {
     use futures::{StreamExt, stream};

--- a/daringsby/tests/logging_motor.rs
+++ b/daringsby/tests/logging_motor.rs
@@ -1,0 +1,15 @@
+use daringsby::logging_motor::LoggingMotor;
+use futures::{StreamExt, stream};
+use psyche_rs::{Action, Intention, Motor, Urge};
+
+#[tokio::test]
+async fn perform_accepts_body_and_succeeds() {
+    let motor = LoggingMotor::default();
+    let body = stream::iter(vec!["hello".to_string(), " world".to_string()]).boxed();
+    let intention = Intention::assign(Urge::new("log"), "log");
+    let action = Action { intention, body };
+    let result = motor.perform(action).await.expect("perform should succeed");
+    assert!(result.completed);
+    assert_eq!(result.sensations.len(), 1);
+    assert_eq!(result.sensations[0].what, "hello world");
+}


### PR DESCRIPTION
## Summary
- warn when `LoggingMotor` receives an empty body
- include `assigned_motor` metadata in the log
- return a `Sensation` describing the logged text
- add an async test verifying `LoggingMotor::perform`
- silence feature-related warnings in `main.rs`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860bf20f19c8320a8de2b58fd4f516e