### PR TITLE
Run each agent on its own LLM client

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,18 @@ Pete is not merely a robot, nor a chatbot. He is:
 
 ```bash
 cargo build --release
-cargo run -- --base-url http://localhost:11434 --tts-url http://localhost:5002
+cargo run -- \
+  --quick-url http://localhost:11434 \
+  --combob-url http://localhost:11434 \
+  --will-url http://localhost:11434 \
+  --tts-url http://localhost:5002
 ````
 
 Available options (see `main.rs`):
 
-* `--base-url`: One or more Ollama base URLs (default: `http://localhost:11434`)
+* `--quick-url`: Ollama URL for Quick (default: `http://localhost:11434`)
+* `--combob-url`: Ollama URL for Combobulator (default: `http://localhost:11434`)
+* `--will-url`: Ollama URL for Will (default: `http://localhost:11434`)
 * `--model`: LLM model (default: `gemma3:27b`)
 * `--tts-url`: Coqui TTS base URL (default: `http://localhost:5002`)
 * `--language-id`: Language identifier for TTS (optional)


### PR DESCRIPTION
## Summary
- split CLI config to pass URLs for Quick, Combobulator and Will
- construct separate HTTP clients and LLMs for each agent
- spawn Quick, Combobulator and Will loops independently
- add debug logs when each agent starts and finishes LLM calls
- document updated CLI options

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68640e82edb48320998d62ba2a8b8cee