### PR TITLE
Add feature gating for Pete's motors and sensors

### DIFF
--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -40,4 +40,27 @@ tower = { version = "0.4", features = ["util"] }
 tokio-tungstenite = "0.21"
 
 [features]
+logging-motor = []
+look-motor = []
+mouth = []
+source-read-motor = []
+source-search-motor = []
+source-tree-motor = []
+development-status-sensor = []
+heard-self-sensor = []
+heartbeat-sensor = []
+self-discovery-sensor = []
+source-discovery-sensor = []
 moment-feedback = []
+default = [
+    "logging-motor",
+    "look-motor",
+    "mouth",
+    "source-read-motor",
+    "source-search-motor",
+    "source-tree-motor",
+    "development-status-sensor",
+    "heard-self-sensor",
+    "heartbeat-sensor",
+    "self-discovery-sensor",
+]

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,14 +1,25 @@
+#[cfg(feature = "development-status-sensor")]
 pub mod development_status;
+#[cfg(feature = "heard-self-sensor")]
 pub mod heard_self_sensor;
+#[cfg(feature = "heartbeat-sensor")]
 pub mod heartbeat;
+#[cfg(feature = "logging-motor")]
 pub mod logging_motor;
+#[cfg(feature = "look-motor")]
 pub mod look_motor;
 pub mod look_stream;
+#[cfg(feature = "mouth")]
 pub mod mouth;
+#[cfg(feature = "self-discovery-sensor")]
 pub mod self_discovery;
+#[cfg(feature = "source-discovery-sensor")]
 pub mod source_discovery;
+#[cfg(feature = "source-read-motor")]
 pub mod source_read_motor;
+#[cfg(feature = "source-search-motor")]
 pub mod source_search_motor;
+#[cfg(feature = "source-tree-motor")]
 pub mod source_tree_motor;
 pub mod speech_stream;
 

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -14,9 +14,11 @@ use psyche_rs::{
     Sensation, SensationSensor, Sensor, Wit,
 };
 
+#[cfg(feature = "source-discovery-sensor")]
+use daringsby::SourceDiscovery;
 use daringsby::{
     DevelopmentStatus, HeardSelfSensor, Heartbeat, LoggingMotor, LookMotor, LookStream, Mouth,
-    SelfDiscovery, SourceDiscovery, SpeechStream,
+    SelfDiscovery, SpeechStream,
 };
 use std::net::SocketAddr;
 
@@ -101,10 +103,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(Heartbeat) as Box<dyn Sensor<String> + Send>,
         Box::new(SelfDiscovery) as Box<dyn Sensor<String> + Send>,
         Box::new(DevelopmentStatus) as Box<dyn Sensor<String> + Send>,
-        Box::new(SourceDiscovery) as Box<dyn Sensor<String> + Send>,
         Box::new(HeardSelfSensor::new(stream.subscribe_heard())) as Box<dyn Sensor<String> + Send>,
         Box::new(SensationSensor::new(look_rx)) as Box<dyn Sensor<String> + Send>,
     ];
+    #[cfg(feature = "source-discovery-sensor")]
+    sensors.push(Box::new(SourceDiscovery) as Box<dyn Sensor<String> + Send>);
     #[cfg(feature = "moment-feedback")]
     sensors.push(Box::new(SensationSensor::new(sens_rx)));
 

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -4,9 +4,15 @@
 /// ```
 /// use daringsby::motors::LoggingMotor;
 /// ```
+#[cfg(feature = "logging-motor")]
 pub use crate::logging_motor::LoggingMotor;
+#[cfg(feature = "look-motor")]
 pub use crate::look_motor::LookMotor;
+#[cfg(feature = "mouth")]
 pub use crate::mouth::Mouth;
+#[cfg(feature = "source-read-motor")]
 pub use crate::source_read_motor::SourceReadMotor;
+#[cfg(feature = "source-search-motor")]
 pub use crate::source_search_motor::SourceSearchMotor;
+#[cfg(feature = "source-tree-motor")]
 pub use crate::source_tree_motor::SourceTreeMotor;

--- a/daringsby/src/sensors.rs
+++ b/daringsby/src/sensors.rs
@@ -4,8 +4,13 @@
 /// ```
 /// use daringsby::sensors::Heartbeat;
 /// ```
+#[cfg(feature = "development-status-sensor")]
 pub use crate::development_status::DevelopmentStatus;
+#[cfg(feature = "heard-self-sensor")]
 pub use crate::heard_self_sensor::HeardSelfSensor;
+#[cfg(feature = "heartbeat-sensor")]
 pub use crate::heartbeat::{Heartbeat, heartbeat_message};
+#[cfg(feature = "self-discovery-sensor")]
 pub use crate::self_discovery::SelfDiscovery;
+#[cfg(feature = "source-discovery-sensor")]
 pub use crate::source_discovery::SourceDiscovery;


### PR DESCRIPTION
## Summary
- feature-gate all motors and sensors in daringsby
- disable `source-discovery-sensor` by default
- conditionally use `SourceDiscovery` in the main binary

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860d86042108320a5721227f4fcd484