### PR TITLE
Remove redundant Motor bounds

### DIFF
--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -98,7 +98,7 @@ where
     }
 
     /// Add a motor to the psyche.
-    pub fn motor(mut self, motor: impl Motor + Send + Sync + 'static) -> Self {
+    pub fn motor(mut self, motor: impl Motor + 'static) -> Self {
         self.motors.push(Arc::new(motor));
         self
     }


### PR DESCRIPTION
## Summary
- stop requiring Send + Sync on Psyche motor parameter

## Testing
- `cargo clippy --all-targets`
- `cargo test --workspace` *(aborted after multiple tests ran over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_6862b1309e0c8320aef5ad3b2dabc11e