### PR TITLE
Auto add motors to will prompts

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -16,6 +16,8 @@ use psyche_rs::{
 
 #[cfg(feature = "development-status-sensor")]
 use daringsby::DevelopmentStatus;
+#[cfg(feature = "self-discovery-sensor")]
+use daringsby::SelfDiscovery;
 #[cfg(feature = "source-discovery-sensor")]
 use daringsby::SourceDiscovery;
 use daringsby::{

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -112,6 +112,9 @@ where
         }
         let mut will_streams = Vec::new();
         for will in self.wills.iter_mut() {
+            for m in self.motors.iter() {
+                will.register_motor(m.as_ref());
+            }
             let sensors_for_will: Vec<_> = self
                 .sensors
                 .iter()


### PR DESCRIPTION
## Summary
- automatically register motors with `Will` to enrich prompts
- fix missing `SelfDiscovery` import in `daringsby`
- test motor descriptions in `Will` prompt

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860f9062ea883209a1c4954b5a9d9ae