### PR TITLE
Add cluster summarization support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,6 +1937,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2907,6 +2908,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1"
 regex = "1"
 anyhow = "1"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/psyche-rs/src/cluster_analyzer.rs
+++ b/psyche-rs/src/cluster_analyzer.rs
@@ -1,0 +1,161 @@
+use crate::{
+    LLMClient,
+    memory_store::{MemoryStore, StoredImpression},
+};
+use chrono::Utc;
+use futures::StreamExt;
+use ollama_rs::generation::chat::ChatMessage;
+use std::sync::Arc;
+
+/// Analyzes clusters of impressions and stores one-sentence summaries.
+///
+/// # Example
+/// ```
+/// use psyche_rs::{ClusterAnalyzer, InMemoryStore, StoredImpression, MemoryStore};
+/// use chrono::Utc;
+/// use std::sync::Arc;
+/// struct EchoLLM;
+/// #[async_trait::async_trait]
+/// impl psyche_rs::LLMClient for EchoLLM {
+///     async fn chat_stream(
+///         &self,
+///         _m: &[ollama_rs::generation::chat::ChatMessage],
+///     ) -> Result<psyche_rs::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///         let stream = futures::stream::once(async { Ok("echo".to_string()) });
+///         Ok(Box::pin(stream))
+///     }
+/// }
+/// let store = InMemoryStore::new();
+/// let llm = Arc::new(EchoLLM);
+/// let analyzer = ClusterAnalyzer::new(store, llm);
+/// let imp = StoredImpression {
+///     id: "i1".into(),
+///     kind: "Instant".into(),
+///     when: Utc::now(),
+///     how: "hi".into(),
+///     sensation_ids: Vec::new(),
+///     impression_ids: Vec::new(),
+/// };
+/// analyzer.store.store_impression(&imp).unwrap();
+/// futures::executor::block_on(async {
+///     analyzer.summarize(vec![vec!["i1".to_string()]]).await.unwrap();
+/// });
+/// ```
+pub struct ClusterAnalyzer<M: MemoryStore, C: LLMClient> {
+    pub store: M,
+    llm: Arc<C>,
+}
+
+impl<M: MemoryStore, C: LLMClient> ClusterAnalyzer<M, C> {
+    /// Create a new analyzer.
+    pub fn new(store: M, llm: Arc<C>) -> Self {
+        Self { store, llm }
+    }
+
+    /// Summarize each cluster of impression IDs.
+    pub async fn summarize(
+        &self,
+        clusters: Vec<Vec<String>>,
+    ) -> anyhow::Result<Vec<StoredImpression>> {
+        let mut summaries = Vec::new();
+        for cluster in clusters {
+            if cluster.is_empty() {
+                continue;
+            }
+            let mut sentences = Vec::new();
+            for id in &cluster {
+                let (imp, _, _) = self.store.load_full_impression(id)?;
+                sentences.push(imp.how);
+            }
+            let prompt = format!(
+                "Summarize the following related memories into one natural sentence that best describes their common theme:\n{}",
+                sentences.join("\n")
+            );
+            tracing::trace!(?prompt, "summary_prompt");
+            let messages = [ChatMessage::user(prompt)];
+            let mut stream = self
+                .llm
+                .chat_stream(&messages)
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let mut out = String::new();
+            while let Some(tok) = stream.next().await {
+                let tok = tok.map_err(|e| anyhow::anyhow!(e))?;
+                tracing::trace!(%tok, "summary_token");
+                out.push_str(&tok);
+            }
+            let summary = StoredImpression {
+                id: uuid::Uuid::new_v4().to_string(),
+                kind: "Summary".into(),
+                when: Utc::now(),
+                how: out.trim().to_string(),
+                sensation_ids: Vec::new(),
+                impression_ids: cluster.clone(),
+            };
+            self.store.store_summary_impression(&summary, &cluster)?;
+            summaries.push(summary);
+        }
+        Ok(summaries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_store::InMemoryStore;
+    use async_trait::async_trait;
+    use futures::stream;
+
+    #[derive(Clone)]
+    struct StaticLLM {
+        reply: String,
+    }
+
+    #[async_trait]
+    impl LLMClient for StaticLLM {
+        async fn chat_stream(
+            &self,
+            _m: &[ChatMessage],
+        ) -> Result<crate::TokenStream, Box<dyn std::error::Error + Send + Sync + 'static>>
+        {
+            let reply = self.reply.clone();
+            Ok(Box::pin(stream::once(async move { Ok(reply) })))
+        }
+    }
+
+    #[tokio::test]
+    async fn stores_summary_impression() {
+        let store = InMemoryStore::new();
+        let imp1 = StoredImpression {
+            id: "i1".into(),
+            kind: "Instant".into(),
+            when: Utc::now(),
+            how: "hello".into(),
+            sensation_ids: Vec::new(),
+            impression_ids: Vec::new(),
+        };
+        let imp2 = StoredImpression {
+            id: "i2".into(),
+            kind: "Instant".into(),
+            when: Utc::now(),
+            how: "world".into(),
+            sensation_ids: Vec::new(),
+            impression_ids: Vec::new(),
+        };
+        store.store_impression(&imp1).unwrap();
+        store.store_impression(&imp2).unwrap();
+
+        let llm = Arc::new(StaticLLM {
+            reply: "summary".into(),
+        });
+        let analyzer = ClusterAnalyzer::new(store, llm);
+        let sums = analyzer
+            .summarize(vec![vec!["i1".into(), "i2".into()]])
+            .await
+            .unwrap();
+        assert_eq!(sums.len(), 1);
+        let sum = &sums[0];
+        assert_eq!(sum.kind, "Summary");
+        assert_eq!(sum.impression_ids, vec!["i1", "i2"]);
+    }
+}

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate currently exposes [`Sensation`], [`Impression`], [`Sensor`] and
 //! [`Wit`] building blocks for constructing artificial agents.
 
+mod cluster_analyzer;
 mod combobulator;
 mod fair_llm;
 mod impression;
@@ -21,6 +22,7 @@ mod will;
 mod wit;
 
 pub use crate::llm_client::{LLMClient, OllamaLLM, TokenStream};
+pub use cluster_analyzer::ClusterAnalyzer;
 pub use combobulator::Combobulator;
 pub use fair_llm::FairLLM;
 pub use impression::Impression;

--- a/psyche-rs/src/memory_sensor.rs
+++ b/psyche-rs/src/memory_sensor.rs
@@ -63,6 +63,7 @@ mod tests {
             when: Utc::now(),
             how: "example".into(),
             sensation_ids: vec!["s1".into()],
+            impression_ids: Vec::new(),
         };
         store.store_impression(&impression).unwrap();
 

--- a/psyche-rs/src/memory_store.rs
+++ b/psyche-rs/src/memory_store.rs
@@ -19,6 +19,9 @@ pub struct StoredImpression {
     pub when: DateTime<Utc>,
     pub how: String,
     pub sensation_ids: Vec<String>,
+    /// IDs of impressions summarized by this one. Empty for regular impressions.
+    #[serde(rename = "summary_of", default)]
+    pub impression_ids: Vec<String>,
 }
 
 /// Trait for interacting with Pete's memory storage.
@@ -30,6 +33,16 @@ pub trait MemoryStore {
     /// Insert a new impression. Implementations are responsible for
     /// persisting the impression and storing its embedding in Qdrant.
     fn store_impression(&self, impression: &StoredImpression) -> anyhow::Result<()>;
+
+    /// Insert a summary impression linked to other impressions.
+    fn store_summary_impression(
+        &self,
+        summary: &StoredImpression,
+        linked_ids: &[String],
+    ) -> anyhow::Result<()> {
+        let _ = linked_ids;
+        self.store_impression(summary)
+    }
 
     /// Link an impression to a lifecycle stage. `detail` may contain a brief
     /// description of the stage.
@@ -165,6 +178,7 @@ mod tests {
             when: Utc::now(),
             how: "example".into(),
             sensation_ids: sens.iter().map(|s| s.id.clone()).collect(),
+            impression_ids: Vec::new(),
         }
     }
 
@@ -207,6 +221,7 @@ mod integration_tests {
             when: Utc::now(),
             how: "Saw a familiar face.".into(),
             sensation_ids,
+            impression_ids: Vec::new(),
         }
     }
 

--- a/psyche-rs/src/neo_qdrant_store.rs
+++ b/psyche-rs/src/neo_qdrant_store.rs
@@ -68,7 +68,7 @@ impl MemoryStore for NeoQdrantMemoryStore {
     fn store_impression(&self, impression: &StoredImpression) -> anyhow::Result<()> {
         let query = r#"
 MERGE (i:Impression {uuid:$id})
-SET i.kind=$kind, i.when=datetime($when), i.how=$how
+SET i.kind=$kind, i.when=datetime($when), i.how=$how, i.summary_of=$imps
 WITH i
 UNWIND $sids AS sid
 MATCH (s:Sensation {uuid:sid})
@@ -80,6 +80,7 @@ MERGE (i)-[:HAS_SENSATION]->(s)
             "when": impression.when.to_rfc3339(),
             "how": impression.how,
             "sids": impression.sensation_ids,
+            "imps": impression.impression_ids,
         });
         self.post_neo(query, params)?;
 
@@ -289,6 +290,7 @@ mod tests {
             when: Utc::now(),
             how: "hi".into(),
             sensation_ids: vec!["s1".into()],
+            impression_ids: Vec::new(),
         };
         store.store_impression(&imp).unwrap();
 


### PR DESCRIPTION
## Summary
- add `ClusterAnalyzer` for summarizing impression clusters
- support summary links in `StoredImpression`
- extend `MemoryStore` with `store_summary_impression`
- record summaries in Neo4j
- tests for new analyzer

## Testing
- `cargo test --doc --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686194d4be2083209121ab0e10340cd7