### PR TITLE
Add PlainDescribe trait and use in LLM prompts

### DIFF
--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -13,6 +13,7 @@ mod memory_store;
 mod motor;
 mod neo_qdrant_store;
 mod ollama_llm;
+mod plain_describe;
 mod psyche;
 mod psyche_event;
 mod round_robin_llm;
@@ -41,6 +42,7 @@ pub use motor::{
     SensorDirectingMotor,
 };
 pub use neo_qdrant_store::NeoQdrantMemoryStore;
+pub use plain_describe::PlainDescribe;
 pub use psyche::Psyche;
 pub use round_robin_llm::RoundRobinLLM;
 pub use sensation::Sensation;

--- a/psyche-rs/src/plain_describe.rs
+++ b/psyche-rs/src/plain_describe.rs
@@ -1,0 +1,48 @@
+use serde::Serialize;
+
+use crate::{Sensation, text_util::to_plain_text};
+
+/// Trait for converting types to a plain text representation.
+///
+/// This is used when building prompts for language models so that
+/// structured data can be embedded as readable text.
+///
+/// # Examples
+///
+/// ```
+/// use chrono::Local;
+/// use psyche_rs::{Sensation, PlainDescribe};
+///
+/// let s = Sensation { kind: "utterance.text".into(), when: Local::now(), what: "hello".into(), source: None };
+/// assert_eq!(s.to_plain(), "hello");
+/// ```
+pub trait PlainDescribe {
+    /// Convert the type to plain text.
+    fn to_plain(&self) -> String;
+}
+
+impl<T> PlainDescribe for Sensation<T>
+where
+    T: Serialize,
+{
+    fn to_plain(&self) -> String {
+        to_plain_text(&self.what)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Local;
+
+    #[test]
+    fn converts_sensation_payload() {
+        let s = Sensation {
+            kind: "utterance".into(),
+            when: Local::now(),
+            what: "hi".to_string(),
+            source: None,
+        };
+        assert_eq!(s.to_plain(), "hi");
+    }
+}

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error, trace, warn};
 use regex::Regex;
 
 use crate::llm_client::LLMClient;
-use crate::{Action, Intention, Motor, Sensation, Sensor};
+use crate::{Action, Intention, Motor, PlainDescribe, Sensation, Sensor};
 use ollama_rs::generation::chat::ChatMessage;
 use serde_json::{Map, Value};
 
@@ -230,7 +230,7 @@ impl<T> Will<T> {
                         let situation = snapshot
                             .iter()
                             .map(|s| {
-                                let what = serde_json::to_string(&s.what).unwrap_or_default();
+                                let what = s.to_plain();
                                 format!("{} {} {}", s.when.format("%Y-%m-%d %H:%M:%S"), s.kind, what)
                             })
                             .collect::<Vec<_>>()
@@ -246,7 +246,7 @@ impl<T> Will<T> {
                         let mut last_moment = String::new();
 
                         for s in &snapshot {
-                            let val = serde_json::to_string(&s.what).unwrap_or_default();
+                            let val = s.to_plain();
                             match s.kind.as_str() {
                                 "instant" => last_instant = val,
                                 "moment" => last_moment = val,

--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace};
 use rand::Rng;
 use segtok::segmenter::{SegmentConfig, split_single};
 
-use crate::{Impression, Sensation, Sensor};
+use crate::{Impression, PlainDescribe, Sensation, Sensor};
 
 use crate::llm_client::LLMClient;
 use ollama_rs::generation::chat::ChatMessage;
@@ -191,7 +191,7 @@ where
                         let timeline = snapshot
                             .iter()
                             .map(|s| {
-                                let what = serde_json::to_string(&s.what).unwrap_or_default();
+                                let what = s.to_plain();
                                 format!(
                                     "{} {} {}",
                                     s.when.format("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
## Summary
- add `PlainDescribe` trait with implementation for `Sensation<T>`
- use `PlainDescribe` in `Will` and `Wit` prompt building
- expose trait from crate
- add tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68632df94b588320a92c7fc1631c300a