### PR TITLE
Rename Vision motor and sensor

### DIFF
--- a/daringsby/src/canvas_stream.rs
+++ b/daringsby/src/canvas_stream.rs
@@ -13,7 +13,7 @@ use tokio::sync::broadcast::{self, Receiver, Sender};
 /// receives JPEG image bytes in response. Connected clients receive
 /// `"snap"` commands and respond with JPEG bytes.
 ///
-/// This is largely identical to `LookStream` but intended for a drawing canvas
+/// This is largely identical to `VisionSensor` but intended for a drawing canvas
 /// rather than a webcam.
 pub struct CanvasStream {
     tx: Sender<Vec<u8>>,    // Image bytes

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -15,7 +15,6 @@ pub mod log_file;
 pub mod log_memory_motor;
 #[cfg(feature = "logging-motor")]
 pub mod logging_motor;
-pub mod look_stream;
 #[cfg(feature = "mouth")]
 pub mod mouth;
 #[cfg(feature = "self-discovery-sensor")]
@@ -33,7 +32,8 @@ pub mod speech_stream;
 #[cfg(feature = "svg-motor")]
 pub mod svg_motor;
 #[cfg(feature = "vision")]
-pub mod vision;
+pub mod vision_motor;
+pub mod vision_sensor;
 
 pub mod logger;
 pub mod motors;

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -21,8 +21,8 @@ use daringsby::SelfDiscovery;
 #[cfg(feature = "source-discovery-sensor")]
 use daringsby::SourceDiscovery;
 use daringsby::{
-    CanvasMotor, CanvasStream, HeardSelfSensor, HeardUserSensor, Heartbeat, LoggingMotor,
-    LookStream, Mouth, SpeechStream, SvgMotor, Vision,
+    CanvasMotor, CanvasStream, HeardSelfSensor, HeardUserSensor, Heartbeat, LoggingMotor, Mouth,
+    SpeechStream, SvgMotor, VisionMotor, VisionSensor,
 };
 use std::net::SocketAddr;
 
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let text_rx = mouth.subscribe_text();
     let segment_rx = mouth.subscribe_segments();
     let stream = Arc::new(SpeechStream::new(audio_rx, text_rx, segment_rx));
-    let vision_stream = Arc::new(LookStream::default());
+    let vision_stream = Arc::new(VisionSensor::default());
     let canvas = Arc::new(CanvasStream::default());
     let app = stream
         .clone()
@@ -146,7 +146,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sensor = ImpressionStreamSensor::new(rx);
     let combo_stream = combob.observe(vec![sensor]).await;
     let logger = Arc::new(LoggingMotor);
-    let vision_motor = Arc::new(Vision::new(
+    let vision_motor = Arc::new(VisionMotor::new(
         vision_stream.clone(),
         wits_llm.clone(),
         look_tx,
@@ -268,7 +268,7 @@ async fn drive_combo_stream(
 async fn drive_will_stream(
     mut will_stream: impl futures::Stream<Item = Vec<Intention>> + Unpin + Send + 'static,
     logger: Arc<LoggingMotor>,
-    vision_motor: Arc<Vision>,
+    vision_motor: Arc<VisionMotor>,
     mouth: Arc<Mouth>,
     canvas: Arc<CanvasMotor>,
     drawer: Arc<SvgMotor>,

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -21,4 +21,4 @@ pub use crate::source_tree_motor::SourceTreeMotor;
 #[cfg(feature = "svg-motor")]
 pub use crate::svg_motor::SvgMotor;
 #[cfg(feature = "vision")]
-pub use crate::vision::Vision;
+pub use crate::vision_motor::VisionMotor;

--- a/daringsby/src/source_search_motor.rs
+++ b/daringsby/src/source_search_motor.rs
@@ -15,7 +15,7 @@ static PSYCHE_SRC_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../psyche-rs/src"
 ///
 /// The `"SourceSearchSensor"` emits a [`Sensation`] for each matching line when
 /// directed. Parameters are appended to the sensor name using
-/// `:"query"`, for example `"SourceSearchSensor:Vision"`.
+/// `:"query"`, for example `"SourceSearchSensor:VisionMotor"`.
 pub struct SourceSearchMotor {
     tx: UnboundedSender<Vec<Sensation<String>>>,
 }

--- a/daringsby/src/streams.rs
+++ b/daringsby/src/streams.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "canvas-stream")]
 pub use crate::canvas_stream::CanvasStream;
+pub use crate::speech_stream::SpeechStream;
+#[cfg(feature = "svg-motor")]
+pub use crate::svg_motor::SvgMotor;
 /// Stream sources provided by the Daringsby runtime.
 ///
 /// # Examples
 /// ```
 /// use daringsby::streams::SpeechStream;
 /// ```
-pub use crate::look_stream::LookStream;
-pub use crate::speech_stream::SpeechStream;
-#[cfg(feature = "svg-motor")]
-pub use crate::svg_motor::SvgMotor;
+pub use crate::vision_sensor::VisionSensor;

--- a/daringsby/src/vision_motor.rs
+++ b/daringsby/src/vision_motor.rs
@@ -9,19 +9,19 @@ use tracing::{debug, trace};
 
 use psyche_rs::{ActionResult, Completion, Intention, LLMClient, Motor, MotorError, Sensation};
 
-use crate::look_stream::LookStream;
+use crate::vision_sensor::VisionSensor;
 
 /// Motor that captures a webcam snapshot and describes it using an LLM.
-pub struct Vision {
-    stream: Arc<LookStream>,
+pub struct VisionMotor {
+    stream: Arc<VisionSensor>,
     llm: Arc<dyn LLMClient>,
     tx: UnboundedSender<Vec<Sensation<String>>>,
 }
 
-impl Vision {
+impl VisionMotor {
     /// Create a new look motor backed by the given stream and LLM.
     pub fn new(
-        stream: Arc<LookStream>,
+        stream: Arc<VisionSensor>,
         llm: Arc<dyn LLMClient>,
         tx: UnboundedSender<Vec<Sensation<String>>>,
     ) -> Self {
@@ -30,7 +30,7 @@ impl Vision {
 }
 
 #[async_trait]
-impl Motor for Vision {
+impl Motor for VisionMotor {
     fn description(&self) -> &'static str {
         "Take a look at what's in front of your face.\n\
 Parameters: none.\n\
@@ -39,7 +39,7 @@ Example:\n\
 Explanation:\n\
 The Will triggers a webcam snapshot and asks the LLM to describe the image.\n\
 The resulting description is returned as a `vision.description` sensation and\
-sent to any `LookStream` subscribers."
+sent to any `VisionSensor` subscribers."
     }
 
     fn name(&self) -> &'static str {
@@ -104,15 +104,15 @@ sent to any `LookStream` subscribers."
 }
 
 #[async_trait::async_trait]
-impl psyche_rs::SensorDirectingMotor for Vision {
+impl psyche_rs::SensorDirectingMotor for VisionMotor {
     /// Return the name of the single sensor controlled by this motor.
     fn attached_sensors(&self) -> Vec<String> {
-        vec!["LookStream".to_string()]
+        vec!["VisionSensor".to_string()]
     }
 
-    /// Trigger a snapshot on the internal [`LookStream`].
+    /// Trigger a snapshot on the internal [`VisionSensor`].
     async fn direct_sensor(&self, sensor_name: &str) -> Result<(), MotorError> {
-        if sensor_name == "LookStream" {
+        if sensor_name == "VisionSensor" {
             self.stream.request_snap();
             Ok(())
         } else {

--- a/daringsby/tests/source_search_motor.rs
+++ b/daringsby/tests/source_search_motor.rs
@@ -15,11 +15,11 @@ async fn attached_sensors_returns_search_sensor() {
 async fn direct_sensor_emits_matches() {
     let (tx, mut rx) = unbounded_channel();
     let motor = SourceSearchMotor::new(tx);
-    SensorDirectingMotor::direct_sensor(&motor, "SourceSearchSensor:Vision")
+    SensorDirectingMotor::direct_sensor(&motor, "SourceSearchSensor:VisionMotor")
         .await
         .expect("should succeed");
     let sensations = rx.try_recv().expect("sensation");
-    assert!(sensations[0].what.contains("Vision"));
+    assert!(sensations[0].what.contains("VisionMotor"));
 }
 
 #[tokio::test]

--- a/daringsby/tests/vision_motor.rs
+++ b/daringsby/tests/vision_motor.rs
@@ -1,4 +1,4 @@
-use daringsby::{look_stream::LookStream, vision::Vision};
+use daringsby::{vision_motor::VisionMotor, vision_sensor::VisionSensor};
 use psyche_rs::{LLMClient, MotorError, SensorDirectingMotor};
 use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
@@ -20,31 +20,31 @@ impl LLMClient for DummyLLM {
 
 #[tokio::test]
 async fn attached_sensors_returns_stream_name() {
-    let stream = Arc::new(LookStream::default());
+    let stream = Arc::new(VisionSensor::default());
     let llm = Arc::new(DummyLLM);
     let (tx, _) = unbounded_channel();
-    let motor = Vision::new(stream, llm, tx);
+    let motor = VisionMotor::new(stream, llm, tx);
     let sensors = SensorDirectingMotor::attached_sensors(&motor);
-    assert_eq!(sensors, vec!["LookStream".to_string()]);
+    assert_eq!(sensors, vec!["VisionSensor".to_string()]);
 }
 
 #[tokio::test]
 async fn direct_sensor_valid_name_succeeds() {
-    let stream = Arc::new(LookStream::default());
+    let stream = Arc::new(VisionSensor::default());
     let llm = Arc::new(DummyLLM);
     let (tx, _) = unbounded_channel();
-    let motor = Vision::new(stream.clone(), llm, tx);
-    SensorDirectingMotor::direct_sensor(&motor, "LookStream")
+    let motor = VisionMotor::new(stream.clone(), llm, tx);
+    SensorDirectingMotor::direct_sensor(&motor, "VisionSensor")
         .await
         .expect("should succeed");
 }
 
 #[tokio::test]
 async fn direct_sensor_unknown_name_fails() {
-    let stream = Arc::new(LookStream::default());
+    let stream = Arc::new(VisionSensor::default());
     let llm = Arc::new(DummyLLM);
     let (tx, _) = unbounded_channel();
-    let motor = Vision::new(stream.clone(), llm, tx);
+    let motor = VisionMotor::new(stream.clone(), llm, tx);
     let err = SensorDirectingMotor::direct_sensor(&motor, "Unknown").await;
     assert!(matches!(err, Err(MotorError::Failed(_))));
 }


### PR DESCRIPTION
## Summary
- rename `Vision` struct to `VisionMotor`
- rename `LookStream` to `VisionSensor`
- update imports and uses across the crate
- adjust tests to new naming

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861e12aa2f083209fa4718b94561ba6