### PR TITLE
Add LLMPool for distributed LLM access

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -11,7 +11,7 @@ use ollama_rs::Ollama;
 use once_cell::sync::Lazy;
 use psyche_rs::{
     Combobulator, Impression, ImpressionStreamSensor, Intention, LLMClient, Motor, OllamaLLM,
-    RoundRobinLLM, Sensation, SensationSensor, Sensor, Will, Wit, shutdown_signal,
+    Sensation, SensationSensor, Sensor, Will, Wit, shutdown_signal,
 };
 use reqwest::Client;
 use url::Url;

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8"
 anyhow = "1"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 uuid = { version = "1", features = ["v4"] }
+url = "2"
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -8,6 +8,7 @@ mod combobulator;
 mod fair_llm;
 mod impression;
 mod llm_client;
+mod llm_pool;
 mod memory_sensor;
 mod memory_store;
 mod motor;
@@ -37,6 +38,7 @@ pub use cluster_analyzer::ClusterAnalyzer;
 pub use combobulator::Combobulator;
 pub use fair_llm::FairLLM;
 pub use impression::Impression;
+pub use llm_pool::LLMPool;
 pub use memory_sensor::MemorySensor;
 pub use memory_store::{InMemoryStore, MemoryStore, StoredImpression, StoredSensation};
 pub use motor::{

--- a/psyche-rs/src/llm_client/tests.rs
+++ b/psyche-rs/src/llm_client/tests.rs
@@ -1,4 +1,4 @@
-use crate::{FairLLM, LLMClient, RoundRobinLLM, LLMTokenStream};
+use crate::{FairLLM, LLMClient, RoundRobinLLM, LLMTokenStream, LLMPool};
 use async_trait::async_trait;
 use futures::{StreamExt, stream};
 use ollama_rs::generation::chat::ChatMessage;
@@ -136,4 +136,31 @@ async fn fair_llm_processes_in_request_order() {
     });
     let _ = futures::join!(f1, f2);
     assert!(start.elapsed() >= std::time::Duration::from_millis(100));
+}
+#[tokio::test]
+async fn llm_pool_uses_round_robin_urls() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    #[derive(Clone)]
+    struct RecUrl {
+        id: usize,
+        log: Arc<Mutex<Vec<usize>>>,
+    }
+    #[async_trait::async_trait]
+    impl LLMClient for RecUrl {
+        async fn chat_stream(
+            &self,
+            _msgs: &[ChatMessage],
+        ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            self.log.lock().unwrap().push(self.id);
+            Ok(Box::pin(stream::empty()))
+        }
+    }
+    let c1 = Arc::new(RecUrl { id: 1, log: log.clone() });
+    let c2 = Arc::new(RecUrl { id: 2, log: log.clone() });
+    let pool = RoundRobinLLM::new(vec![c1.clone(), c2.clone()]);
+    let llm_pool = LLMPool::from_round_robin(pool);
+    llm_pool.chat_stream(&[]).await.unwrap().next().await;
+    llm_pool.chat_stream(&[]).await.unwrap().next().await;
+    let l = log.lock().unwrap();
+    assert_eq!(l.as_slice(), &[1, 2]);
 }

--- a/psyche-rs/src/llm_pool.rs
+++ b/psyche-rs/src/llm_pool.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::Client;
+use url::Url;
+
+use crate::{
+    OllamaLLM, RoundRobinLLM,
+    llm_client::{LLMClient, LLMTokenStream},
+};
+use ollama_rs::Ollama;
+use ollama_rs::generation::chat::ChatMessage;
+
+/// Pool of LLM backends identified by base URLs.
+///
+/// Each request is delegated to the next backend in round-robin order.
+/// This allows distributing load across multiple Ollama instances.
+///
+/// # Examples
+/// ```ignore
+/// let urls = vec!["http://localhost:11434".to_string()];
+/// let pool = LLMPool::new(urls, "llama");
+/// ```
+pub struct LLMPool {
+    inner: RoundRobinLLM,
+}
+
+impl LLMPool {
+    /// Create a new pool from base URLs and model name.
+    pub fn new(urls: Vec<String>, model: impl Into<String>) -> Self {
+        assert!(!urls.is_empty(), "LLM URLs cannot be empty");
+        let model = model.into();
+        let http = Client::builder()
+            .pool_max_idle_per_host(10)
+            .build()
+            .expect("http client");
+        let clients: Vec<Arc<dyn LLMClient>> = urls
+            .into_iter()
+            .map(|u| new_client(&http, &u, &model))
+            .collect();
+        Self {
+            inner: RoundRobinLLM::new(clients),
+        }
+    }
+
+    /// Create a pool from an existing [`RoundRobinLLM`]. Used in tests.
+    #[cfg(test)]
+    pub(crate) fn from_round_robin(inner: RoundRobinLLM) -> Self {
+        Self { inner }
+    }
+
+    /// Spawn a task that collects all tokens into a `String`.
+    pub async fn spawn_llm_task(
+        &self,
+        msgs: Vec<ChatMessage>,
+    ) -> tokio::task::JoinHandle<Result<String, Box<dyn std::error::Error + Send + Sync>>> {
+        let inner = self.inner.clone();
+        tokio::spawn(async move {
+            let mut stream = inner.chat_stream(&msgs).await?;
+            let mut out = String::new();
+            while let Some(tok) = stream.next().await {
+                out.push_str(&tok?);
+            }
+            Ok(out)
+        })
+    }
+
+    /// Stream tokens from the next backend.
+    pub async fn stream_llm_response(
+        &self,
+        msgs: &[ChatMessage],
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        self.inner.chat_stream(msgs).await
+    }
+}
+
+fn new_client(http: &Client, base: &str, model: &str) -> Arc<dyn LLMClient> {
+    let url = Url::parse(base).expect("invalid base url");
+    let host = format!("{}://{}", url.scheme(), url.host_str().expect("no host"));
+    let port = url.port_or_known_default().expect("no port");
+    let ollama = Ollama::new_with_client(host, port, http.clone());
+    Arc::new(OllamaLLM::new(ollama, model.to_string())) as Arc<dyn LLMClient>
+}
+
+#[async_trait]
+impl LLMClient for LLMPool {
+    async fn chat_stream(
+        &self,
+        msgs: &[ChatMessage],
+    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        self.inner.chat_stream(msgs).await
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LLMPool` for round-robin dispatch across multiple base URLs
- expose `LLMPool` from library
- add unit test for `LLMPool`
- fix unused import warning in `daringsby`
- add `url` to dependencies

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68642ea87ccc832085307cb435cace89