### PR TITLE
Share reqwest client across Ollama instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { version = "1", features = ["v4"] }
 [dev-dependencies]
 httpmock = "0.7.0"
 tokio = { version = "1", features = ["macros", "rt"] }
+url = "2"
 
 [features]
 canvas-motor = []


### PR DESCRIPTION
## Summary
- use a reqwest client with a larger idle connection pool
- construct Ollama clients using the shared client
- update tests to build Ollama with shared client
- add `url` dev dependency

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68633ffe526c8320abd47528cd660251