### PR TITLE
Rename LookMotor to Vision

### DIFF
--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -44,7 +44,7 @@ serial_test = "2"
 
 [features]
 logging-motor = []
-look-motor = []
+vision = []
 canvas-motor = []
 mouth = []
 source-read-motor = []
@@ -62,7 +62,7 @@ source-discovery-sensor = []
 moment-feedback = []
 default = [
     "logging-motor",
-    "look-motor",
+    "vision",
     "canvas-motor",
     "mouth",
     "development-status-sensor",

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -15,8 +15,6 @@ pub mod log_file;
 pub mod log_memory_motor;
 #[cfg(feature = "logging-motor")]
 pub mod logging_motor;
-#[cfg(feature = "look-motor")]
-pub mod look_motor;
 pub mod look_stream;
 #[cfg(feature = "mouth")]
 pub mod mouth;
@@ -34,6 +32,8 @@ pub mod speech_segment;
 pub mod speech_stream;
 #[cfg(feature = "svg-motor")]
 pub mod svg_motor;
+#[cfg(feature = "vision")]
+pub mod vision;
 
 pub mod logger;
 pub mod motors;

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -10,8 +10,6 @@ pub use crate::log_memory_motor::LogMemoryMotor;
 /// ```
 #[cfg(feature = "logging-motor")]
 pub use crate::logging_motor::LoggingMotor;
-#[cfg(feature = "look-motor")]
-pub use crate::look_motor::LookMotor;
 #[cfg(feature = "mouth")]
 pub use crate::mouth::Mouth;
 #[cfg(feature = "source-read-motor")]
@@ -22,3 +20,5 @@ pub use crate::source_search_motor::SourceSearchMotor;
 pub use crate::source_tree_motor::SourceTreeMotor;
 #[cfg(feature = "svg-motor")]
 pub use crate::svg_motor::SvgMotor;
+#[cfg(feature = "vision")]
+pub use crate::vision::Vision;

--- a/daringsby/src/source_search_motor.rs
+++ b/daringsby/src/source_search_motor.rs
@@ -15,7 +15,7 @@ static PSYCHE_SRC_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../psyche-rs/src"
 ///
 /// The `"SourceSearchSensor"` emits a [`Sensation`] for each matching line when
 /// directed. Parameters are appended to the sensor name using
-/// `:"query"`, for example `"SourceSearchSensor:LookMotor"`.
+/// `:"query"`, for example `"SourceSearchSensor:Vision"`.
 pub struct SourceSearchMotor {
     tx: UnboundedSender<Vec<Sensation<String>>>,
 }

--- a/daringsby/src/vision.rs
+++ b/daringsby/src/vision.rs
@@ -12,13 +12,13 @@ use psyche_rs::{ActionResult, Completion, Intention, LLMClient, Motor, MotorErro
 use crate::look_stream::LookStream;
 
 /// Motor that captures a webcam snapshot and describes it using an LLM.
-pub struct LookMotor {
+pub struct Vision {
     stream: Arc<LookStream>,
     llm: Arc<dyn LLMClient>,
     tx: UnboundedSender<Vec<Sensation<String>>>,
 }
 
-impl LookMotor {
+impl Vision {
     /// Create a new look motor backed by the given stream and LLM.
     pub fn new(
         stream: Arc<LookStream>,
@@ -30,7 +30,7 @@ impl LookMotor {
 }
 
 #[async_trait]
-impl Motor for LookMotor {
+impl Motor for Vision {
     fn description(&self) -> &'static str {
         "Take a look at what's in front of your face.\n\
 Parameters: none.\n\
@@ -61,7 +61,7 @@ sent to any `LookStream` subscribers."
         let prompt = format!(
             "This is what you are seeing. If this is your first person perspective, what do you see?\n{b64}"
         );
-        debug!(?prompt, "look prompt");
+        debug!(?prompt, "vision prompt");
         let msgs = vec![ollama_rs::generation::chat::ChatMessage::user(prompt)];
         let mut stream = self
             .llm
@@ -104,7 +104,7 @@ sent to any `LookStream` subscribers."
 }
 
 #[async_trait::async_trait]
-impl psyche_rs::SensorDirectingMotor for LookMotor {
+impl psyche_rs::SensorDirectingMotor for Vision {
     /// Return the name of the single sensor controlled by this motor.
     fn attached_sensors(&self) -> Vec<String> {
         vec!["LookStream".to_string()]

--- a/daringsby/tests/source_search_motor.rs
+++ b/daringsby/tests/source_search_motor.rs
@@ -15,11 +15,11 @@ async fn attached_sensors_returns_search_sensor() {
 async fn direct_sensor_emits_matches() {
     let (tx, mut rx) = unbounded_channel();
     let motor = SourceSearchMotor::new(tx);
-    SensorDirectingMotor::direct_sensor(&motor, "SourceSearchSensor:LookMotor")
+    SensorDirectingMotor::direct_sensor(&motor, "SourceSearchSensor:Vision")
         .await
         .expect("should succeed");
     let sensations = rx.try_recv().expect("sensation");
-    assert!(sensations[0].what.contains("LookMotor"));
+    assert!(sensations[0].what.contains("Vision"));
 }
 
 #[tokio::test]

--- a/daringsby/tests/vision.rs
+++ b/daringsby/tests/vision.rs
@@ -1,4 +1,4 @@
-use daringsby::{look_motor::LookMotor, look_stream::LookStream};
+use daringsby::{look_stream::LookStream, vision::Vision};
 use psyche_rs::{LLMClient, MotorError, SensorDirectingMotor};
 use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
@@ -23,7 +23,7 @@ async fn attached_sensors_returns_stream_name() {
     let stream = Arc::new(LookStream::default());
     let llm = Arc::new(DummyLLM);
     let (tx, _) = unbounded_channel();
-    let motor = LookMotor::new(stream, llm, tx);
+    let motor = Vision::new(stream, llm, tx);
     let sensors = SensorDirectingMotor::attached_sensors(&motor);
     assert_eq!(sensors, vec!["LookStream".to_string()]);
 }
@@ -33,7 +33,7 @@ async fn direct_sensor_valid_name_succeeds() {
     let stream = Arc::new(LookStream::default());
     let llm = Arc::new(DummyLLM);
     let (tx, _) = unbounded_channel();
-    let motor = LookMotor::new(stream.clone(), llm, tx);
+    let motor = Vision::new(stream.clone(), llm, tx);
     SensorDirectingMotor::direct_sensor(&motor, "LookStream")
         .await
         .expect("should succeed");
@@ -44,7 +44,7 @@ async fn direct_sensor_unknown_name_fails() {
     let stream = Arc::new(LookStream::default());
     let llm = Arc::new(DummyLLM);
     let (tx, _) = unbounded_channel();
-    let motor = LookMotor::new(stream.clone(), llm, tx);
+    let motor = Vision::new(stream.clone(), llm, tx);
     let err = SensorDirectingMotor::direct_sensor(&motor, "Unknown").await;
     assert!(matches!(err, Err(MotorError::Failed(_))));
 }


### PR DESCRIPTION
## Summary
- rename `LookMotor` to `Vision`
- update crate feature and imports
- adjust tests for the new name

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861de22195c8320916c8bfaa31bfb3a