### PR TITLE
Cache motor descriptions in Will

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,4 @@
   shutdown to ensure HTTP connections close quickly.
 - When throttling duplicate Will snapshots, hash the serialized snapshot and
   skip LLM calls within `min_llm_interval_ms`; ensure tests cover this logic.
+- Keep `WillRuntimeConfig` in sync with fields used by `Will` runtimes.


### PR DESCRIPTION
## Summary
- store precomputed motor description list on `Will`
- pass cached description into runtime instead of recomputing
- expose `motor_text` accessor
- ensure runtime config stays synced with `Will`
- test cached motor description updates on registration
- document runtime config sync requirement in AGENTS instructions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68648bdc02fc832080cf04876956616e