### PR TITLE
Simplify round robin error

### DIFF
--- a/psyche-rs/src/round_robin_llm.rs
+++ b/psyche-rs/src/round_robin_llm.rs
@@ -71,9 +71,6 @@ impl LLMClient for RoundRobinLLM {
                 }
             }
         }
-        Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "all llm clients failed",
-        )))
+        Err(Box::new(std::io::Error::other("all llm clients failed")))
     }
 }


### PR DESCRIPTION
## Summary
- use `Error::other` for the fallback error in `RoundRobinLLM`

## Testing
- `cargo test -p psyche-rs --lib` *(fails: hung)*

------
https://chatgpt.com/codex/tasks/task_e_6862b1370f9c8320a3648dc029eaca93