### PR TITLE
Support multiple base LLM URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,13 @@ Pete is not merely a robot, nor a chatbot. He is:
 ```bash
 cargo build --release
 cargo run -- \
-  --quick-url http://localhost:11434 \
-  --combob-url http://localhost:11434 \
-  --will-url http://localhost:11434 \
+  --base-url http://localhost:11434 \
   --tts-url http://localhost:5002
 ````
 
 Available options (see `main.rs`):
 
-* `--quick-url`: Ollama URL for Quick (default: `http://localhost:11434`)
-* `--combob-url`: Ollama URL for Combobulator (default: `http://localhost:11434`)
-* `--will-url`: Ollama URL for Will (default: `http://localhost:11434`)
+* `--base-url`: Ollama base URL. Repeat to add more servers (default: `http://localhost:11434`)
 * `--quick-model`: Model used for Quick tasks (default: `gemma3:27b`)
 * `--combob-model`: Model used for Combobulator tasks (default: `gemma3:27b`)
 * `--will-model`: Model used for Will tasks (default: `gemma3:27b`)

--- a/daringsby/src/args.rs
+++ b/daringsby/src/args.rs
@@ -3,12 +3,12 @@ use clap::Parser;
 /// Command line arguments for the daringsby binary.
 #[derive(Parser, Clone)]
 pub struct Args {
-    #[arg(long = "quick-url", default_value = "http://localhost:11434")]
-    pub quick_url: String,
-    #[arg(long = "combob-url", default_value = "http://localhost:11434")]
-    pub combob_url: String,
-    #[arg(long = "will-url", default_value = "http://localhost:11434")]
-    pub will_url: String,
+    /// Base URLs of Ollama servers used by all LLM tasks.
+    ///
+    /// Specify this flag multiple times to add more servers. If omitted,
+    /// `http://localhost:11434` is used.
+    #[arg(long = "base-url", num_args(1..), default_value = "http://localhost:11434")]
+    pub base_url: Vec<String>,
     #[arg(long = "quick-model", default_value = "gemma3:27b")]
     pub quick_model: String,
     #[arg(long = "combob-model", default_value = "gemma3:27b")]

--- a/daringsby/src/heard_self_sensor.rs
+++ b/daringsby/src/heard_self_sensor.rs
@@ -48,6 +48,7 @@ impl Sensor<String> for HeardSelfSensor {
                     template.clone()
                 });
                 vec![Sensation {
+                    kind: "self_audio".into(),
                     when: Local::now(),
                     what,
                     source: None,

--- a/daringsby/src/llm_helpers.rs
+++ b/daringsby/src/llm_helpers.rs
@@ -1,5 +1,5 @@
 use crate::args::Args;
-use psyche_rs::{LLMClient, OllamaLLM};
+use psyche_rs::{FairLLM, LLMClient, OllamaLLM, RoundRobinLLM};
 use reqwest::Client;
 use std::sync::Arc;
 use url::Url;
@@ -11,6 +11,22 @@ fn build_ollama(client: &Client, base: &str) -> ollama_rs::Ollama {
     ollama_rs::Ollama::new_with_client(host, port, client.clone())
 }
 
+fn build_pool(base_urls: &[String], model: &str) -> Arc<dyn LLMClient> {
+    let clients: Vec<Arc<dyn LLMClient>> = base_urls
+        .iter()
+        .map(|base| {
+            let http = Client::builder()
+                .pool_max_idle_per_host(10)
+                .build()
+                .expect("ollama http client");
+            Arc::new(OllamaLLM::new(build_ollama(&http, base), model.to_string()))
+                as Arc<dyn LLMClient>
+        })
+        .collect();
+    let rr = RoundRobinLLM::new(clients);
+    Arc::new(FairLLM::new(rr, base_urls.len())) as Arc<dyn LLMClient>
+}
+
 /// Build all Ollama LLM clients.
 pub fn build_ollama_clients(
     args: &Args,
@@ -20,35 +36,10 @@ pub fn build_ollama_clients(
     Arc<dyn LLMClient>,
     Arc<dyn LLMClient>,
 ) {
-    let quick_http = Client::builder()
-        .pool_max_idle_per_host(10)
-        .build()
-        .expect("quick http client");
-    let combob_http = Client::builder()
-        .pool_max_idle_per_host(10)
-        .build()
-        .expect("combob http client");
-    let will_http = Client::builder()
-        .pool_max_idle_per_host(10)
-        .build()
-        .expect("will http client");
-
-    let quick_llm: Arc<dyn LLMClient> = Arc::new(OllamaLLM::new(
-        build_ollama(&quick_http, &args.quick_url),
-        args.quick_model.clone(),
-    ));
-    let combob_llm: Arc<dyn LLMClient> = Arc::new(OllamaLLM::new(
-        build_ollama(&combob_http, &args.combob_url),
-        args.combob_model.clone(),
-    ));
-    let will_llm: Arc<dyn LLMClient> = Arc::new(OllamaLLM::new(
-        build_ollama(&will_http, &args.will_url),
-        args.will_model.clone(),
-    ));
-    let memory_llm: Arc<dyn LLMClient> = Arc::new(OllamaLLM::new(
-        build_ollama(&quick_http, &args.quick_url),
-        args.memory_model.clone(),
-    ));
+    let quick_llm = build_pool(&args.base_url, &args.quick_model);
+    let combob_llm = build_pool(&args.base_url, &args.combob_model);
+    let will_llm = build_pool(&args.base_url, &args.will_model);
+    let memory_llm = build_pool(&args.base_url, &args.memory_model);
 
     (quick_llm, combob_llm, will_llm, memory_llm)
 }

--- a/daringsby/tests/args.rs
+++ b/daringsby/tests/args.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+use daringsby::args::Args;
+
+#[test]
+fn parse_multiple_base_urls_collects_all_values() {
+    let args = Args::parse_from([
+        "test",
+        "--base-url",
+        "http://one",
+        "--base-url",
+        "http://two",
+    ]);
+    assert_eq!(
+        args.base_url,
+        vec!["http://one".to_string(), "http://two".to_string()]
+    );
+}
+
+#[test]
+fn default_base_url_is_localhost() {
+    let args = Args::parse_from(["test"]);
+    assert_eq!(args.base_url, vec!["http://localhost:11434".to_string()]);
+}

--- a/psyche-rs/src/voice.rs
+++ b/psyche-rs/src/voice.rs
@@ -205,8 +205,8 @@ impl Voice {
                                 }
                             }
                             drop(tok_tx);
-                            debug!(agent=%name, %reply, "llm full response");
-                            convo.lock().unwrap().push_assistant(&reply);
+                            debug!(agent=%name, text=%buf, "llm full response");
+                            convo.lock().unwrap().push_assistant(&buf);
                         }
                         Err(e) => {
                             warn!(?e, "voice llm failed");


### PR DESCRIPTION
## Summary
- allow specifying `--base-url` multiple times
- create LLM pools from the base URLs
- update README and tests
- fix a few compile warnings

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6864af14336c8320b4744ed5fdfa28b9