### PR TITLE
Log full LLM responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Run `cargo fmt` before committing changes.
 - Instrument code with tracing logs at appropriate levels.
 - Emit `trace` level logs for all LLM prompts and streaming token events.
+- Log the complete response from every LLM call at `debug` level.
 - When implementing test memory stores that persist `Memory::Of`, clone the inner
   value before saving to prevent panics when cloning.
 - Ensure every async call is awaited unless intentionally detached with

--- a/psyche-rs/src/cluster_analyzer.rs
+++ b/psyche-rs/src/cluster_analyzer.rs
@@ -84,6 +84,7 @@ impl<M: MemoryStore, C: LLMClient> ClusterAnalyzer<M, C> {
                 tracing::trace!(%tok, "summary_token");
                 out.push_str(&tok);
             }
+            tracing::debug!(%out, "llm full response");
             let summary = StoredImpression {
                 id: uuid::Uuid::new_v4().to_string(),
                 kind: "Summary".into(),

--- a/psyche-rs/src/fair_llm.rs
+++ b/psyche-rs/src/fair_llm.rs
@@ -97,6 +97,7 @@ where
         while let Some(tok) = stream.next().await {
             out.push_str(&tok?);
         }
+        tracing::debug!(%out, "llm full response");
         Ok(out)
     })
 }

--- a/psyche-rs/src/llm_client.rs
+++ b/psyche-rs/src/llm_client.rs
@@ -55,6 +55,7 @@ pub async fn spawn_llm_task(
         while let Some(tok) = stream.next().await {
             out.push_str(&tok?);
         }
+        tracing::debug!(%out, "llm full response");
         Ok(out)
     })
 }

--- a/psyche-rs/src/voice.rs
+++ b/psyche-rs/src/voice.rs
@@ -129,6 +129,7 @@ impl Voice {
                                 }
                             }
                             drop(tok_tx);
+                            debug!(agent=%name, %reply, "llm full response");
                             convo.lock().unwrap().push_assistant(&reply);
                         }
                         Err(e) => {

--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -234,6 +234,7 @@ where
                                     if text.trim().is_empty() {
                                         text = "No meaningful observation was made.".to_string();
                                     }
+                                    debug!(agent = %name_clone, %text, "llm full response");
                                     *last_frame_clone.lock().unwrap() = text.clone();
                                     let impressions: Vec<Impression<T>> = split_single(&text, SegmentConfig::default())
                                         .into_iter()


### PR DESCRIPTION
## Summary
- record entire LLM responses at debug level for easier troubleshooting
- document debug logging requirement for LLM results

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6864ab9ce8a08320b02036c183ce7e62