### PR TITLE
Implement streaming voice feedback

### DIFF
--- a/daringsby/src/heard_self_sensor.rs
+++ b/daringsby/src/heard_self_sensor.rs
@@ -48,7 +48,7 @@ impl Sensor<String> for HeardSelfSensor {
                     template.clone()
                 });
                 vec![Sensation {
-                    kind: "self_audio".into(),
+                    kind: "utterance.spoken".into(),
                     when: Local::now(),
                     what,
                     source: None,
@@ -74,7 +74,7 @@ mod tests {
         let mut stream = sensor.stream();
         let batch = stream.next().await.unwrap();
         assert_eq!(batch[0].what, "I heard myself say out loud: \"Hello\"");
-        assert_eq!(batch[0].kind, "self_audio");
+        assert_eq!(batch[0].kind, "utterance.spoken");
         assert!(batch[0].when >= start && batch[0].when <= Local::now());
     }
 

--- a/psyche-rs/src/voice.rs
+++ b/psyche-rs/src/voice.rs
@@ -1,10 +1,15 @@
 use std::sync::{Arc, Mutex};
 
+use chrono::Local;
 use futures::{StreamExt, stream::BoxStream};
-use tokio::sync::mpsc::unbounded_channel;
+use segtok::segmenter::{SegmentConfig, split_single};
+use serde_json::Value;
+use std::collections::VecDeque;
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace, warn};
 
+use crate::Action;
 use crate::conversation::Conversation;
 use crate::{
     Intention, Sensation, Sensor,
@@ -24,6 +29,7 @@ pub struct Voice {
     conversation: Arc<Mutex<Conversation>>,
     delay_ms: u64,
     system_prompt: String,
+    quick_tx: Option<UnboundedSender<Vec<Sensation<String>>>>,
 }
 
 impl Voice {
@@ -35,6 +41,7 @@ impl Voice {
             conversation: Arc::new(Mutex::new(Conversation::new(max_tail_len))),
             delay_ms: 500,
             system_prompt: DEFAULT_PROMPT.to_string(),
+            quick_tx: None,
         }
     }
 
@@ -56,6 +63,12 @@ impl Voice {
         self
     }
 
+    /// Channel used to send planned utterances to Quick.
+    pub fn quick_tx(mut self, tx: UnboundedSender<Vec<Sensation<String>>>) -> Self {
+        self.quick_tx = Some(tx);
+        self
+    }
+
     /// Observe the provided ear sensor and emit speech intentions.
     pub async fn observe(
         &self,
@@ -69,12 +82,21 @@ impl Voice {
         let name = self.name.clone();
         let prompt_tpl = self.system_prompt.clone();
         let delay = self.delay_ms;
+        let quick_tx = self.quick_tx.clone();
         tokio::spawn(async move {
             let mut stream = ear.stream();
             let window: Arc<Mutex<Vec<Sensation<serde_json::Value>>>> =
                 Arc::new(Mutex::new(Vec::new()));
+            let mut pending: VecDeque<String> = VecDeque::new();
             while let Some(batch) = stream.next().await {
                 for s in batch {
+                    if s.kind == "utterance.spoken" {
+                        if let Some(sent) = pending.pop_front() {
+                            convo.lock().unwrap().push_assistant(&sent);
+                        }
+                        continue;
+                    }
+
                     convo.lock().unwrap().push_user(&s.what);
                     let situation = (get_situation)();
                     let instant = (get_instant)();
@@ -114,13 +136,48 @@ impl Voice {
                                 .await;
                             });
 
-                            let mut reply = String::new();
+                            let mut buf = String::new();
                             while let Some(tok) = llm_stream.next().await {
                                 match tok {
                                     Ok(t) => {
                                         trace!(agent=%name, %t, "voice llm token");
-                                        reply.push_str(&t);
+                                        if !t.contains('<') && !t.contains('>') {
+                                            buf.push_str(&t);
+                                        }
                                         let _ = tok_tx.send(Ok(t));
+
+                                        let mut sents =
+                                            split_single(&buf, SegmentConfig::default());
+                                        if let Some(last) = sents.last() {
+                                            if !last.trim_end().ends_with(['.', '!', '?']) {
+                                                buf = last.clone();
+                                                sents.pop();
+                                            } else {
+                                                buf.clear();
+                                            }
+                                        }
+                                        for sent in sents {
+                                            pending.push_back(sent.clone());
+                                            let text = sent.clone();
+                                            let body_text = text.clone();
+                                            let body =
+                                                futures::stream::once(async move { body_text })
+                                                    .boxed();
+                                            let action = Action::new("say", Value::Null, body);
+                                            let intent = Intention::to(action).assign("say");
+                                            let _ = tx.send(vec![intent]);
+                                            if let Some(qtx) = &quick_tx {
+                                                let sens = Sensation {
+                                                    kind: "utterance.planned".into(),
+                                                    when: Local::now(),
+                                                    what: format!(
+                                                        "I feel myself starting to say: '{text}'"
+                                                    ),
+                                                    source: None,
+                                                };
+                                                let _ = qtx.send(vec![sens]);
+                                            }
+                                        }
                                     }
                                     Err(e) => {
                                         warn!(?e, "llm token error");
@@ -128,8 +185,26 @@ impl Voice {
                                     }
                                 }
                             }
+                            if !buf.trim().is_empty() {
+                                let sent = buf.trim().to_string();
+                                pending.push_back(sent.clone());
+                                let text = sent.clone();
+                                let body_text = text.clone();
+                                let body = futures::stream::once(async move { body_text }).boxed();
+                                let action = Action::new("say", Value::Null, body);
+                                let intent = Intention::to(action).assign("say");
+                                let _ = tx.send(vec![intent]);
+                                if let Some(qtx) = &quick_tx {
+                                    let sens = Sensation {
+                                        kind: "utterance.planned".into(),
+                                        when: Local::now(),
+                                        what: format!("I feel myself starting to say: '{text}'"),
+                                        source: None,
+                                    };
+                                    let _ = qtx.send(vec![sens]);
+                                }
+                            }
                             drop(tok_tx);
-                            convo.lock().unwrap().push_assistant(&reply);
                         }
                         Err(e) => {
                             warn!(?e, "voice llm failed");
@@ -174,5 +249,19 @@ mod tests {
         let batch = stream.next().await.unwrap();
         assert!(!batch.is_empty());
         assert_eq!(batch[0].assigned_motor, "say");
+    }
+
+    #[tokio::test]
+    async fn streams_sentences() {
+        let llm = Arc::new(StaticLLM::new("Hello there. How are you?"));
+        let voice = Voice::new(llm, 5).delay_ms(10);
+        let ear = TestEar;
+        let get_situation = Arc::new(|| "".to_string());
+        let get_instant = Arc::new(|| "".to_string());
+        let mut stream = voice.observe(ear, get_situation, get_instant).await;
+        let a = stream.next().await.unwrap();
+        let b = stream.next().await.unwrap();
+        assert_eq!(a[0].assigned_motor, "say");
+        assert_eq!(b[0].assigned_motor, "say");
     }
 }


### PR DESCRIPTION
## Summary
- emit `utterance.spoken` from `HeardSelfSensor`
- stream LLM replies sentence by sentence in `Voice`
- send planned speech to Quick
- produce `say` intentions for each sentence

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6864aa8d4b448320af6daa93997342aa