### PR TITLE
Improve timeline readability

### DIFF
--- a/psyche-rs/src/combobulator.rs
+++ b/psyche-rs/src/combobulator.rs
@@ -55,7 +55,7 @@ impl<T> Combobulator<T> {
     /// Returns a textual timeline of sensations in the current window.
     pub fn timeline(&self) -> String
     where
-        T: serde::Serialize,
+        T: serde::Serialize + Clone,
     {
         self.wit.timeline()
     }
@@ -63,7 +63,7 @@ impl<T> Combobulator<T> {
     /// Returns the timeline with a short description prefix.
     pub fn describe_timeline(&self) -> String
     where
-        T: serde::Serialize,
+        T: serde::Serialize + Clone,
     {
         format!("Situation timeline\n{}", self.timeline())
     }

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -22,6 +22,7 @@ mod sensor_util;
 mod stream_util;
 #[cfg(test)]
 pub mod test_helpers;
+mod text_util;
 mod will;
 mod wit;
 

--- a/psyche-rs/src/text_util.rs
+++ b/psyche-rs/src/text_util.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+use serde_json::Value;
+
+/// Converts a serializable value to plain text.
+///
+/// Strings are returned without surrounding quotes. Other values are serialized
+/// to JSON using [`serde_json`].
+#[inline]
+pub fn to_plain_text<T: Serialize>(value: &T) -> String {
+    match serde_json::to_value(value) {
+        Ok(Value::String(s)) => s,
+        Ok(v) => v.to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_is_unquoted() {
+        assert_eq!(to_plain_text(&"hello"), "hello");
+    }
+
+    #[test]
+    fn numbers_become_json() {
+        assert_eq!(to_plain_text(&42), "42");
+    }
+}

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -106,14 +106,18 @@ impl<T> Will<T> {
     /// Returns a textual timeline of sensations in the current window.
     pub fn timeline(&self) -> String
     where
-        T: serde::Serialize,
+        T: serde::Serialize + Clone,
     {
-        self.window
-            .lock()
-            .unwrap()
+        let mut sensations = self.window.lock().unwrap().clone();
+        sensations.sort_by_key(|s| s.when);
+        sensations.dedup_by(|a, b| {
+            a.kind == b.kind
+                && serde_json::to_string(&a.what).ok() == serde_json::to_string(&b.what).ok()
+        });
+        sensations
             .iter()
             .map(|s| {
-                let what = serde_json::to_string(&s.what).unwrap_or_default();
+                let what = crate::text_util::to_plain_text(&s.what);
                 format!("{} {} {}", s.when.format("%Y-%m-%d %H:%M:%S"), s.kind, what)
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary
- add `text_util::to_plain_text` for cleaner timeline output
- deduplicate and sort timeline entries in `Will` and `Wit`
- require `Clone` for `timeline` methods and adjust `Combobulator`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6862019177888320bcfc8b406cbe6402