### PR TITLE
Add source code motors

### DIFF
--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -7,6 +7,9 @@ pub mod look_stream;
 pub mod mouth;
 pub mod self_discovery;
 pub mod source_discovery;
+pub mod source_read_motor;
+pub mod source_search_motor;
+pub mod source_tree_motor;
 pub mod speech_stream;
 
 pub mod motors;

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -7,3 +7,6 @@
 pub use crate::logging_motor::LoggingMotor;
 pub use crate::look_motor::LookMotor;
 pub use crate::mouth::Mouth;
+pub use crate::source_read_motor::SourceReadMotor;
+pub use crate::source_search_motor::SourceSearchMotor;
+pub use crate::source_tree_motor::SourceTreeMotor;

--- a/daringsby/src/source_read_motor.rs
+++ b/daringsby/src/source_read_motor.rs
@@ -1,0 +1,119 @@
+use async_trait::async_trait;
+use chrono::Local;
+use include_dir::{Dir, include_dir};
+use tokio::sync::mpsc::UnboundedSender;
+
+use psyche_rs::{Action, ActionResult, Motor, MotorError, Sensation, SensorDirectingMotor};
+
+static DARINGSBY_SRC_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src");
+static PSYCHE_SRC_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../psyche-rs/src");
+
+const MAX_LINES: usize = 20;
+
+/// Motor that reads blocks of source code on demand.
+///
+/// The sensor `"SourceBlockSensor"` emits a single [`Sensation`] with the
+/// requested portion of a file when directed. Parameters are supplied by
+/// appending `:"path":index` to the sensor name, e.g. `"SourceBlockSensor:src/main.rs:1"`.
+/// The index selects the `MAX_LINES` sized chunk to return.
+pub struct SourceReadMotor {
+    tx: UnboundedSender<Vec<Sensation<String>>>,
+}
+
+impl SourceReadMotor {
+    /// Create a new motor sending sensations through the provided channel.
+    pub fn new(tx: UnboundedSender<Vec<Sensation<String>>>) -> Self {
+        Self { tx }
+    }
+
+    fn get_file(path: &str) -> Option<&'static include_dir::File<'static>> {
+        DARINGSBY_SRC_DIR
+            .get_file(path)
+            .or_else(|| PSYCHE_SRC_DIR.get_file(path))
+    }
+
+    fn read_block(path: &str, index: usize) -> Result<String, MotorError> {
+        let file = Self::get_file(path)
+            .ok_or_else(|| MotorError::Failed(format!("unknown file: {}", path)))?;
+        let text = file
+            .contents_utf8()
+            .ok_or_else(|| MotorError::Failed("invalid utf8".into()))?;
+        let lines: Vec<&str> = text.lines().collect();
+        let chunks: Vec<&[&str]> = lines.chunks(MAX_LINES).collect();
+        let idx = index.min(chunks.len().saturating_sub(1));
+        Ok(chunks[idx].join("\n"))
+    }
+}
+
+#[async_trait]
+impl Motor for SourceReadMotor {
+    fn description(&self) -> &'static str {
+        "Read a block of source code"
+    }
+
+    fn name(&self) -> &'static str {
+        "read_source"
+    }
+
+    async fn perform(&self, action: Action) -> Result<ActionResult, MotorError> {
+        if action.intention.urge.name != "read_source" {
+            return Err(MotorError::Unrecognized);
+        }
+        let path = action
+            .intention
+            .urge
+            .args
+            .get("file_path")
+            .ok_or_else(|| MotorError::Failed("missing file_path".into()))?;
+        let index = action
+            .intention
+            .urge
+            .args
+            .get("block_index")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        let block = Self::read_block(path, index)?;
+        Ok(ActionResult {
+            sensations: vec![Sensation {
+                kind: "source.block".into(),
+                when: Local::now(),
+                what: serde_json::Value::String(block),
+                source: Some(path.clone()),
+            }],
+            completed: true,
+            completion: None,
+            interruption: None,
+        })
+    }
+}
+
+#[async_trait]
+impl SensorDirectingMotor for SourceReadMotor {
+    fn attached_sensors(&self) -> Vec<String> {
+        vec!["SourceBlockSensor".to_string()]
+    }
+
+    async fn direct_sensor(&self, sensor_name: &str) -> Result<(), MotorError> {
+        if !sensor_name.starts_with("SourceBlockSensor") {
+            return Err(MotorError::Failed(format!(
+                "Unknown sensor: {}",
+                sensor_name
+            )));
+        }
+        let mut parts = sensor_name.splitn(3, ':');
+        let _ = parts.next();
+        let path = parts
+            .next()
+            .ok_or_else(|| MotorError::Failed("missing file path".into()))?;
+        let index = parts.next().and_then(|v| v.parse().ok()).unwrap_or(0);
+        let block = Self::read_block(path, index)?;
+        let s = Sensation {
+            kind: "source.block".into(),
+            when: Local::now(),
+            what: block,
+            source: Some(path.to_string()),
+        };
+        let _ = self.tx.send(vec![s]);
+        Ok(())
+    }
+}

--- a/daringsby/src/source_search_motor.rs
+++ b/daringsby/src/source_search_motor.rs
@@ -1,0 +1,122 @@
+use async_trait::async_trait;
+use chrono::Local;
+use include_dir::{Dir, include_dir};
+use tokio::sync::mpsc::UnboundedSender;
+
+use psyche_rs::{Action, ActionResult, Motor, MotorError, Sensation, SensorDirectingMotor};
+
+static DARINGSBY_SRC_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src");
+static PSYCHE_SRC_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../psyche-rs/src");
+
+/// Motor that searches source files for a query string.
+///
+/// The `"SourceSearchSensor"` emits a [`Sensation`] for each matching line when
+/// directed. Parameters are appended to the sensor name using
+/// `:"query"`, for example `"SourceSearchSensor:LookMotor"`.
+pub struct SourceSearchMotor {
+    tx: UnboundedSender<Vec<Sensation<String>>>,
+}
+
+impl SourceSearchMotor {
+    /// Create a new motor sending sensations through the provided channel.
+    pub fn new(tx: UnboundedSender<Vec<Sensation<String>>>) -> Self {
+        Self { tx }
+    }
+
+    fn search(query: &str) -> Vec<Sensation<String>> {
+        let mut out = Vec::new();
+        for (prefix, dir) in [
+            ("daringsby/src", &DARINGSBY_SRC_DIR),
+            ("psyche-rs/src", &PSYCHE_SRC_DIR),
+        ] {
+            for file in dir.files() {
+                if file.path().extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                if let Some(text) = file.contents_utf8() {
+                    for (i, line) in text.lines().enumerate() {
+                        if line.contains(query) {
+                            let what = format!(
+                                "{}:{}: {}",
+                                format!("{}/{}", prefix, file.path().display()),
+                                i + 1,
+                                line.trim_end()
+                            );
+                            out.push(Sensation {
+                                kind: "source.search".into(),
+                                when: Local::now(),
+                                what,
+                                source: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+#[async_trait]
+impl Motor for SourceSearchMotor {
+    fn description(&self) -> &'static str {
+        "Search the source code for a string"
+    }
+
+    fn name(&self) -> &'static str {
+        "search_source"
+    }
+
+    async fn perform(&self, action: Action) -> Result<ActionResult, MotorError> {
+        if action.intention.urge.name != "search_source" {
+            return Err(MotorError::Unrecognized);
+        }
+        let query = action
+            .intention
+            .urge
+            .args
+            .get("query")
+            .ok_or_else(|| MotorError::Failed("missing query".into()))?;
+        let results = Self::search(query);
+        Ok(ActionResult {
+            sensations: results
+                .into_iter()
+                .map(|s| Sensation {
+                    kind: s.kind,
+                    when: s.when,
+                    what: serde_json::Value::String(s.what),
+                    source: s.source,
+                })
+                .collect(),
+            completed: true,
+            completion: None,
+            interruption: None,
+        })
+    }
+}
+
+#[async_trait]
+impl SensorDirectingMotor for SourceSearchMotor {
+    fn attached_sensors(&self) -> Vec<String> {
+        vec!["SourceSearchSensor".to_string()]
+    }
+
+    async fn direct_sensor(&self, sensor_name: &str) -> Result<(), MotorError> {
+        if !sensor_name.starts_with("SourceSearchSensor") {
+            return Err(MotorError::Failed(format!(
+                "Unknown sensor: {}",
+                sensor_name
+            )));
+        }
+        let mut parts = sensor_name.splitn(2, ':');
+        let _ = parts.next();
+        let query = parts
+            .next()
+            .ok_or_else(|| MotorError::Failed("missing query".into()))?;
+        let results = Self::search(query);
+        if !results.is_empty() {
+            let _ = self.tx.send(results);
+        }
+        Ok(())
+    }
+}

--- a/daringsby/tests/source_read_motor.rs
+++ b/daringsby/tests/source_read_motor.rs
@@ -1,0 +1,31 @@
+use daringsby::source_read_motor::SourceReadMotor;
+use psyche_rs::{MotorError, SensorDirectingMotor};
+use tokio::sync::mpsc::unbounded_channel;
+
+#[tokio::test]
+async fn attached_sensors_returns_block_sensor() {
+    let (tx, _rx) = unbounded_channel();
+    let motor = SourceReadMotor::new(tx);
+    let sensors = SensorDirectingMotor::attached_sensors(&motor);
+    assert_eq!(sensors, vec!["SourceBlockSensor".to_string()]);
+}
+
+#[tokio::test]
+async fn direct_sensor_emits_block() {
+    let (tx, mut rx) = unbounded_channel();
+    let motor = SourceReadMotor::new(tx);
+    // file path relative to daringsby crate
+    SensorDirectingMotor::direct_sensor(&motor, "SourceBlockSensor:lib.rs:0")
+        .await
+        .expect("should succeed");
+    let sensations = rx.try_recv().expect("sensation");
+    assert!(sensations[0].what.contains("pub mod"));
+}
+
+#[tokio::test]
+async fn direct_sensor_unknown() {
+    let (tx, _rx) = unbounded_channel();
+    let motor = SourceReadMotor::new(tx);
+    let err = SensorDirectingMotor::direct_sensor(&motor, "Unknown").await;
+    assert!(matches!(err, Err(MotorError::Failed(_))));
+}

--- a/daringsby/tests/source_search_motor.rs
+++ b/daringsby/tests/source_search_motor.rs
@@ -1,0 +1,30 @@
+use daringsby::source_search_motor::SourceSearchMotor;
+use psyche_rs::{MotorError, SensorDirectingMotor};
+use tokio::sync::mpsc::unbounded_channel;
+
+#[tokio::test]
+async fn attached_sensors_returns_search_sensor() {
+    let (tx, _rx) = unbounded_channel();
+    let motor = SourceSearchMotor::new(tx);
+    let sensors = SensorDirectingMotor::attached_sensors(&motor);
+    assert_eq!(sensors, vec!["SourceSearchSensor".to_string()]);
+}
+
+#[tokio::test]
+async fn direct_sensor_emits_matches() {
+    let (tx, mut rx) = unbounded_channel();
+    let motor = SourceSearchMotor::new(tx);
+    SensorDirectingMotor::direct_sensor(&motor, "SourceSearchSensor:LookMotor")
+        .await
+        .expect("should succeed");
+    let sensations = rx.try_recv().expect("sensation");
+    assert!(sensations[0].what.contains("LookMotor"));
+}
+
+#[tokio::test]
+async fn direct_sensor_unknown_name() {
+    let (tx, _rx) = unbounded_channel();
+    let motor = SourceSearchMotor::new(tx);
+    let err = SensorDirectingMotor::direct_sensor(&motor, "Unknown").await;
+    assert!(matches!(err, Err(MotorError::Failed(_))));
+}

--- a/daringsby/tests/source_tree_motor.rs
+++ b/daringsby/tests/source_tree_motor.rs
@@ -1,0 +1,30 @@
+use daringsby::source_tree_motor::SourceTreeMotor;
+use psyche_rs::{MotorError, SensorDirectingMotor};
+use tokio::sync::mpsc::unbounded_channel;
+
+#[tokio::test]
+async fn attached_sensors_returns_tree_sensor() {
+    let (tx, _rx) = unbounded_channel();
+    let motor = SourceTreeMotor::new(tx);
+    let sensors = SensorDirectingMotor::attached_sensors(&motor);
+    assert_eq!(sensors, vec!["SourceTreeSensor".to_string()]);
+}
+
+#[tokio::test]
+async fn direct_sensor_emits_tree() {
+    let (tx, mut rx) = unbounded_channel();
+    let motor = SourceTreeMotor::new(tx);
+    SensorDirectingMotor::direct_sensor(&motor, "SourceTreeSensor")
+        .await
+        .expect("should succeed");
+    let sensations = rx.try_recv().expect("sensation sent");
+    assert!(sensations[0].what.contains("daringsby"));
+}
+
+#[tokio::test]
+async fn direct_sensor_unknown_name() {
+    let (tx, _rx) = unbounded_channel();
+    let motor = SourceTreeMotor::new(tx);
+    let err = SensorDirectingMotor::direct_sensor(&motor, "Unknown").await;
+    assert!(matches!(err, Err(MotorError::Failed(_))));
+}


### PR DESCRIPTION
## Summary
- implement SourceTreeMotor, SourceReadMotor and SourceSearchMotor
- export new motors
- test attached_sensors and direct_sensor behavior for each

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860c5c1aec0832095bd130c743dee9a