### PR TITLE
Consistent WebSocket naming

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -48,7 +48,7 @@ function play() {
 }
 
 function start() {
-  ws = openSocket(ws, `ws://${location.host}/ws/audio/out`, 'arraybuffer');
+  ws = openSocket(ws, `ws://${location.host}/speech-audio-out`, 'arraybuffer');
   if (ws.readyState <= WebSocket.OPEN) {
     ws.onmessage = ev => {
       queue.push(new Int16Array(ev.data));
@@ -56,11 +56,11 @@ function start() {
       play();
     };
   }
-  textWs = openSocket(textWs, `ws://${location.host}/ws/audio/text/out`);
+  textWs = openSocket(textWs, `ws://${location.host}/speech-text-out`);
   if (textWs.readyState <= WebSocket.OPEN)
     textWs.onmessage = ev => texts.push(ev.data);
-  heardWs = openSocket(heardWs, `ws://${location.host}/ws/audio/self/in`);
-  lookWs = openSocket(lookWs, `ws://${location.host}/ws/look/in`, 'arraybuffer');
+  heardWs = openSocket(heardWs, `ws://${location.host}/speech-text-self-in`);
+  lookWs = openSocket(lookWs, `ws://${location.host}/look-jpeg-in`, 'arraybuffer');
   if (lookWs.readyState <= WebSocket.OPEN)
     lookWs.onmessage = ev => {
       if (ev.data === 'snap') capture();

--- a/daringsby/src/look_motor.rs
+++ b/daringsby/src/look_motor.rs
@@ -5,7 +5,7 @@ use chrono::Local;
 use futures::StreamExt;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::{trace,debug};
+use tracing::{debug, trace};
 
 use psyche_rs::{Action, ActionResult, LLMClient, Motor, MotorError, Sensation};
 

--- a/daringsby/src/look_stream.rs
+++ b/daringsby/src/look_stream.rs
@@ -38,7 +38,7 @@ impl LookStream {
     /// Build a router exposing the look WebSocket endpoint.
     pub fn router(self: Arc<Self>) -> Router {
         Router::new().route(
-            "/ws/look/in",
+            "/look-jpeg-in",
             get(move |ws: WebSocketUpgrade| {
                 let stream = self.clone();
                 async move { ws.on_upgrade(move |sock| stream.clone().session(sock)) }
@@ -84,7 +84,7 @@ mod tests {
     async fn forwards_images_and_commands() {
         let stream = Arc::new(LookStream::default());
         let addr = start_server(stream.clone()).await;
-        let url = format!("ws://{addr}/ws/look/in");
+        let url = format!("ws://{addr}/look-jpeg-in");
         let (mut ws, _) = connect_async(url).await.unwrap();
         let mut rx = stream.subscribe();
         ws.send(WsMessage::Binary(vec![1, 2, 3])).await.unwrap();

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -14,13 +14,12 @@ use psyche_rs::{
     Sensation, SensationSensor, Sensor, Wit,
 };
 
-#[cfg(feature = "source-discovery-sensor")]
-use daringsby::SourceDiscovery;
 #[cfg(feature = "development-status-sensor")]
 use daringsby::DevelopmentStatus;
+#[cfg(feature = "source-discovery-sensor")]
+use daringsby::SourceDiscovery;
 use daringsby::{
-    HeardSelfSensor, Heartbeat, LoggingMotor, LookMotor, LookStream, Mouth,
-    SpeechStream,
+    HeardSelfSensor, Heartbeat, LoggingMotor, LookMotor, LookStream, Mouth, SpeechStream,
 };
 use std::net::SocketAddr;
 
@@ -107,7 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(SensationSensor::new(look_rx)) as Box<dyn Sensor<String> + Send>,
     ];
     #[cfg(feature = "development-status-sensor")]
-    sensors.push(Box::new(DevelopmentStatus) as Box<dyn Sensor<String> + Send>);    
+    sensors.push(Box::new(DevelopmentStatus) as Box<dyn Sensor<String> + Send>);
     #[cfg(feature = "self-discovery-sensor")]
     sensors.push(Box::new(SelfDiscovery) as Box<dyn Sensor<String> + Send>);
     #[cfg(feature = "source-discovery-sensor")]


### PR DESCRIPTION
## Summary
- rename WebSocket endpoints
- update index page paths
- adjust tests for new URLs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860f3e60ce88320afd4da74b2dd9aa9