### PR TITLE
Add feature gates for Pete devices

### DIFF
--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -40,4 +40,8 @@ tower = { version = "0.4", features = ["util"] }
 tokio-tungstenite = "0.21"
 
 [features]
+default = ["petes_motors", "petes_sensors"]
 moment-feedback = []
+petes_motors = []
+petes_sensors = []
+source-discovery = []

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,14 +1,25 @@
+#[cfg(feature = "petes_sensors")]
 pub mod development_status;
+#[cfg(feature = "petes_sensors")]
 pub mod heard_self_sensor;
+#[cfg(feature = "petes_sensors")]
 pub mod heartbeat;
+#[cfg(feature = "petes_motors")]
 pub mod logging_motor;
+#[cfg(feature = "petes_motors")]
 pub mod look_motor;
 pub mod look_stream;
+#[cfg(feature = "petes_motors")]
 pub mod mouth;
+#[cfg(feature = "petes_sensors")]
 pub mod self_discovery;
+#[cfg(all(feature = "petes_sensors", feature = "source-discovery"))]
 pub mod source_discovery;
+#[cfg(feature = "petes_motors")]
 pub mod source_read_motor;
+#[cfg(feature = "petes_motors")]
 pub mod source_search_motor;
+#[cfg(feature = "petes_motors")]
 pub mod source_tree_motor;
 pub mod speech_stream;
 

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -4,9 +4,15 @@
 /// ```
 /// use daringsby::motors::LoggingMotor;
 /// ```
+#[cfg(feature = "petes_motors")]
 pub use crate::logging_motor::LoggingMotor;
+#[cfg(feature = "petes_motors")]
 pub use crate::look_motor::LookMotor;
+#[cfg(feature = "petes_motors")]
 pub use crate::mouth::Mouth;
+#[cfg(feature = "petes_motors")]
 pub use crate::source_read_motor::SourceReadMotor;
+#[cfg(feature = "petes_motors")]
 pub use crate::source_search_motor::SourceSearchMotor;
+#[cfg(feature = "petes_motors")]
 pub use crate::source_tree_motor::SourceTreeMotor;

--- a/daringsby/src/sensors.rs
+++ b/daringsby/src/sensors.rs
@@ -4,8 +4,13 @@
 /// ```
 /// use daringsby::sensors::Heartbeat;
 /// ```
+#[cfg(feature = "petes_sensors")]
 pub use crate::development_status::DevelopmentStatus;
+#[cfg(feature = "petes_sensors")]
 pub use crate::heard_self_sensor::HeardSelfSensor;
+#[cfg(feature = "petes_sensors")]
 pub use crate::heartbeat::{Heartbeat, heartbeat_message};
+#[cfg(feature = "petes_sensors")]
 pub use crate::self_discovery::SelfDiscovery;
+#[cfg(all(feature = "petes_sensors", feature = "source-discovery"))]
 pub use crate::source_discovery::SourceDiscovery;


### PR DESCRIPTION
## Summary
- add `petes_motors` and `petes_sensors` features with defaults
- gate Daringsby modules and main logic behind the new features
- disable `source-discovery` by default

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860cf94e9a883209af5bdba9bc521f4