### PR TITLE
Improve doctests

### DIFF
--- a/psyche-rs/src/impression_sensor.rs
+++ b/psyche-rs/src/impression_sensor.rs
@@ -6,6 +6,17 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use crate::{Impression, Sensation, Sensor};
 
 /// Sensor that converts impression batches into sensations.
+///
+/// ```no_run
+/// use psyche_rs::{ImpressionSensor, Impression, Sensation};
+/// use tokio::sync::mpsc::unbounded_channel;
+///
+/// let (tx, rx) = unbounded_channel();
+/// let mut sensor = ImpressionSensor::new(rx);
+/// tx.send(vec![Impression { how: "hi".into(), what: Vec::<Sensation<String>>::new() }]).unwrap();
+/// drop(tx);
+/// // async context: sensor.stream().next().await
+/// ```
 pub struct ImpressionSensor<T> {
     rx: Option<UnboundedReceiver<Vec<Impression<T>>>>,
 }

--- a/psyche-rs/src/motor.rs
+++ b/psyche-rs/src/motor.rs
@@ -23,6 +23,15 @@ impl std::fmt::Debug for Action {
 
 impl Action {
     /// Helper to create an [`Action`] from parts.
+    ///
+    /// ```
+    /// use futures::stream::{self, StreamExt};
+    /// use psyche_rs::Action;
+    ///
+    /// let body = stream::empty().boxed();
+    /// let action = Action::new("log", serde_json::Value::Null, body);
+    /// assert_eq!(action.intention.urge.name, "log");
+    /// ```
     pub fn new(name: impl Into<String>, args: Value, body: BoxStream<'static, String>) -> Self {
         Self {
             intention: Intention::to(name, args),

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -38,6 +38,34 @@ impl<T> Sensor<T> for SharedSensor<T> {
 }
 
 /// Core orchestrator coordinating sensors, wits and motors.
+///
+/// ```no_run
+/// use psyche_rs::{Psyche, Wit, Sensor, LLMClient, TokenStream, Sensation};
+/// use async_trait::async_trait;
+/// use futures::{stream, StreamExt};
+/// use std::sync::Arc;
+///
+/// #[derive(Clone)]
+/// struct DummyLLM;
+/// #[async_trait]
+/// impl LLMClient for DummyLLM {
+///     async fn chat_stream(
+///         &self,
+///         _msgs: &[ollama_rs::generation::chat::ChatMessage],
+///     ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///         Ok(Box::pin(stream::empty()))
+///     }
+/// }
+/// struct DummySensor;
+/// impl Sensor<String> for DummySensor {
+///     fn stream(&mut self) -> futures::stream::BoxStream<'static, Vec<Sensation<String>>> {
+///         stream::empty().boxed()
+///     }
+/// }
+/// let llm = Arc::new(DummyLLM);
+/// let wit = Wit::new(llm);
+/// let _psyche = Psyche::new().sensor(DummySensor).wit(wit);
+/// ```
 pub struct Psyche<T = serde_json::Value> {
     sensors: Vec<Arc<Mutex<dyn Sensor<T> + Send>>>,
     motors: Vec<Box<dyn Motor + Send>>,


### PR DESCRIPTION
## Summary
- add doctest example for `ImpressionSensor`
- add doctest example for `Action::new`
- add doctest example for `Psyche`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860fcaff3f483208f6af974bfee589e