### PR TITLE
Throttle duplicate LLM snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,5 @@
 - Comment out or ignore tests that consistently hang for over 60s.
 - When spawning long-running tasks, keep the `JoinHandle` and abort it on
   shutdown to ensure HTTP connections close quickly.
+- When throttling duplicate Will snapshots, hash the serialized snapshot and
+  skip LLM calls within `min_llm_interval_ms`; ensure tests cover this logic.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,7 @@ dependencies = [
  "segtok",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tinytemplate",
  "tokio",
@@ -2416,6 +2417,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -22,6 +22,7 @@ tinytemplate = "1"
 thiserror = "1"
 regex = "1"
 rand = "0.8"
+sha2 = "0.10"
 anyhow = "1"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
## Summary
- skip LLM calls when Will receives the same snapshot
- expose `min_llm_interval_ms` to control throttle interval
- test duplicate snapshot throttling
- document the behavior in AGENTS notes

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686488dcf1248320a63f70d7bd2eca7b