### PR TITLE
Add user message sensor and form

### DIFF
--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -52,6 +52,7 @@ svg-motor = []
 canvas-stream = []
 development-status-sensor = []
 heard-self-sensor = []
+heard-user-sensor = []
 heartbeat-sensor = []
 self-discovery-sensor = []
 source-discovery-sensor = []
@@ -69,5 +70,6 @@ default = [
     "svg-motor",
     "canvas-stream",
     "heard-self-sensor",
+    "heard-user-sensor",
     "heartbeat-sensor",
 ]

--- a/daringsby/src/heard_user_sensor.rs
+++ b/daringsby/src/heard_user_sensor.rs
@@ -1,0 +1,82 @@
+use chrono::Local;
+use futures::{StreamExt, TryStreamExt, stream::BoxStream};
+use tokio::sync::broadcast::Receiver;
+use tokio_stream::wrappers::BroadcastStream;
+
+use psyche_rs::{Sensation, Sensor};
+
+/// Sensor emitting sensations when the agent hears a user speaking.
+/// Each text received is wrapped in a sentence describing the event.
+pub struct HeardUserSensor {
+    rx: Option<Receiver<String>>,
+    template: String,
+}
+
+impl HeardUserSensor {
+    /// Create a new sensor from the given broadcast receiver.
+    pub fn new(rx: Receiver<String>) -> Self {
+        Self::with_template(rx, "I heard the user say: \"{text}\"")
+    }
+
+    /// Create a sensor with a custom phrase template.
+    pub fn with_template(rx: Receiver<String>, template: impl Into<String>) -> Self {
+        Self {
+            rx: Some(rx),
+            template: template.into(),
+        }
+    }
+}
+
+impl Sensor<String> for HeardUserSensor {
+    fn stream(&mut self) -> BoxStream<'static, Vec<Sensation<String>>> {
+        let rx = self
+            .rx
+            .take()
+            .expect("HeardUserSensor stream called more than once");
+        let template = self.template.clone();
+        BroadcastStream::new(rx)
+            .inspect_err(|e| tracing::warn!(error=?e, "HeardUserSensor receiver error"))
+            .filter_map(|msg| async move { msg.ok() })
+            .map(move |text| {
+                vec![Sensation {
+                    kind: "user_audio".into(),
+                    when: Local::now(),
+                    what: template.replace("{text}", &text),
+                    source: None,
+                }]
+            })
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use tokio::sync::broadcast;
+
+    #[tokio::test]
+    async fn emits_sensation_per_message() {
+        let (tx, rx) = broadcast::channel(4);
+        let mut sensor = HeardUserSensor::new(rx);
+        tx.send("Hello".into()).unwrap();
+        drop(tx);
+        let start = Local::now();
+        let mut stream = sensor.stream();
+        let batch = stream.next().await.unwrap();
+        assert_eq!(batch[0].what, "I heard the user say: \"Hello\"");
+        assert_eq!(batch[0].kind, "user_audio");
+        assert!(batch[0].when >= start && batch[0].when <= Local::now());
+    }
+
+    #[tokio::test]
+    async fn custom_template_is_used() {
+        let (tx, rx) = broadcast::channel(4);
+        let mut sensor = HeardUserSensor::with_template(rx, "user said {text}");
+        tx.send("Yo".into()).unwrap();
+        drop(tx);
+        let mut stream = sensor.stream();
+        let batch = stream.next().await.unwrap();
+        assert_eq!(batch[0].what, "user said Yo");
+    }
+}

--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -9,12 +9,25 @@
 </head>
 <body class="container">
 <button id="start" class="secondary">Start</button>
+<form id="message-form" role="form">
+  <label for="message-input">Message:</label>
+  <input
+    type="text"
+    id="message-input"
+    name="message"
+    required
+    autofocus
+    autocomplete="off"
+  />
+  <button type="submit">Send</button>
+</form>
 <canvas id="drawing-area" class="container" width="640" height="480"></canvas>
 <script>
 const SAMPLE_RATE = 22050;
 const ctx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: SAMPLE_RATE });
 let segWs;
 let heardWs;
+let userWs;
 let lookWs;
 let lookVideo;
 let lookCanvas;
@@ -46,6 +59,16 @@ function sendHeard() {
   }
   pendingText = null;
   console.log("Queue length", queue.length, "Texts length", texts.length);
+}
+
+function sendMessage(ev) {
+  ev.preventDefault();
+  const input = document.getElementById('message-input');
+  const text = input.value.trim();
+  if (text && userWs && userWs.readyState === WebSocket.OPEN) {
+    userWs.send(text);
+  }
+  input.value = '';
 }
 
 function play() {
@@ -90,6 +113,10 @@ function start() {
   heardWs.onopen = () => console.log("heardWs connected");
   heardWs.onerror = e => console.error("heardWs error", e);
   heardWs.onclose = () => console.warn("heardWs closed");
+  userWs = openSocket(userWs, `ws://${location.host}/speech-text-user-in`);
+  userWs.onopen = () => console.log('userWs connected');
+  userWs.onerror = e => console.error('userWs error', e);
+  userWs.onclose = () => console.warn('userWs closed');
   lookWs = openSocket(lookWs, `ws://${location.host}/vision-jpeg-in`, 'arraybuffer');
   if (lookWs.readyState <= WebSocket.OPEN)
     lookWs.onmessage = ev => {
@@ -115,9 +142,12 @@ function capture() {
 
 // Attach the start handler only once so we don't open duplicate WebSocket
 // connections if the user clicks multiple times.
+  document
+    .getElementById('start')
+    .addEventListener('click', start, { once: true });
 document
-  .getElementById('start')
-  .addEventListener('click', start, { once: true });
+  .getElementById('message-form')
+  .addEventListener('submit', sendMessage);
 </script>
 </body>
 </html>

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -6,6 +6,8 @@ pub mod canvas_stream;
 pub mod development_status;
 #[cfg(feature = "heard-self-sensor")]
 pub mod heard_self_sensor;
+#[cfg(feature = "heard-user-sensor")]
+pub mod heard_user_sensor;
 #[cfg(feature = "heartbeat-sensor")]
 pub mod heartbeat;
 #[cfg(feature = "logging-motor")]

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -21,7 +21,8 @@ use daringsby::SelfDiscovery;
 #[cfg(feature = "source-discovery-sensor")]
 use daringsby::SourceDiscovery;
 use daringsby::{
-    HeardSelfSensor, Heartbeat, LoggingMotor, LookMotor, LookStream, Mouth, SpeechStream,
+    HeardSelfSensor, HeardUserSensor, Heartbeat, LoggingMotor, LookMotor, LookStream, Mouth,
+    SpeechStream,
 };
 use std::net::SocketAddr;
 
@@ -104,6 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut sensors: Vec<Box<dyn Sensor<String> + Send>> = vec![
         Box::new(Heartbeat) as Box<dyn Sensor<String> + Send>,
         Box::new(HeardSelfSensor::new(stream.subscribe_heard())) as Box<dyn Sensor<String> + Send>,
+        Box::new(HeardUserSensor::new(stream.subscribe_user())) as Box<dyn Sensor<String> + Send>,
         Box::new(SensationSensor::new(look_rx)) as Box<dyn Sensor<String> + Send>,
     ];
     #[cfg(feature = "development-status-sensor")]

--- a/daringsby/src/sensors.rs
+++ b/daringsby/src/sensors.rs
@@ -8,6 +8,8 @@
 pub use crate::development_status::DevelopmentStatus;
 #[cfg(feature = "heard-self-sensor")]
 pub use crate::heard_self_sensor::HeardSelfSensor;
+#[cfg(feature = "heard-user-sensor")]
+pub use crate::heard_user_sensor::HeardUserSensor;
 #[cfg(feature = "heartbeat-sensor")]
 pub use crate::heartbeat::{Heartbeat, heartbeat_message};
 #[cfg(feature = "self-discovery-sensor")]


### PR DESCRIPTION
## Summary
- add `HeardUserSensor` for detecting user speech
- support `/speech-text-user-in` websocket in `SpeechStream`
- hook user message sensor into the runtime
- update frontend with a message form and websocket connection
- test user message forwarding

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861ad2fb484832099e1cbceb391e0a5