### PR TITLE
Improve speech feedback loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "rand",
  "reqwest",
  "segtok",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-stream",

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = "0.1"
 ollama-rs = { version = "0.3.2", features = ["stream"] }
 once_cell = "1"
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 include_dir = "0.7"
 reqwest = { version = "0.12", features = ["stream"] }
 segtok = "0.1.5"

--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -5,8 +5,7 @@
 <script>
 const SAMPLE_RATE = 22050;
 const ctx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: SAMPLE_RATE });
-let ws;
-let textWs;
+let segWs;
 let heardWs;
 let lookWs;
 let lookVideo;
@@ -67,17 +66,18 @@ function play() {
 }
 
 function start() {
-  ws = openSocket(ws, `ws://${location.host}/speech-audio-out`, 'arraybuffer');
-  if (ws.readyState <= WebSocket.OPEN) {
-    ws.onmessage = ev => {
-      queue.push(new Int16Array(ev.data));
+  segWs = openSocket(segWs, `ws://${location.host}/speech-segments-out`);
+  if (segWs.readyState <= WebSocket.OPEN)
+    segWs.onmessage = ev => {
+      const seg = JSON.parse(ev.data);
+      const bin = atob(seg.audio_b64);
+      const buf = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+      queue.push(new Int16Array(buf.buffer));
+      texts.push(seg.text);
       if (ctx.state === 'suspended') ctx.resume();
       play();
     };
-  }
-  textWs = openSocket(textWs, `ws://${location.host}/speech-text-out`);
-  if (textWs.readyState <= WebSocket.OPEN)
-    textWs.onmessage = ev => texts.push(ev.data);
   heardWs = openSocket(heardWs, `ws://${location.host}/speech-text-self-in`);
   heardWs.onopen = () => console.log("heardWs connected");
   heardWs.onerror = e => console.error("heardWs error", e);

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -21,6 +21,7 @@ pub mod source_read_motor;
 pub mod source_search_motor;
 #[cfg(feature = "source-tree-motor")]
 pub mod source_tree_motor;
+pub mod speech_segment;
 pub mod speech_stream;
 
 pub mod motors;

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -79,7 +79,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mouth = Arc::new(Mouth::new(args.tts_url.clone(), args.language_id));
     let audio_rx = mouth.subscribe();
     let text_rx = mouth.subscribe_text();
-    let stream = Arc::new(SpeechStream::new(audio_rx, text_rx));
+    let segment_rx = mouth.subscribe_segments();
+    let stream = Arc::new(SpeechStream::new(audio_rx, text_rx, segment_rx));
     let vision = Arc::new(LookStream::default());
     let app = stream.clone().router().merge(vision.clone().router());
     let addr: SocketAddr = format!("{}:{}", args.host, args.port).parse()?;

--- a/daringsby/src/speech_segment.rs
+++ b/daringsby/src/speech_segment.rs
@@ -1,0 +1,33 @@
+use base64::{Engine, engine::general_purpose::STANDARD};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+/// Combined speech segment containing the spoken text and its PCM audio.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpeechSegment {
+    /// The sentence that was synthesized.
+    pub text: String,
+    /// Base64 encoded PCM bytes.
+    pub audio_b64: String,
+}
+
+impl SpeechSegment {
+    /// Create a segment from raw PCM bytes.
+    pub fn new(text: impl Into<String>, audio: &[u8]) -> Self {
+        Self {
+            text: text.into(),
+            audio_b64: STANDARD.encode(audio),
+        }
+    }
+
+    /// Decode the stored audio into raw PCM bytes.
+    ///
+    /// ```
+    /// use daringsby::speech_segment::SpeechSegment;
+    /// let seg = SpeechSegment::new("hi", &[1u8, 2]);
+    /// assert_eq!(seg.decode_audio().unwrap(), bytes::Bytes::from_static(&[1, 2]));
+    /// ```
+    pub fn decode_audio(&self) -> Result<Bytes, base64::DecodeError> {
+        STANDARD.decode(&self.audio_b64).map(Bytes::from)
+    }
+}


### PR DESCRIPTION
## Summary
- bundle spoken text and audio bytes in a new `SpeechSegment`
- stream segments via `/speech-segments-out`
- send segments from `Mouth` and update frontend
- wire new segment channel through main
- adjust tests for new route

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68610056ab608320bc57ba538f4502ab