### PR TITLE
Improve Motor docs and ActionResult

### DIFF
--- a/daringsby/src/logging_motor.rs
+++ b/daringsby/src/logging_motor.rs
@@ -39,6 +39,8 @@ impl Motor for LoggingMotor {
                 source: None,
             }],
             completed: true,
+            completion: None,
+            interruption: None,
         })
     }
 }

--- a/daringsby/src/look_motor.rs
+++ b/daringsby/src/look_motor.rs
@@ -81,6 +81,8 @@ impl Motor for LookMotor {
                 source: None,
             }],
             completed: true,
+            completion: None,
+            interruption: None,
         })
     }
 }

--- a/daringsby/src/mouth.rs
+++ b/daringsby/src/mouth.rs
@@ -251,6 +251,8 @@ impl Motor for Mouth {
         Ok(ActionResult {
             sensations: Vec::new(),
             completed: true,
+            completion: None,
+            interruption: None,
         })
     }
 }

--- a/daringsby/tests/logging_motor.rs
+++ b/daringsby/tests/logging_motor.rs
@@ -10,6 +10,8 @@ async fn perform_accepts_body_and_succeeds() {
     let action = Action { intention, body };
     let result = motor.perform(action).await.expect("perform should succeed");
     assert!(result.completed);
+    assert!(result.completion.is_none());
+    assert!(result.interruption.is_none());
     assert_eq!(result.sensations.len(), 1);
     assert_eq!(result.sensations[0].what, "hello world");
 }

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -141,6 +141,8 @@ mod tests {
                 Ok(ActionResult {
                     sensations: Vec::new(),
                     completed: true,
+                    completion: None,
+                    interruption: None,
                 })
             }
         }

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -194,6 +194,8 @@ mod tests {
             Ok(ActionResult {
                 sensations: Vec::new(),
                 completed: true,
+                completion: None,
+                interruption: None,
             })
         }
     }
@@ -238,6 +240,8 @@ mod tests {
                         source: None,
                     }],
                     completed: true,
+                    completion: None,
+                    interruption: None,
                 })
             }
         }


### PR DESCRIPTION
## Summary
- document Intention::to
- extend `ActionResult` with optional `completion` and `interruption`
- verify streaming body and ActionResult metadata
- update motors and tests for the new fields

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860c40ae3cc8320b433fd75a51c107b