### PR TITLE
Add canvas streaming motors

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -21,7 +21,8 @@ use daringsby::SelfDiscovery;
 #[cfg(feature = "source-discovery-sensor")]
 use daringsby::SourceDiscovery;
 use daringsby::{
-    HeardSelfSensor, Heartbeat, LoggingMotor, LookMotor, LookStream, Mouth, SpeechStream,
+    CanvasMotor, CanvasStream, HeardSelfSensor, Heartbeat, LoggingMotor, LookMotor, LookStream,
+    Mouth, SpeechStream, SvgMotor,
 };
 use std::net::SocketAddr;
 
@@ -80,7 +81,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let segment_rx = mouth.subscribe_segments();
     let stream = Arc::new(SpeechStream::new(audio_rx, text_rx, segment_rx));
     let vision = Arc::new(LookStream::default());
-    let app = stream.clone().router().merge(vision.clone().router());
+    let canvas = Arc::new(CanvasStream::default());
+    let app = stream
+        .clone()
+        .router()
+        .merge(vision.clone().router())
+        .merge(canvas.clone().router());
     let addr: SocketAddr = format!("{}:{}", args.host, args.port).parse()?;
     tokio::spawn(async move {
         tracing::info!(%addr, "serving speech stream");
@@ -97,6 +103,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (tx, rx) = unbounded_channel::<Vec<Impression<String>>>();
     let (look_tx, look_rx) = unbounded_channel::<Vec<Sensation<String>>>();
+    let (canvas_tx, canvas_rx) = unbounded_channel::<Vec<Sensation<String>>>();
+    let (svg_tx, svg_rx) = unbounded_channel::<String>();
     #[cfg(feature = "moment-feedback")]
     let (sens_tx, sens_rx) = unbounded_channel::<Vec<Sensation<String>>>();
 
@@ -105,6 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(Heartbeat) as Box<dyn Sensor<String> + Send>,
         Box::new(HeardSelfSensor::new(stream.subscribe_heard())) as Box<dyn Sensor<String> + Send>,
         Box::new(SensationSensor::new(look_rx)) as Box<dyn Sensor<String> + Send>,
+        Box::new(SensationSensor::new(canvas_rx)) as Box<dyn Sensor<String> + Send>,
     ];
     #[cfg(feature = "development-status-sensor")]
     sensors.push(Box::new(DevelopmentStatus) as Box<dyn Sensor<String> + Send>);
@@ -120,6 +129,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let combo_stream = combob.observe(vec![sensor]).await;
     let logger = Arc::new(LoggingMotor);
     let looker = Arc::new(LookMotor::new(vision.clone(), llm.clone(), look_tx));
+    let canvas_motor = Arc::new(CanvasMotor::new(canvas.clone(), llm.clone(), canvas_tx));
+    let svg_motor = Arc::new(SvgMotor::new(svg_tx));
+    {
+        let canvas = canvas.clone();
+        tokio::spawn(async move {
+            let mut rx = svg_rx;
+            while let Some(svg) = rx.recv().await {
+                canvas.broadcast_svg(svg);
+            }
+        });
+    }
     let _speaker_id = args.speaker_id.clone();
 
     let (will_tx, will_rx) = unbounded_channel::<Vec<Impression<String>>>();
@@ -128,6 +148,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     will.register_motor(logger.as_ref());
     will.register_motor(looker.as_ref());
     will.register_motor(mouth.as_ref());
+    will.register_motor(canvas_motor.as_ref());
+    will.register_motor(svg_motor.as_ref());
     let will_stream = will.observe(vec![will_sensor]).await;
 
     let q_instant = INSTANT.clone();
@@ -157,7 +179,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tokio::spawn(drive_combo_stream(combo_stream, logger.clone()));
     }
 
-    tokio::spawn(drive_will_stream(will_stream, logger, looker, mouth));
+    tokio::spawn(drive_will_stream(
+        will_stream,
+        logger,
+        looker,
+        mouth,
+        canvas_motor,
+        svg_motor,
+    ));
 
     tokio::signal::ctrl_c().await?;
     Ok(())
@@ -212,6 +241,8 @@ async fn drive_will_stream(
     logger: Arc<LoggingMotor>,
     looker: Arc<LookMotor>,
     mouth: Arc<Mouth>,
+    canvas: Arc<CanvasMotor>,
+    drawer: Arc<SvgMotor>,
 ) {
     use futures::StreamExt;
 
@@ -226,6 +257,12 @@ async fn drive_will_stream(
                 }
                 "say" => {
                     mouth.perform(intent).await.expect("mouth motor failed");
+                }
+                "canvas" => {
+                    canvas.perform(intent).await.expect("canvas motor failed");
+                }
+                "draw" => {
+                    drawer.perform(intent).await.expect("svg motor failed");
                 }
                 _ => {
                     tracing::warn!(motor = %intent.assigned_motor, "unknown motor");

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -27,3 +27,8 @@ uuid = { version = "1", features = ["v4"] }
 [dev-dependencies]
 httpmock = "0.7.0"
 tokio = { version = "1", features = ["macros", "rt"] }
+
+[features]
+canvas-motor = []
+svg-motor = []
+default = ["canvas-motor", "svg-motor"]


### PR DESCRIPTION
## Summary
- integrate CanvasStream into the web router
- wire up CanvasMotor and SvgMotor into runtime
- expose optional canvas-motor and svg-motor features in library crate

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861acc4f5008320b86b941171363e26