### PR TITLE
Integrate recall motor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,5 @@
 - When modifying canvas-related code, run `cargo test --workspace` to verify
   canvas and SVG motors.
 - Use `Will::thoughts` to broadcast reasoning as sensations when needed.
+- When adding new sensors or motors, be sure to register them in `daringsby/src/main.rs`
+  and extend the dispatch logic in `drive_will_stream`.

--- a/psyche-rs/src/memory_store.rs
+++ b/psyche-rs/src/memory_store.rs
@@ -167,6 +167,59 @@ impl MemoryStore for InMemoryStore {
     }
 }
 
+impl<M> MemoryStore for std::sync::Arc<M>
+where
+    M: MemoryStore + ?Sized,
+{
+    fn store_sensation(&self, s: &StoredSensation) -> anyhow::Result<()> {
+        (**self).store_sensation(s)
+    }
+
+    fn store_impression(&self, i: &StoredImpression) -> anyhow::Result<()> {
+        (**self).store_impression(i)
+    }
+
+    fn store_summary_impression(
+        &self,
+        summary: &StoredImpression,
+        linked_ids: &[String],
+    ) -> anyhow::Result<()> {
+        (**self).store_summary_impression(summary, linked_ids)
+    }
+
+    fn add_lifecycle_stage(
+        &self,
+        impression_id: &str,
+        stage: &str,
+        detail: &str,
+    ) -> anyhow::Result<()> {
+        (**self).add_lifecycle_stage(impression_id, stage, detail)
+    }
+
+    fn retrieve_related_impressions(
+        &self,
+        query_how: &str,
+        top_k: usize,
+    ) -> anyhow::Result<Vec<StoredImpression>> {
+        (**self).retrieve_related_impressions(query_how, top_k)
+    }
+
+    fn fetch_recent_impressions(&self, limit: usize) -> anyhow::Result<Vec<StoredImpression>> {
+        (**self).fetch_recent_impressions(limit)
+    }
+
+    fn load_full_impression(
+        &self,
+        impression_id: &str,
+    ) -> anyhow::Result<(
+        StoredImpression,
+        Vec<StoredSensation>,
+        HashMap<String, String>,
+    )> {
+        (**self).load_full_impression(impression_id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- document new step in AGENTS about motor registration
- allow using `Arc<M>` as a `MemoryStore`
- wire up `RecallMotor` in the daringsby binary

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861e59b7fb0832096674ef64fb260eb