### PR TITLE
Fix clippy issues in will and sensation

### DIFF
--- a/psyche-rs/src/sensation.rs
+++ b/psyche-rs/src/sensation.rs
@@ -57,10 +57,10 @@ mod local_time_format {
     {
         let s = String::deserialize(de)?;
         let naive = NaiveDateTime::parse_from_str(&s, FORMAT).map_err(serde::de::Error::custom)?;
-        Ok(Local
+        Local
             .from_local_datetime(&naive)
             .single()
-            .ok_or_else(|| serde::de::Error::custom("invalid local time"))?)
+            .ok_or_else(|| serde::de::Error::custom("invalid local time"))
     }
 }
 

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -22,7 +22,7 @@ const DEFAULT_PROMPT: &str = include_str!("prompts/will_prompt.txt");
 ///
 /// If `max_bytes` does not land on a char boundary, the prefix is truncated to
 /// the previous valid boundary and a warning is emitted.
-pub fn safe_prefix<'a>(s: &'a str, max_bytes: usize) -> &'a str {
+pub fn safe_prefix(s: &str, max_bytes: usize) -> &str {
     if let Some(slice) = s.get(..max_bytes) {
         return slice;
     }
@@ -165,6 +165,7 @@ impl<T> Will<T> {
         UnboundedReceiverStream::new(rx).boxed()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn spawn_runtime<S>(
         llm: Arc<dyn LLMClient>,
         template: String,

--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -138,6 +138,7 @@ where
         self.observe_inner(sensors, Some(abort)).await
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn spawn_runtime<S>(
         llm: Arc<dyn LLMClient>,
         template: String,


### PR DESCRIPTION
## Summary
- remove explicit lifetime from `safe_prefix`
- clean up `deserialize` in `sensation`
- silence clippy `too_many_arguments` for runtime helpers

## Testing
- `cargo clippy -p psyche-rs -- -D warnings`
- `cargo test` *(failed: terminated due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6862d8c4b11c832097cfa27c6bb5535f