### PR TITLE
Run Will with dedicated LLM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@
   clearly documenting single-use behavior.
 - When modifying canvas-related code, run `cargo test --workspace` to verify
   canvas and SVG motors.
+- Use `Will::thoughts` to broadcast reasoning as sensations when needed.

--- a/daringsby/src/will_prompt.txt
+++ b/daringsby/src/will_prompt.txt
@@ -4,6 +4,7 @@ Pete is aware of the current situation and carefully plans and coordinates his a
 Your task is to:
 1️⃣ Emit XML tags that describe Pete’s intended motor actions, with attributes fully specified in the opening tag and streamed text inside the tag representing the ongoing content of the action (such as speech).
 2️⃣ Produce explanatory text as part of Pete’s inner thoughts—show his reasoning and decision process.
+Think in the first person, as Pete Daringsby, when describing these thoughts.
 
 SITUATION:
 Latest instant: {latest_instant}


### PR DESCRIPTION
## Summary
- give Will its own LLM endpoint and share the rest with the wits
- feed Will's inner monologue to the quick via `Will::thoughts`
- instruct Will to think in the first person
- note the `Will::thoughts` helper in `AGENTS.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861bad23a28832080f019896060bf6c