### PR TITLE
Rename look-jpeg-in endpoint

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -60,7 +60,7 @@ function start() {
   if (textWs.readyState <= WebSocket.OPEN)
     textWs.onmessage = ev => texts.push(ev.data);
   heardWs = openSocket(heardWs, `ws://${location.host}/speech-text-self-in`);
-  lookWs = openSocket(lookWs, `ws://${location.host}/look-jpeg-in`, 'arraybuffer');
+  lookWs = openSocket(lookWs, `ws://${location.host}/vision-jpeg-in`, 'arraybuffer');
   if (lookWs.readyState <= WebSocket.OPEN)
     lookWs.onmessage = ev => {
       if (ev.data === 'snap') capture();

--- a/daringsby/src/look_stream.rs
+++ b/daringsby/src/look_stream.rs
@@ -38,7 +38,7 @@ impl LookStream {
     /// Build a router exposing the look WebSocket endpoint.
     pub fn router(self: Arc<Self>) -> Router {
         Router::new().route(
-            "/look-jpeg-in",
+            "/vision-jpeg-in",
             get(move |ws: WebSocketUpgrade| {
                 let stream = self.clone();
                 async move { ws.on_upgrade(move |sock| stream.clone().session(sock)) }
@@ -84,7 +84,7 @@ mod tests {
     async fn forwards_images_and_commands() {
         let stream = Arc::new(LookStream::default());
         let addr = start_server(stream.clone()).await;
-        let url = format!("ws://{addr}/look-jpeg-in");
+        let url = format!("ws://{addr}/vision-jpeg-in");
         let (mut ws, _) = connect_async(url).await.unwrap();
         let mut rx = stream.subscribe();
         ws.send(WsMessage::Binary(vec![1, 2, 3])).await.unwrap();


### PR DESCRIPTION
## Summary
- rename `/look-jpeg-in` websocket endpoint to `/vision-jpeg-in`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860f6cb597883209241534b280a7a25