### PR TITLE
Refactor LLM client

### DIFF
--- a/daringsby/tests/look_motor.rs
+++ b/daringsby/tests/look_motor.rs
@@ -10,7 +10,7 @@ impl LLMClient for DummyLLM {
     async fn chat_stream(
         &self,
         _messages: &[ollama_rs::generation::chat::ChatMessage],
-    ) -> Result<psyche_rs::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let stream = async_stream::stream! {
             yield Ok(String::new());
         };

--- a/psyche-rs/src/cluster_analyzer.rs
+++ b/psyche-rs/src/cluster_analyzer.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 ///     async fn chat_stream(
 ///         &self,
 ///         _m: &[ollama_rs::generation::chat::ChatMessage],
-///     ) -> Result<psyche_rs::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///     ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
 ///         let stream = futures::stream::once(async { Ok("echo".to_string()) });
 ///         Ok(Box::pin(stream))
 ///     }
@@ -116,7 +116,7 @@ mod tests {
         async fn chat_stream(
             &self,
             _m: &[ChatMessage],
-        ) -> Result<crate::TokenStream, Box<dyn std::error::Error + Send + Sync + 'static>>
+        ) -> Result<crate::LLMTokenStream, Box<dyn std::error::Error + Send + Sync + 'static>>
         {
             let reply = self.reply.clone();
             Ok(Box::pin(stream::once(async move { Ok(reply) })))

--- a/psyche-rs/src/fair_llm.rs
+++ b/psyche-rs/src/fair_llm.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::Semaphore;
 
-use crate::llm_client::{LLMClient, TokenStream};
+use crate::llm_client::{LLMClient, LLMTokenStream};
 use crate::stream_util::ReleasingStream;
 use ollama_rs::generation::chat::ChatMessage;
 
@@ -34,7 +34,7 @@ where
     async fn chat_stream(
         &self,
         messages: &[ChatMessage],
-    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
         tracing::trace!("waiting for llm permit");
         let permit = self
             .semaphore

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -13,6 +13,7 @@ mod memory_sensor;
 mod memory_store;
 mod motor;
 mod neo_qdrant_store;
+mod ollama_llm;
 mod psyche;
 mod round_robin_llm;
 mod sensation;
@@ -24,7 +25,8 @@ pub mod test_helpers;
 mod will;
 mod wit;
 
-pub use crate::llm_client::{LLMClient, OllamaLLM, TokenStream};
+pub use crate::llm_client::{LLMClient, LLMTokenStream};
+pub use crate::ollama_llm::OllamaLLM;
 pub use cluster_analyzer::ClusterAnalyzer;
 pub use combobulator::Combobulator;
 pub use fair_llm::FairLLM;
@@ -80,7 +82,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 Ok(Box::pin(stream::once(async {
                     Ok("ping event".to_string())
                 })))
@@ -123,7 +125,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 Ok(Box::pin(stream::once(async {
                     Ok("ping event".to_string())
                 })))

--- a/psyche-rs/src/llm_client.rs
+++ b/psyche-rs/src/llm_client.rs
@@ -2,68 +2,18 @@ use async_trait::async_trait;
 use futures::Stream;
 use std::pin::Pin;
 
-use async_stream::stream;
-use ollama_rs::{
-    Ollama, generation::chat::ChatMessage, generation::chat::request::ChatMessageRequest,
-};
-use tokio_stream::StreamExt;
+use ollama_rs::generation::chat::ChatMessage;
 
-/// Stream of LLM tokens.
-pub type TokenStream =
+/// Stream of LLM-generated text fragments.
+pub type LLMTokenStream =
     Pin<Box<dyn Stream<Item = Result<String, Box<dyn std::error::Error + Send + Sync>>> + Send>>;
 
 /// Common interface for chat-based LLMs.
 #[async_trait]
 pub trait LLMClient: Send + Sync {
-    /// Streams tokens in response to chat messages.
+    /// Streams text fragments in response to chat messages.
     async fn chat_stream(
         &self,
         messages: &[ChatMessage],
-    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>>;
-}
-
-/// [`LLMClient`] implementation backed by [`Ollama`].
-#[derive(Clone)]
-pub struct OllamaLLM {
-    client: Ollama,
-    model: String,
-}
-
-#[cfg(test)]
-mod tests;
-
-impl OllamaLLM {
-    /// Creates a new Ollama-backed client.
-    pub fn new(client: Ollama, model: impl Into<String>) -> Self {
-        Self {
-            client,
-            model: model.into(),
-        }
-    }
-}
-
-#[async_trait]
-impl LLMClient for OllamaLLM {
-    async fn chat_stream(
-        &self,
-        messages: &[ChatMessage],
-    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
-        let req = ChatMessageRequest::new(self.model.clone(), messages.to_vec());
-        let mut stream = self.client.send_chat_messages_stream(req).await?;
-        let mapped = stream! {
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(resp) => {
-                        let tok = resp.message.content;
-                        tracing::trace!(%tok, "llm token");
-                        yield Ok(tok);
-                    }
-                    Err(_) => {
-                        yield Err(Box::<dyn std::error::Error + Send + Sync>::from("stream error"));
-                    }
-                }
-            }
-        };
-        Ok(Box::pin(mapped))
-    }
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/psyche-rs/src/llm_client/tests.rs
+++ b/psyche-rs/src/llm_client/tests.rs
@@ -1,4 +1,4 @@
-use crate::{FairLLM, LLMClient, RoundRobinLLM, TokenStream};
+use crate::{FairLLM, LLMClient, RoundRobinLLM, LLMTokenStream};
 use async_trait::async_trait;
 use futures::{StreamExt, stream};
 use ollama_rs::generation::chat::ChatMessage;
@@ -15,7 +15,7 @@ impl LLMClient for RecordLLM {
     async fn chat_stream(
         &self,
         _msgs: &[ChatMessage],
-    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
         self.log.lock().unwrap().push(self.id);
         Ok(Box::pin(stream::empty()))
     }
@@ -29,7 +29,7 @@ impl LLMClient for FailingLLM {
     async fn chat_stream(
         &self,
         _msgs: &[ChatMessage],
-    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
         Err(Box::new(std::io::Error::new(
             std::io::ErrorKind::Other,
             "fail",
@@ -47,7 +47,7 @@ impl LLMClient for DelayLLM {
     async fn chat_stream(
         &self,
         _msgs: &[ChatMessage],
-    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let d = self.delay;
         let s = stream::once(async move {
             tokio::time::sleep(std::time::Duration::from_millis(d)).await;

--- a/psyche-rs/src/ollama_llm.rs
+++ b/psyche-rs/src/ollama_llm.rs
@@ -1,0 +1,91 @@
+use crate::llm_client::{LLMClient, LLMTokenStream};
+use async_trait::async_trait;
+use futures::TryStreamExt;
+use ollama_rs::{
+    Ollama,
+    generation::chat::{ChatMessage, ChatMessageResponseStream, request::ChatMessageRequest},
+};
+
+/// Build a chat request for the given model and messages.
+fn build_request(model: &str, messages: &[ChatMessage]) -> ChatMessageRequest {
+    ChatMessageRequest::new(model.to_string(), messages.to_vec())
+}
+
+/// Map an Ollama response stream into an [`LLMTokenStream`].
+fn map_stream(stream: ChatMessageResponseStream) -> LLMTokenStream {
+    let mapped = stream
+        .map_err(|_| Box::<dyn std::error::Error + Send + Sync>::from("ollama stream error"))
+        .map_ok(|resp| {
+            let tok = resp.message.content;
+            tracing::trace!(%tok, "llm token");
+            tok
+        });
+    Box::pin(mapped)
+}
+
+/// [`LLMClient`] implementation backed by [`Ollama`].
+#[derive(Clone)]
+pub struct OllamaLLM {
+    client: Ollama,
+    model: String,
+}
+
+impl OllamaLLM {
+    /// Creates a new Ollama-backed client.
+    pub fn new(client: Ollama, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+        }
+    }
+
+    /// Returns the configured model name.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+}
+
+#[async_trait]
+impl LLMClient for OllamaLLM {
+    /// Streams text fragments produced by the model in response to `messages`.
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        let req = build_request(&self.model, messages);
+        let stream = self.client.send_chat_messages_stream(req).await?;
+        Ok(map_stream(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use httpmock::prelude::*;
+
+    #[tokio::test]
+    async fn yields_all_tokens() {
+        let server = MockServer::start_async().await;
+        let body = concat!(
+            "{\"model\":\"m\",\"created_at\":\"n\",\"message\":{\"role\":\"assistant\",\"content\":\"he\"},\"done\":false}\n",
+            "{\"model\":\"m\",\"created_at\":\"n\",\"message\":{\"role\":\"assistant\",\"content\":\"llo\"},\"done\":true}"
+        );
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/api/chat");
+                then.status(200).body(body);
+            })
+            .await;
+
+        let client = Ollama::try_new(server.base_url()).unwrap();
+        let llm = OllamaLLM::new(client, "m");
+        let msgs = [ChatMessage::user("hi".into())];
+        let mut stream = llm.chat_stream(&msgs).await.unwrap();
+        let mut collected = String::new();
+        while let Some(tok) = stream.next().await {
+            collected.push_str(&tok.unwrap());
+        }
+        assert_eq!(collected, "hello");
+    }
+}

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -39,7 +39,7 @@ impl<T> Sensor<T> for SharedSensor<T> {
 /// Core orchestrator coordinating sensors, wits and motors.
 ///
 /// ```no_run
-/// use psyche_rs::{Psyche, Wit, Sensor, LLMClient, TokenStream, Sensation};
+/// use psyche_rs::{Psyche, Wit, Sensor, LLMClient, LLMTokenStream, Sensation};
 /// use async_trait::async_trait;
 /// use futures::{stream, StreamExt};
 /// use std::sync::Arc;
@@ -51,7 +51,7 @@ impl<T> Sensor<T> for SharedSensor<T> {
 ///     async fn chat_stream(
 ///         &self,
 ///         _msgs: &[ollama_rs::generation::chat::ChatMessage],
-///     ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///     ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
 ///         Ok(Box::pin(stream::empty()))
 ///     }
 /// }
@@ -185,7 +185,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Intention, LLMClient, TokenStream};
+    use crate::{Intention, LLMClient, LLMTokenStream};
     use futures::{StreamExt, stream};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -232,7 +232,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
                 let tokens = vec!["<log>".to_string(), "hi".to_string(), "</log>".to_string()];
                 Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
@@ -260,7 +260,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
                 let tokens = vec!["<log>".to_string(), "hi".to_string(), "</log>".to_string()];
                 Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
@@ -292,7 +292,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
                 let tokens = vec![
                     "<say>".to_string(),
@@ -367,7 +367,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
                 let toks = vec!["<a>".to_string(), "hi".to_string(), "</a>".to_string()];
                 Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
@@ -382,7 +382,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
                 let toks = vec!["<b>".to_string(), "bye".to_string(), "</b>".to_string()];
                 Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))

--- a/psyche-rs/src/round_robin_llm.rs
+++ b/psyche-rs/src/round_robin_llm.rs
@@ -5,7 +5,7 @@ use std::sync::{
 
 use async_trait::async_trait;
 
-use crate::llm_client::{LLMClient, TokenStream};
+use crate::llm_client::{LLMClient, LLMTokenStream};
 use ollama_rs::generation::chat::ChatMessage;
 
 /// Round-robin pool of [`LLMClient`] implementations.
@@ -25,7 +25,7 @@ use ollama_rs::generation::chat::ChatMessage;
 /// # struct Dummy;
 /// # #[async_trait]
 /// # impl LLMClient for Dummy {
-/// #   async fn chat_stream(&self, _: &[ChatMessage]) -> Result<psyche_rs::TokenStream, Box<dyn Error + Send + Sync>> {
+/// #   async fn chat_stream(&self, _: &[ChatMessage]) -> Result<psyche_rs::LLMTokenStream, Box<dyn Error + Send + Sync>> {
 /// #       Ok(Box::pin(stream::empty()))
 /// #   }
 /// # }
@@ -60,7 +60,7 @@ impl LLMClient for RoundRobinLLM {
     async fn chat_stream(
         &self,
         messages: &[ChatMessage],
-    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let len = self.clients.len();
         for _ in 0..len {
             let client = self.pick();

--- a/psyche-rs/src/test_helpers.rs
+++ b/psyche-rs/src/test_helpers.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{Impression, LLMClient, Sensation, Sensor, TokenStream};
+use crate::{Impression, LLMClient, LLMTokenStream, Sensation, Sensor};
 use async_trait::async_trait;
 use futures::stream::{self, BoxStream};
 
@@ -23,7 +23,7 @@ impl LLMClient for StaticLLM {
     async fn chat_stream(
         &self,
         _msgs: &[ollama_rs::generation::chat::ChatMessage],
-    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let words: Vec<String> = self
             .reply
             .split_whitespace()

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -257,7 +257,7 @@ impl<T> Will<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::llm_client::{LLMClient, TokenStream};
+    use crate::llm_client::{LLMClient, LLMTokenStream};
     use crate::{ActionResult, MotorError};
     use async_trait::async_trait;
     use futures::{StreamExt, stream};
@@ -270,7 +270,7 @@ mod tests {
         async fn chat_stream(
             &self,
             _msgs: &[ChatMessage],
-        ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
             let tokens = vec![
                 "<say mood=\"calm\">".to_string(),
                 "Hello ".to_string(),
@@ -322,7 +322,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 msgs: &[ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.prompts.lock().unwrap().push(msgs[0].content.clone());
                 Ok(Box::pin(stream::once(async { Ok("<say></say>".into()) })))
             }
@@ -370,7 +370,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 msgs: &[ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.prompts.lock().unwrap().push(msgs[0].content.clone());
                 Ok(Box::pin(stream::once(async {
                     Ok("<dummy></dummy>".into())

--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -211,7 +211,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::llm_client::{LLMClient, TokenStream};
+    use crate::llm_client::{LLMClient, LLMTokenStream};
     use async_trait::async_trait;
     use futures::{StreamExt, stream};
 
@@ -225,7 +225,7 @@ mod tests {
         async fn chat_stream(
             &self,
             _msgs: &[ChatMessage],
-        ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
             let words: Vec<String> = self
                 .reply
                 .split_whitespace()
@@ -275,7 +275,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(Box::pin(stream::once(async { Ok("done".to_string()) })))
             }
@@ -343,7 +343,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 msgs: &[ChatMessage],
-            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.prompts.lock().unwrap().push(msgs[0].content.clone());
                 Ok(Box::pin(stream::once(async { Ok("frame".to_string()) })))
             }


### PR DESCRIPTION
## Summary
- rename `TokenStream` to `LLMTokenStream`
- extract Ollama-specific client to `ollama_llm.rs`
- document and refactor streaming logic
- adjust uses across library and tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68619a6bc68883209f23641bbea953f9