### PR TITLE
Fix Will UTF-8 slicing panic

### DIFF
--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -45,7 +45,7 @@ pub use sensation::Sensation;
 pub use sensation_channel_sensor::SensationSensor;
 pub use sensor::Sensor;
 pub use sensor_util::ImpressionStreamSensor;
-pub use will::{MotorDescription, Will};
+pub use will::{MotorDescription, Will, safe_prefix};
 pub use wit::Wit;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add `safe_prefix` helper to trim strings on character boundaries
- use `safe_prefix` within `Will::observe` when slicing tokens
- export `safe_prefix` in `lib.rs`
- test handling of multibyte tokens

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686202efd3148320a33d3210afb05a7a