### PR TITLE
Add SensorDirectingMotor trait

### DIFF
--- a/daringsby/src/look_motor.rs
+++ b/daringsby/src/look_motor.rs
@@ -84,3 +84,24 @@ impl Motor for LookMotor {
         })
     }
 }
+
+#[async_trait::async_trait]
+impl psyche_rs::SensorDirectingMotor for LookMotor {
+    /// Return the name of the single sensor controlled by this motor.
+    fn attached_sensors(&self) -> Vec<String> {
+        vec!["LookStream".to_string()]
+    }
+
+    /// Trigger a snapshot on the internal [`LookStream`].
+    async fn direct_sensor(&self, sensor_name: &str) -> Result<(), MotorError> {
+        if sensor_name == "LookStream" {
+            self.stream.request_snap();
+            Ok(())
+        } else {
+            Err(MotorError::Failed(format!(
+                "Unknown sensor: {}",
+                sensor_name
+            )))
+        }
+    }
+}

--- a/daringsby/tests/look_motor.rs
+++ b/daringsby/tests/look_motor.rs
@@ -1,0 +1,50 @@
+use daringsby::{look_motor::LookMotor, look_stream::LookStream};
+use psyche_rs::{LLMClient, MotorError, SensorDirectingMotor};
+use std::sync::Arc;
+use tokio::sync::mpsc::unbounded_channel;
+
+struct DummyLLM;
+
+#[async_trait::async_trait]
+impl LLMClient for DummyLLM {
+    async fn chat_stream(
+        &self,
+        _messages: &[ollama_rs::generation::chat::ChatMessage],
+    ) -> Result<psyche_rs::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        let stream = async_stream::stream! {
+            yield Ok(String::new());
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+#[tokio::test]
+async fn attached_sensors_returns_stream_name() {
+    let stream = Arc::new(LookStream::default());
+    let llm = Arc::new(DummyLLM);
+    let (tx, _) = unbounded_channel();
+    let motor = LookMotor::new(stream, llm, tx);
+    let sensors = SensorDirectingMotor::attached_sensors(&motor);
+    assert_eq!(sensors, vec!["LookStream".to_string()]);
+}
+
+#[tokio::test]
+async fn direct_sensor_valid_name_succeeds() {
+    let stream = Arc::new(LookStream::default());
+    let llm = Arc::new(DummyLLM);
+    let (tx, _) = unbounded_channel();
+    let motor = LookMotor::new(stream.clone(), llm, tx);
+    SensorDirectingMotor::direct_sensor(&motor, "LookStream")
+        .await
+        .expect("should succeed");
+}
+
+#[tokio::test]
+async fn direct_sensor_unknown_name_fails() {
+    let stream = Arc::new(LookStream::default());
+    let llm = Arc::new(DummyLLM);
+    let (tx, _) = unbounded_channel();
+    let motor = LookMotor::new(stream.clone(), llm, tx);
+    let err = SensorDirectingMotor::direct_sensor(&motor, "Unknown").await;
+    assert!(matches!(err, Err(MotorError::Failed(_))));
+}

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -22,7 +22,8 @@ pub use impression::Impression;
 pub use impression_sensor::ImpressionSensor;
 pub use llm_pool::LLMPool;
 pub use motor::{
-    Action, ActionResult, Completion, Intention, Interruption, Motor, MotorError, Urge,
+    Action, ActionResult, Completion, Intention, Interruption, Motor, MotorError,
+    SensorDirectingMotor, Urge,
 };
 pub use psyche::Psyche;
 pub use sensation::Sensation;

--- a/psyche-rs/src/motor.rs
+++ b/psyche-rs/src/motor.rs
@@ -42,6 +42,21 @@ pub trait Motor: Send + Sync {
     fn name(&self) -> &'static str;
 }
 
+/// Motors that can direct sensors implement this trait in addition to [`Motor`].
+///
+/// Implementors are able to activate one or more sensors and should return the
+/// set of known sensor identifiers from [`attached_sensors`]. The
+/// [`direct_sensor`] method requests activation of a specific sensor and returns
+/// an error if the name is not recognized.
+#[async_trait::async_trait]
+pub trait SensorDirectingMotor: Motor {
+    /// Names or identifiers of sensors this motor is able to control.
+    fn attached_sensors(&self) -> Vec<String>;
+
+    /// Instruct the motor to activate the given sensor.
+    async fn direct_sensor(&self, sensor_name: &str) -> Result<(), MotorError>;
+}
+
 /// Errors that may occur while executing a motor action.
 #[derive(Debug, thiserror::Error)]
 pub enum MotorError {


### PR DESCRIPTION
## Summary
- define `SensorDirectingMotor` trait in library
- export the trait publicly
- implement sensor directing for `LookMotor`
- test sensor-directing behavior

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860c1bc3bcc8320bf977b53f083c21c