### PR TITLE
Integrate memory store into motor runtime

### DIFF
--- a/psyche-rs/src/memory_store.rs
+++ b/psyche-rs/src/memory_store.rs
@@ -91,6 +91,17 @@ impl InMemoryStore {
     }
 }
 
+#[cfg(test)]
+impl InMemoryStore {
+    pub fn sensation_count(&self) -> usize {
+        self.sensations.lock().unwrap().len()
+    }
+
+    pub fn impression_count(&self) -> usize {
+        self.impressions.lock().unwrap().len()
+    }
+}
+
 impl MemoryStore for InMemoryStore {
     fn store_sensation(&self, sensation: &StoredSensation) -> anyhow::Result<()> {
         self.sensations

--- a/psyche-rs/src/motor.rs
+++ b/psyche-rs/src/motor.rs
@@ -145,6 +145,15 @@ impl Serialize for Intention {
     }
 }
 
+impl std::fmt::Display for Intention {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_string(self) {
+            Ok(s) => write!(f, "{}", s),
+            Err(_) => Err(std::fmt::Error),
+        }
+    }
+}
+
 /// Metadata describing an interruption to an action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Interruption {

--- a/psyche-rs/src/motor_executor.rs
+++ b/psyche-rs/src/motor_executor.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 use tracing::{debug, warn};
 
-use crate::{AbortGuard, Intention, Motor};
+use crate::{AbortGuard, Intention, MemoryStore, Motor, StoredImpression, StoredSensation};
 
 /// Central dispatcher for motor intentions.
 ///
@@ -12,20 +12,28 @@ use crate::{AbortGuard, Intention, Motor};
 pub struct MotorExecutor {
     tx: mpsc::Sender<Intention>,
     _guards: Vec<AbortGuard>,
+    store: Option<Arc<dyn MemoryStore + Send + Sync>>,
 }
 
 impl MotorExecutor {
     /// Create a new executor with the provided motors, worker count and queue
-    /// capacity.
-    pub fn new(motors: Vec<Arc<dyn Motor + Send + Sync>>, workers: usize, capacity: usize) -> Self {
+    /// capacity. Provide a [`MemoryStore`] to persist intentions and sensations.
+    pub fn new(
+        motors: Vec<Arc<dyn Motor + Send + Sync>>,
+        workers: usize,
+        capacity: usize,
+        store: Option<Arc<dyn MemoryStore + Send + Sync>>,
+    ) -> Self {
         let (tx, rx) = mpsc::channel::<Intention>(capacity);
         let rx = Arc::new(Mutex::new(rx));
         let motors = Arc::new(motors);
+        let store = store.clone();
         let mut guards = Vec::new();
 
         for _ in 0..workers.max(1) {
             let motors = motors.clone();
             let rx = rx.clone();
+            let store = store.clone();
             let handle = tokio::spawn(async move {
                 loop {
                     let next = {
@@ -38,8 +46,43 @@ impl MotorExecutor {
                         motors.iter().find(|m| m.name() == intention.assigned_motor)
                     {
                         debug!(target_motor = %motor.name(), "Executing motor");
-                        if let Err(e) = motor.perform(intention).await {
-                            warn!(?e, "Motor action failed");
+
+                        if let Some(store) = &store {
+                            let stored_imp = StoredImpression {
+                                id: uuid::Uuid::new_v4().to_string(),
+                                kind: "Intention".into(),
+                                when: chrono::Utc::now(),
+                                how: intention.to_string(),
+                                sensation_ids: Vec::new(),
+                                impression_ids: Vec::new(),
+                            };
+                            if let Err(e) = store.store_impression(&stored_imp) {
+                                warn!(?e, "failed to store intention as impression");
+                            }
+                        }
+
+                        match motor.perform(intention).await {
+                            Ok(result) => {
+                                if let Some(store) = &store {
+                                    for s in result.sensations {
+                                        match serde_json::to_string(&s.what) {
+                                            Ok(data) => {
+                                                let stored = StoredSensation {
+                                                    id: uuid::Uuid::new_v4().to_string(),
+                                                    kind: s.kind.clone(),
+                                                    when: s.when.with_timezone(&chrono::Utc),
+                                                    data,
+                                                };
+                                                if let Err(e) = store.store_sensation(&stored) {
+                                                    warn!(?e, "failed to store motor sensation");
+                                                }
+                                            }
+                                            Err(e) => warn!(?e, "failed to serialize sensation"),
+                                        }
+                                    }
+                                }
+                            }
+                            Err(e) => warn!(?e, "Motor action failed"),
                         }
                     } else {
                         warn!(?intention, "No matching motor for intention");
@@ -52,6 +95,7 @@ impl MotorExecutor {
         Self {
             tx,
             _guards: guards,
+            store,
         }
     }
 
@@ -66,7 +110,7 @@ impl MotorExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Action, ActionResult, MotorError};
+    use crate::{Action, ActionResult, InMemoryStore, MotorError, Sensation};
     use futures::stream::{self, StreamExt};
     use serde_json::Value;
     use std::sync::{
@@ -100,13 +144,54 @@ mod tests {
         Intention::to(Action::new("count", Value::Null, body)).assign("count")
     }
 
+    fn sensing_intention() -> Intention {
+        let body = stream::empty().boxed();
+        Intention::to(Action::new("sense", Value::Null, body)).assign("sense")
+    }
+
     #[tokio::test]
     async fn dispatches_to_motor() {
         let counter = Arc::new(AtomicUsize::new(0));
         let motor = Arc::new(CountMotor(counter.clone()));
-        let executor = MotorExecutor::new(vec![motor], 1, 4);
+        let executor = MotorExecutor::new(vec![motor], 1, 4, None);
         executor.spawn_intention(sample_intention());
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    struct SensationMotor;
+
+    #[async_trait::async_trait]
+    impl Motor for SensationMotor {
+        fn description(&self) -> &'static str {
+            "sensates"
+        }
+        fn name(&self) -> &'static str {
+            "sense"
+        }
+        async fn perform(&self, _i: Intention) -> Result<ActionResult, MotorError> {
+            Ok(ActionResult {
+                sensations: vec![Sensation {
+                    kind: "test".into(),
+                    when: chrono::Local::now(),
+                    what: serde_json::Value::Null,
+                    source: None,
+                }],
+                completed: true,
+                completion: None,
+                interruption: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn stores_intentions_and_sensations() {
+        let store = Arc::new(InMemoryStore::new());
+        let motor = Arc::new(SensationMotor);
+        let executor = MotorExecutor::new(vec![motor], 1, 4, Some(store.clone()));
+        executor.spawn_intention(sensing_intention());
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(store.impression_count(), 1);
+        assert_eq!(store.sensation_count(), 1);
     }
 }

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -157,7 +157,7 @@ where
         for m in self.motors.iter() {
             will.register_motor(m.as_ref());
         }
-        let executor = crate::MotorExecutor::new(self.motors.clone(), 4, 16);
+        let executor = crate::MotorExecutor::new(self.motors.clone(), 4, 16, self.store.clone());
         let sensors_for_will: Vec<_> = self
             .sensors
             .iter()


### PR DESCRIPTION
## Summary
- store intentions as impressions when motors run
- persist motor-produced sensations
- expose count helpers in `InMemoryStore` for tests
- implement `Display` for `Intention`
- add test verifying persistence

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6864a02f8cbc8320b84db290398955ac