### PR TITLE
Use RUST_LOG for tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,8 +811,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
  "bit-set 0.8.0",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1502,7 +1502,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1516,7 +1516,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -1576,6 +1576,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2033,8 +2042,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2045,8 +2063,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2805,10 +2829,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1", features = ["macros", "rt"] }
 clap = { version = "4", features = ["derive"] }
 rand = "0.8"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = "0.4"
 futures = "0.3"
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -24,6 +24,7 @@ pub mod source_tree_motor;
 pub mod speech_segment;
 pub mod speech_stream;
 
+pub mod logger;
 pub mod motors;
 pub mod sensors;
 pub mod streams;

--- a/daringsby/src/logger.rs
+++ b/daringsby/src/logger.rs
@@ -1,0 +1,25 @@
+use tracing_subscriber::{EnvFilter, fmt};
+
+/// Initializes tracing using the `RUST_LOG` environment variable.
+///
+/// If `RUST_LOG` is not set or fails to parse, logging defaults to the `debug`
+/// level. This function is intended for binaries; tests should prefer
+/// [`try_init`] to avoid panicking if the subscriber is already set.
+///
+/// # Examples
+///
+/// ```no_run
+/// use daringsby::logger;
+/// unsafe { std::env::set_var("RUST_LOG", "info") };
+/// logger::try_init().expect("logger initialized");
+/// ```
+pub fn init() {
+    try_init().expect("failed to initialize tracing")
+}
+
+/// Attempts to initialize tracing and returns an error if a subscriber is
+/// already set.
+pub fn try_init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
+    fmt().with_env_filter(filter).try_init().map_err(Into::into)
+}

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
+use daringsby::logger;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::Level;
 
 #[cfg(feature = "moment-feedback")]
 use chrono::Local;
@@ -60,9 +60,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_max_level(Level::DEBUG)
-        .init();
+    logger::init();
     let args = Args::parse();
     use tokio::sync::mpsc::unbounded_channel;
 


### PR DESCRIPTION
## Summary
- add logger module that initializes tracing via `RUST_LOG`
- expose `logger` from the `daringsby` crate
- switch main binary to use `logger::init`
- enable `env-filter` feature for tracing-subscriber

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861a07166c0832095253119dc6419d1