### PR TITLE
Share HTTP client across components

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -106,7 +106,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::new(RoundRobinLLM::new(clients))
     };
 
-    let mouth = Arc::new(Mouth::new(args.tts_url.clone(), args.language_id));
+    let mouth = Arc::new(Mouth::new(
+        http_client.clone(),
+        args.tts_url.clone(),
+        args.language_id,
+    ));
     let audio_rx = mouth.subscribe();
     let text_rx = mouth.subscribe_text();
     let segment_rx = mouth.subscribe_segments();


### PR DESCRIPTION
## Summary
- share a single reqwest::Client for all HTTP calls
- inject the client into `Mouth` and main
- update tests for new `Mouth::new` API

## Testing
- `cargo test --lib` *(fails: tests hang over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_6863c2eb02dc832098a05d13736b646e