### PR TITLE
Fix Will/Wit scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "futures",
  "httpmock",
  "ollama-rs",
+ "rand",
  "regex",
  "reqwest",
  "segtok",

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -20,6 +20,7 @@ segtok = "0.1.5"
 tracing = "0.1"
 thiserror = "1"
 regex = "1"
+rand = "0.8"
 anyhow = "1"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
## Summary
- add `start_jitter_ms` option to `Wit`
- stagger witness loops to avoid simultaneous LLM calls
- document jitter usage and add `rand` dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861c7294ae08320b2817345bb1a9d7b