### PR TITLE
Fix webcam init

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -35,6 +35,7 @@ let canvasWs;
 let svgWs;
 let lookVideo;
 let lookCanvas;
+let lookStreamPromise = null;
 // Queues of audio PCM buffers and corresponding text waiting to be played.
 let queue = [];
 let texts = [];
@@ -46,6 +47,30 @@ function openSocket(existing, url, binaryType) {
   const s = new WebSocket(url);
   if (binaryType) s.binaryType = binaryType;
   return s;
+}
+
+// Start or resume the webcam, ensuring only one initialization at a time.
+function startVideo() {
+  if (!lookStreamPromise) {
+    lookStreamPromise = navigator.mediaDevices
+      .getUserMedia({ video: true })
+      .catch(e => {
+        lookStreamPromise = null;
+        throw e;
+      });
+  }
+  return lookStreamPromise.then(s => {
+    if (!lookVideo) {
+      lookVideo = document.createElement('video');
+      lookCanvas = document.getElementById('drawing-area');
+      lookVideo.srcObject = s;
+      const track = s.getVideoTracks()[0];
+      track.addEventListener('ended', () => {
+        lookStreamPromise = null;
+      });
+    }
+    if (lookVideo.paused) lookVideo.play();
+  });
 }
 
 function segmentDone() {
@@ -159,17 +184,15 @@ function start() {
     lookWs.onmessage = ev => {
       if (ev.data === 'snap') capture();
     };
-  navigator.mediaDevices.getUserMedia({ video: true }).then(s => {
-    lookVideo = document.createElement('video');
-    lookVideo.srcObject = s;
-    lookVideo.play();
-    lookCanvas = document.getElementById('drawing-area');
-  });
+  startVideo();
   document.getElementById('start').style.display = 'none';
 }
 
 function capture() {
-  if (!lookVideo) return;
+  if (!lookVideo || lookVideo.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA) {
+    startVideo().then(capture);
+    return;
+  }
   lookCanvas.width = lookVideo.videoWidth;
   lookCanvas.height = lookVideo.videoHeight;
   const ctx2d = lookCanvas.getContext('2d');

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -10,8 +10,8 @@ use futures::{StreamExt, stream};
 use ollama_rs::Ollama;
 use once_cell::sync::Lazy;
 use psyche_rs::{
-    Action, Combobulator, Impression, ImpressionStreamSensor, Intention, LLMClient, Motor,
-    OllamaLLM, RoundRobinLLM, Sensation, SensationSensor, Sensor, Will, Wit, shutdown_signal,
+    Combobulator, Impression, ImpressionStreamSensor, Intention, LLMClient, Motor, OllamaLLM,
+    RoundRobinLLM, Sensation, SensationSensor, Sensor, Will, Wit, shutdown_signal,
 };
 use reqwest::Client;
 use url::Url;
@@ -291,7 +291,7 @@ async fn drive_combo_stream(
     + Unpin
     + Send
     + 'static,
-    logger: Arc<LoggingMotor>,
+    _logger: Arc<LoggingMotor>,
     #[cfg(feature = "moment-feedback")] sens_tx: tokio::sync::mpsc::UnboundedSender<
         Vec<Sensation<String>>,
     >,
@@ -299,7 +299,7 @@ async fn drive_combo_stream(
 ) {
     use futures::StreamExt;
 
-    while let Some(imps) = combo_stream.next().await {
+    while let Some(_imps) = combo_stream.next().await {
         #[cfg(feature = "moment-feedback")]
         {
             let mut guard = moment.lock().await;

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -246,10 +246,11 @@ fn persist_impression<T: serde::Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Intention, LLMClient, LLMTokenStream};
+    use crate::Intention;
     use futures::{StreamExt, stream};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    #[allow(dead_code)]
     struct TestSensor;
     impl Sensor<String> for TestSensor {
         fn stream(&mut self) -> BoxStream<'static, Vec<Sensation<String>>> {
@@ -263,6 +264,7 @@ mod tests {
         }
     }
 
+    #[allow(dead_code)]
     struct CountMotor(Arc<AtomicUsize>);
     #[async_trait::async_trait]
     impl Motor for CountMotor {


### PR DESCRIPTION
## Summary
- initialize webcam only once and keep it alive
- silence unused parameter warnings
- clean up unused test imports

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68640d0198bc832086f9b96188a1ee48