### PR TITLE
Fix webcam play error

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -24,6 +24,7 @@
 </form>
 <canvas id="drawing-area" class="container" width="640" height="480"></canvas>
 <audio id="audio-player" hidden></audio>
+<video id="look-video" hidden playsinline></video>
 <script>
 const SAMPLE_RATE = 22050;
 let audioEl;
@@ -61,15 +62,22 @@ function startVideo() {
   }
   return lookStreamPromise.then(s => {
     if (!lookVideo) {
-      lookVideo = document.createElement('video');
+      // Reuse the hidden video element so browsers keep the stream alive
+      lookVideo = document.getElementById('look-video');
       lookCanvas = document.getElementById('drawing-area');
       lookVideo.srcObject = s;
+      lookVideo.muted = true;
       const track = s.getVideoTracks()[0];
       track.addEventListener('ended', () => {
         lookStreamPromise = null;
       });
     }
-    if (lookVideo.paused) lookVideo.play();
+    if (lookVideo.paused) {
+      const playPromise = lookVideo.play();
+      if (playPromise !== undefined) {
+        playPromise.catch(e => console.error('video play error', e));
+      }
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- keep webcam video element in DOM
- play video via hidden element and handle play() errors

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68644f7bb38c8320afa9b712a8e63a7b