### PR TITLE
Add Ear sensor combining heard speech

### DIFF
--- a/daringsby/src/ear.rs
+++ b/daringsby/src/ear.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use futures::{
+    StreamExt,
+    stream::{BoxStream, select},
+};
+
+use crate::{HeardSelfSensor, HeardUserSensor, SpeechStream};
+use psyche_rs::{Sensation, Sensor};
+
+/// Sensor merging self and interlocutor speech.
+///
+/// The returned stream yields batches from either the self-heard or
+/// interlocutor-heard sensors as soon as they arrive.
+///
+/// # Examples
+/// ```ignore
+/// use daringsby::{Ear, SpeechStream, HeardSelfSensor, HeardUserSensor};
+/// use std::sync::Arc;
+/// # use tokio::sync::broadcast;
+/// # let (tx, rx) = broadcast::channel(1);
+/// # let (utx, urx) = broadcast::channel(1);
+/// # let stream = Arc::new(SpeechStream::new(rx, utx.subscribe(), urx));
+/// let mut ear = Ear::new(
+///     HeardSelfSensor::new(stream.subscribe_heard()),
+///     HeardUserSensor::new(stream.subscribe_user()),
+/// );
+/// let _stream = ear.stream();
+/// ```
+pub struct Ear {
+    self_sensor: HeardSelfSensor,
+    interlocutor_sensor: HeardUserSensor,
+}
+
+impl Ear {
+    /// Construct an [`Ear`] from the provided sensors.
+    pub fn new(self_sensor: HeardSelfSensor, interlocutor_sensor: HeardUserSensor) -> Self {
+        Self {
+            self_sensor,
+            interlocutor_sensor,
+        }
+    }
+
+    /// Build an [`Ear`] subscribing to the given [`SpeechStream`].
+    pub fn from_stream(stream: Arc<SpeechStream>) -> Self {
+        Self {
+            self_sensor: HeardSelfSensor::new(stream.subscribe_heard()),
+            interlocutor_sensor: HeardUserSensor::new(stream.subscribe_user()),
+        }
+    }
+}
+
+impl Sensor<String> for Ear {
+    fn stream(&mut self) -> BoxStream<'static, Vec<Sensation<String>>> {
+        let a = self.self_sensor.stream();
+        let b = self.interlocutor_sensor.stream();
+        select(a, b).boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use tokio::sync::broadcast;
+
+    #[tokio::test]
+    async fn forwards_both_sensors() {
+        let (self_tx, self_rx) = broadcast::channel(4);
+        let (user_tx, user_rx) = broadcast::channel(4);
+        let mut ear = Ear::new(HeardSelfSensor::new(self_rx), HeardUserSensor::new(user_rx));
+        self_tx.send("me".into()).unwrap();
+        user_tx.send("you".into()).unwrap();
+        drop(self_tx);
+        drop(user_tx);
+        let mut stream = ear.stream();
+        let mut heard = Vec::new();
+        while let Some(batch) = stream.next().await {
+            heard.extend(batch.into_iter().map(|s| s.what));
+        }
+        assert!(heard.iter().any(|t| t.contains("me")));
+        assert!(heard.iter().any(|t| t.contains("you")));
+    }
+}

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -4,6 +4,8 @@ pub mod canvas_motor;
 pub mod canvas_stream;
 #[cfg(feature = "development-status-sensor")]
 pub mod development_status;
+#[cfg(all(feature = "heard-self-sensor", feature = "heard-user-sensor"))]
+pub mod ear;
 #[cfg(feature = "heard-self-sensor")]
 pub mod heard_self_sensor;
 #[cfg(feature = "heard-user-sensor")]

--- a/daringsby/src/sensor_helpers.rs
+++ b/daringsby/src/sensor_helpers.rs
@@ -1,4 +1,4 @@
-use crate::{HeardSelfSensor, HeardUserSensor, Heartbeat, SpeechStream};
+use crate::{Ear, HeardSelfSensor, HeardUserSensor, Heartbeat, SpeechStream};
 use psyche_rs::Sensor;
 use std::sync::Arc;
 
@@ -9,4 +9,9 @@ pub fn build_sensors(stream: Arc<SpeechStream>) -> Vec<Box<dyn Sensor<String> + 
         Box::new(HeardSelfSensor::new(stream.subscribe_heard())) as Box<dyn Sensor<String> + Send>,
         Box::new(HeardUserSensor::new(stream.subscribe_user())) as Box<dyn Sensor<String> + Send>,
     ]
+}
+
+/// Build the [`Ear`] sensor combining heard self and user speech.
+pub fn build_ear(stream: Arc<SpeechStream>) -> Ear {
+    Ear::from_stream(stream)
 }

--- a/daringsby/src/sensors.rs
+++ b/daringsby/src/sensors.rs
@@ -6,6 +6,8 @@
 /// ```
 #[cfg(feature = "development-status-sensor")]
 pub use crate::development_status::DevelopmentStatus;
+#[cfg(all(feature = "heard-self-sensor", feature = "heard-user-sensor"))]
+pub use crate::ear::Ear;
 #[cfg(feature = "heard-self-sensor")]
 pub use crate::heard_self_sensor::HeardSelfSensor;
 #[cfg(feature = "heard-user-sensor")]


### PR DESCRIPTION
## Summary
- introduce `Ear` sensor merging `HeardSelfSensor` and `HeardUserSensor`
- export `Ear` and provide helper to build it

## Testing
- `cargo fmt`
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6864a88ec974832084af8ba49a0279fb