### PR TITLE
Add canvas motor and stream

### DIFF
--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -43,6 +43,7 @@ tokio-tungstenite = "0.21"
 [features]
 logging-motor = []
 look-motor = []
+canvas-motor = []
 mouth = []
 source-read-motor = []
 source-search-motor = []
@@ -56,6 +57,7 @@ moment-feedback = []
 default = [
     "logging-motor",
     "look-motor",
+    "canvas-motor",
     "mouth",
     "development-status-sensor",
     "self-discovery-sensor",

--- a/daringsby/src/canvas_motor.rs
+++ b/daringsby/src/canvas_motor.rs
@@ -1,0 +1,118 @@
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+use chrono::Local;
+use futures::StreamExt;
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::{debug, trace};
+
+use psyche_rs::{ActionResult, Completion, Intention, LLMClient, Motor, MotorError, Sensation};
+
+use crate::canvas_stream::CanvasStream;
+
+/// Motor that captures a canvas snapshot and describes it using an LLM.
+pub struct CanvasMotor {
+    stream: Arc<CanvasStream>,
+    llm: Arc<dyn LLMClient>,
+    tx: UnboundedSender<Vec<Sensation<String>>>,
+}
+
+impl CanvasMotor {
+    /// Create a new motor backed by the given stream and LLM.
+    pub fn new(
+        stream: Arc<CanvasStream>,
+        llm: Arc<dyn LLMClient>,
+        tx: UnboundedSender<Vec<Sensation<String>>>,
+    ) -> Self {
+        Self { stream, llm, tx }
+    }
+}
+
+#[async_trait]
+impl Motor for CanvasMotor {
+    fn description(&self) -> &'static str {
+        "Capture an image from the canvas and describe it"
+    }
+
+    fn name(&self) -> &'static str {
+        "canvas"
+    }
+
+    async fn perform(&self, intention: Intention) -> Result<ActionResult, MotorError> {
+        let action = intention.action;
+        if action.name != "canvas" {
+            return Err(MotorError::Unrecognized);
+        }
+        self.stream.request_snap();
+        let mut rx = self.stream.subscribe();
+        let img = rx
+            .recv()
+            .await
+            .map_err(|e| MotorError::Failed(e.to_string()))?;
+        let b64 = B64.encode(&img);
+        let prompt = format!(
+            "This is what you are seeing. If this is your first person perspective, what do you see?\n{b64}"
+        );
+        debug!(?prompt, "canvas prompt");
+        let msgs = vec![ollama_rs::generation::chat::ChatMessage::user(prompt)];
+        let mut stream = self
+            .llm
+            .chat_stream(&msgs)
+            .await
+            .map_err(|e| MotorError::Failed(e.to_string()))?;
+        let mut desc = String::new();
+        while let Some(Ok(tok)) = stream.next().await {
+            trace!(%tok, "llm token");
+            desc.push_str(&tok);
+        }
+        let when = Local::now();
+        let sensation = Sensation {
+            kind: "vision.description".into(),
+            when,
+            what: desc.clone(),
+            source: None,
+        };
+        let _ = self.tx.send(vec![sensation.clone()]);
+        let completion = Completion::of_action(action);
+        debug!(
+            completion_name = %completion.name,
+            completion_params = ?completion.params,
+            completion_result = ?completion.result,
+            ?completion,
+            "action completed"
+        );
+        Ok(ActionResult {
+            sensations: vec![Sensation {
+                kind: "vision.description".into(),
+                when,
+                what: serde_json::Value::String(desc),
+                source: None,
+            }],
+            completed: true,
+            completion: Some(completion),
+            interruption: None,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl psyche_rs::SensorDirectingMotor for CanvasMotor {
+    /// Return the name of the single sensor controlled by this motor.
+    fn attached_sensors(&self) -> Vec<String> {
+        vec!["CanvasStream".to_string()]
+    }
+
+    /// Trigger a snapshot on the internal [`CanvasStream`].
+    async fn direct_sensor(&self, sensor_name: &str) -> Result<(), MotorError> {
+        if sensor_name == "CanvasStream" {
+            self.stream.request_snap();
+            Ok(())
+        } else {
+            Err(MotorError::Failed(format!(
+                "Unknown sensor: {}",
+                sensor_name
+            )))
+        }
+    }
+}

--- a/daringsby/src/canvas_stream.rs
+++ b/daringsby/src/canvas_stream.rs
@@ -1,0 +1,106 @@
+use axum::{
+    Router,
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    routing::get,
+};
+use futures::StreamExt;
+use std::sync::Arc;
+use tokio::sync::broadcast::{self, Receiver, Sender};
+
+/// WebSocket streamer for canvas snapshots.
+///
+/// The server broadcasts `"snap"` commands to connected clients and
+/// receives JPEG image bytes in response.
+///
+/// This is largely identical to [`LookStream`] but intended for a drawing
+/// canvas rather than a webcam. Connected clients receive `"snap"` commands and
+/// respond with JPEG bytes.
+pub struct CanvasStream {
+    tx: Sender<Vec<u8>>, // image bytes
+    cmd: Sender<String>, // commands like "snap"
+}
+
+impl Default for CanvasStream {
+    fn default() -> Self {
+        let (tx, _) = broadcast::channel(8);
+        let (cmd, _) = broadcast::channel(8);
+        Self { tx, cmd }
+    }
+}
+
+impl CanvasStream {
+    /// Subscribe to incoming images.
+    pub fn subscribe(&self) -> Receiver<Vec<u8>> {
+        self.tx.subscribe()
+    }
+
+    /// Request a snapshot from all connected clients.
+    pub fn request_snap(&self) {
+        let _ = self.cmd.send("snap".into());
+    }
+
+    /// Subscribe to outgoing command messages. Primarily used for tests.
+    pub fn subscribe_cmd(&self) -> Receiver<String> {
+        self.cmd.subscribe()
+    }
+
+    /// Build a router exposing the look WebSocket endpoint.
+    pub fn router(self: Arc<Self>) -> Router {
+        Router::new().route(
+            "/canvas-jpeg-in",
+            get(move |ws: WebSocketUpgrade| {
+                let stream = self.clone();
+                async move { ws.on_upgrade(move |sock| stream.clone().session(sock)) }
+            }),
+        )
+    }
+
+    async fn session(self: Arc<Self>, mut socket: WebSocket) {
+        let mut cmd_rx = self.cmd.subscribe();
+        loop {
+            tokio::select! {
+                Some(Ok(msg)) = socket.next() => {
+                    if let Message::Binary(data) = msg {
+                        let _ = self.tx.send(data);
+                    }
+                }
+                Ok(cmd) = cmd_rx.recv() => {
+                    if socket.send(Message::Text(cmd)).await.is_err() {
+                        break;
+                    }
+                }
+                else => break,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{SinkExt, StreamExt};
+    use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
+
+    async fn start_server(stream: Arc<CanvasStream>) -> std::net::SocketAddr {
+        let app = stream.router();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        addr
+    }
+
+    #[tokio::test]
+    async fn forwards_images_and_commands() {
+        let stream = Arc::new(CanvasStream::default());
+        let addr = start_server(stream.clone()).await;
+        let url = format!("ws://{addr}/canvas-jpeg-in");
+        let (mut ws, _) = connect_async(url).await.unwrap();
+        let mut rx = stream.subscribe();
+        ws.send(WsMessage::Binary(vec![1, 2, 3])).await.unwrap();
+        let img = rx.recv().await.unwrap();
+        assert_eq!(img, vec![1, 2, 3]);
+        stream.request_snap();
+        let msg = ws.next().await.unwrap().unwrap();
+        assert_eq!(msg, WsMessage::Text("snap".into()));
+    }
+}

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "canvas-motor")]
+pub mod canvas_motor;
+pub mod canvas_stream;
 #[cfg(feature = "development-status-sensor")]
 pub mod development_status;
 #[cfg(feature = "heard-self-sensor")]

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "canvas-motor")]
+pub use crate::canvas_motor::CanvasMotor;
 /// Motor implementations used by the Daringsby binary.
 ///
 /// # Examples

--- a/daringsby/src/streams.rs
+++ b/daringsby/src/streams.rs
@@ -1,3 +1,4 @@
+pub use crate::canvas_stream::CanvasStream;
 /// Stream sources provided by the Daringsby runtime.
 ///
 /// # Examples

--- a/daringsby/tests/canvas_motor.rs
+++ b/daringsby/tests/canvas_motor.rs
@@ -1,0 +1,54 @@
+use daringsby::{canvas_motor::CanvasMotor, canvas_stream::CanvasStream};
+use psyche_rs::{LLMClient, MotorError, SensorDirectingMotor};
+use std::sync::Arc;
+use tokio::sync::mpsc::unbounded_channel;
+
+struct DummyLLM;
+
+#[async_trait::async_trait]
+impl LLMClient for DummyLLM {
+    async fn chat_stream(
+        &self,
+        _messages: &[ollama_rs::generation::chat::ChatMessage],
+    ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        let stream = async_stream::stream! {
+            yield Ok(String::new());
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+#[tokio::test]
+async fn attached_sensors_returns_stream_name() {
+    let stream = Arc::new(CanvasStream::default());
+    let llm = Arc::new(DummyLLM);
+    let (tx, _) = unbounded_channel();
+    let motor = CanvasMotor::new(stream, llm, tx);
+    let sensors = SensorDirectingMotor::attached_sensors(&motor);
+    assert_eq!(sensors, vec!["CanvasStream".to_string()]);
+}
+
+#[tokio::test]
+async fn direct_sensor_triggers_snapshot() {
+    let stream = Arc::new(CanvasStream::default());
+    let mut cmd_rx = stream.subscribe_cmd();
+    let llm = Arc::new(DummyLLM);
+    let (tx, _) = unbounded_channel();
+    let motor = CanvasMotor::new(stream.clone(), llm, tx);
+    SensorDirectingMotor::direct_sensor(&motor, "CanvasStream")
+        .await
+        .expect("should succeed");
+    // command should have been sent
+    let cmd = cmd_rx.recv().await.unwrap();
+    assert_eq!(cmd, "snap");
+}
+
+#[tokio::test]
+async fn direct_sensor_unknown_name_fails() {
+    let stream = Arc::new(CanvasStream::default());
+    let llm = Arc::new(DummyLLM);
+    let (tx, _) = unbounded_channel();
+    let motor = CanvasMotor::new(stream, llm, tx);
+    let err = SensorDirectingMotor::direct_sensor(&motor, "Unknown").await;
+    assert!(matches!(err, Err(MotorError::Failed(_))));
+}


### PR DESCRIPTION
## Summary
- introduce `CanvasStream` for snapshotting canvas images
- add `CanvasMotor` to describe canvas snapshots via LLM
- expose new feature flag `canvas-motor`
- export canvas types and motor
- test sensor directing and snapshot requests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861a6b0e2688320b7755bdcb083d98d