### PR TITLE
Fix impression JSON dump in prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@
   large modules like `lib.rs` into smaller pieces.
 - Use the `LLMClient` trait for streaming LLM interactions.
 - Avoid streaming silence frames when audio is not playing.
+- Format `Impression` values using their `how` string when included in prompts
+  instead of serializing the entire struct.
 - Stream HTTP responses using `bytes_stream` to avoid blocking when servers
     stream data chunked.
 - Use `src/test_helpers.rs` for shared test utilities like `StaticLLM`,

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -22,7 +22,7 @@ mod sensor_util;
 mod stream_util;
 #[cfg(test)]
 pub mod test_helpers;
-mod text_util;
+pub mod text_util;
 mod will;
 mod wit;
 

--- a/psyche-rs/src/text_util.rs
+++ b/psyche-rs/src/text_util.rs
@@ -1,22 +1,43 @@
+use crate::Impression;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{self, Value};
 
 /// Converts a serializable value to plain text.
 ///
-/// Strings are returned without surrounding quotes. Other values are serialized
-/// to JSON using [`serde_json`].
+/// Strings are returned without surrounding quotes. [`Impression`] instances are
+/// rendered as quoted summary sentences. All other values are serialized to JSON
+/// using [`serde_json`].
+///
+/// # Examples
+///
+/// ```
+/// use psyche_rs::{Impression, text_util::to_plain_text};
+///
+/// let imp = Impression::<()>::new(Vec::new(), "He waved.").unwrap();
+/// assert_eq!(to_plain_text(&imp), "\"He waved.\"");
+/// assert_eq!(to_plain_text(&"hello"), "hello");
+/// ```
 #[inline]
 pub fn to_plain_text<T: Serialize>(value: &T) -> String {
-    match serde_json::to_value(value) {
-        Ok(Value::String(s)) => s,
-        Ok(v) => v.to_string(),
-        Err(_) => String::new(),
+    let val = match serde_json::to_value(value) {
+        Ok(v) => v,
+        Err(_) => return String::new(),
+    };
+
+    if let Ok(imp) = serde_json::from_value::<Impression<Value>>(val.clone()) {
+        return format!("\"{}\"", imp.how);
+    }
+
+    match val {
+        Value::String(s) => s,
+        v => v.to_string(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Impression;
 
     #[test]
     fn string_is_unquoted() {
@@ -26,5 +47,11 @@ mod tests {
     #[test]
     fn numbers_become_json() {
         assert_eq!(to_plain_text(&42), "42");
+    }
+
+    #[test]
+    fn impression_is_quoted_summary() {
+        let imp = Impression::new(Vec::<crate::Sensation<String>>::new(), "Hi.").unwrap();
+        assert_eq!(to_plain_text(&imp), "\"Hi.\"");
     }
 }


### PR DESCRIPTION
## Summary
- export `text_util` and handle `Impression` in `to_plain_text`
- teach doctest to format impressions
- note impression formatting rule in `AGENTS.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686206a33b288320814fa2c4ee08d2dc