### PR TITLE
Refactor timeline usage

### DIFF
--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -148,7 +148,7 @@ where
             let stream = wit.observe(sensors_for_wit).await;
             wit_streams.push(stream);
         }
-        let mut merged_wits = stream::select_all(wit_streams);
+        let merged_wits = stream::select_all(wit_streams);
 
         let will = self
             .will
@@ -163,7 +163,7 @@ where
             .map(|s| SharedSensor::new(s.clone()))
             .collect();
         let stream = will.observe(sensors_for_will).await;
-        let mut merged_wills = stream::select_all(vec![stream]);
+        let merged_wills = stream::select_all(vec![stream]);
 
         use crate::psyche_event::PsycheEvent;
         let mut merged = stream::select(

--- a/psyche-rs/src/template.rs
+++ b/psyche-rs/src/template.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn renders_variable() {
-        let out = render_template("Hello {{text}}", &Ctx { text: "world" }).unwrap();
+        let out = render_template("Hello {text}", &Ctx { text: "world" }).unwrap();
         assert_eq!(out, "Hello world");
     }
 }

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -227,14 +227,7 @@ impl<T> Will<T> {
 
                         trace!(snapshot_len = snapshot.len(), "Will captured snapshot");
 
-                        let situation = snapshot
-                            .iter()
-                            .map(|s| {
-                                let what = s.to_plain();
-                                format!("{} {} {}", s.when.format("%Y-%m-%d %H:%M:%S"), s.kind, what)
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n");
+                        let situation = crate::build_timeline(&window);
 
                         let motor_text = motors
                             .iter()

--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace};
 use rand::Rng;
 use segtok::segmenter::{SegmentConfig, split_single};
 
-use crate::{Impression, PlainDescribe, Sensation, Sensor, render_template};
+use crate::{Impression, Sensation, Sensor, render_template};
 
 use crate::llm_client::LLMClient;
 use ollama_rs::generation::chat::ChatMessage;
@@ -188,19 +188,7 @@ where
                             trace!("Wit skipping LLM call due to empty snapshot");
                             continue;
                         }
-                        let timeline = snapshot
-                            .iter()
-                            .map(|s| {
-                                let what = s.to_plain();
-                                format!(
-                                    "{} {} {}",
-                                    s.when.format("%Y-%m-%d %H:%M:%S"),
-                                    s.kind,
-                                    what
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n");
+                        let timeline = crate::build_timeline(&window);
                         let lf = { last_frame.lock().unwrap().clone() };
                         trace!(?timeline, "preparing prompt");
                         #[derive(serde::Serialize)]


### PR DESCRIPTION
## Summary
- remove unused mut from Psyche event streams
- build timelines via shared helper in Will & Wit
- fix TinyTemplate example

## Testing
- `cargo test -p psyche-rs timeline::tests::builds_sorted_deduped_timeline -- --exact`
- `cargo test -p psyche-rs plain_describe::tests::converts_sensation_payload -- --exact`
- `cargo test -p psyche-rs template::tests::renders_variable -- --exact`


------
https://chatgpt.com/codex/tasks/task_e_6863d37ff00883208bed4b3c611eb875