### PR TITLE
Fix duplicate websocket connections

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -83,7 +83,11 @@ function capture() {
   lookCanvas.toBlob(b => b && b.arrayBuffer().then(buf => lookWs.send(buf)), 'image/jpeg', 0.8);
 }
 
-document.getElementById('start').addEventListener('click', start);
+// Attach the start handler only once so we don't open duplicate WebSocket
+// connections if the user clicks multiple times.
+document
+  .getElementById('start')
+  .addEventListener('click', start, { once: true });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure start handler is only fired once to prevent duplicate websocket connections

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860ef27f18883208345b47e2167e0fe