### PR TITLE
Fix wit loop tick log

### DIFF
--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -172,7 +172,6 @@ where
                 let streams: Vec<_> = sensors.into_iter().map(|mut s| s.stream()).collect();
                 let mut sensor_stream = stream::select_all(streams);
                 loop {
-                    trace!("wit loop tick");
                     tokio::select! {
                         Some(batch) = sensor_stream.next() => {
                             trace!(count = batch.len(), "sensations received");
@@ -182,6 +181,7 @@ where
                             if pending.is_empty() {
                                 continue;
                             }
+                            trace!("wit loop tick");
                             {
                                 let mut w = window.lock().unwrap();
                                 w.extend(pending.drain(..));


### PR DESCRIPTION
## Summary
- log wit ticks only when we call the LLM

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6861fd60432083209d64f03556e98ecb