### PR TITLE
Introduce action body helpers

### DIFF
--- a/daringsby/src/logging_motor.rs
+++ b/daringsby/src/logging_motor.rs
@@ -1,4 +1,3 @@
-use futures::StreamExt;
 use tracing::{debug, info, warn};
 
 use chrono::Local;
@@ -19,10 +18,7 @@ impl Motor for LoggingMotor {
     }
     async fn perform(&self, intention: Intention) -> Result<ActionResult, MotorError> {
         let mut action = intention.action;
-        let mut text = String::new();
-        while let Some(chunk) = action.body.next().await {
-            text.push_str(&chunk);
-        }
+        let text = action.collect_text().await;
         if text.trim().is_empty() {
             warn!(name = %action.name, "LoggingMotor received empty body");
         }

--- a/daringsby/src/mouth.rs
+++ b/daringsby/src/mouth.rs
@@ -181,7 +181,8 @@ impl Motor for Mouth {
         {
             let _guard = queue.lock().await;
             let mut buf = String::new();
-            while let Some(chunk) = action.body.next().await {
+            let mut chunks = action.logged_chunks();
+            while let Some(chunk) = chunks.next().await {
                 buf.push_str(&chunk);
                 let mut sents = split_single(&buf, SegmentConfig::default());
                 if let Some(last) = sents.last() {

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -135,11 +135,7 @@ mod tests {
             }
             async fn perform(&self, intention: Intention) -> Result<ActionResult, MotorError> {
                 let mut action = intention.action;
-                use futures::StreamExt;
-                let mut collected = String::new();
-                while let Some(chunk) = action.body.next().await {
-                    collected.push_str(&chunk);
-                }
+                let collected = action.collect_text().await;
                 self.log.lock().unwrap().push(collected);
                 Ok(ActionResult {
                     sensations: Vec::new(),


### PR DESCRIPTION
## Summary
- add `collect_text` and `logged_chunks` helpers on `Action`
- use helpers in `LoggingMotor`, `Mouth`, and example motor
- adjust tests for new utilities

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861857d2a4c8320aeba423a6afb6b9c