### PR TITLE
Enable parallel LLM agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Use `httpmock` for HTTP-based tests to avoid external network dependencies.
 - Keep `.rs` files focused. Create a new source file for each new type and split
   large modules like `lib.rs` into smaller pieces.
+- Provide mutable `set_*` variants when adding builder methods to wrappers.
 - Use the `LLMClient` trait for streaming LLM interactions.
 - Avoid streaming silence frames when audio is not playing.
 - Format `Impression` values using their `how` string when included in prompts

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -114,16 +114,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sensors = build_sensors(stream.clone());
     let ear = build_ear(stream.clone());
-    let voice =
-        Voice::new(llms.quick.clone(), 10).system_prompt(include_str!("prompts/voice_prompt.txt"));
+    let voice = Voice::new(llms.quick.clone(), 10)
+        .name("Voice")
+        .system_prompt(include_str!("prompts/voice_prompt.txt"));
 
     let (instant_tx, instant_rx) = unbounded_channel();
-    let quick = Wit::new(llms.quick.clone()).prompt(include_str!("prompts/quick_prompt.txt"));
+    let quick = Wit::new(llms.quick.clone())
+        .name("Quick")
+        .prompt(include_str!("prompts/quick_prompt.txt"));
     let quick_task = tokio::spawn(run_quick(quick, sensors, instant_tx, store.clone()));
 
     let quick_sensor = ImpressionStreamSensor::new(instant_rx);
     let (situ_tx, situ_rx) = unbounded_channel();
     let combob = Combobulator::new(llms.combob.clone())
+        .name("Combobulator")
         .prompt(include_str!("prompts/combobulator_prompt.txt"));
     let combob_task = tokio::spawn(run_combobulator(
         combob,
@@ -133,7 +137,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     let combo_sensor = ImpressionStreamSensor::new(situ_rx);
-    let mut will = Will::new(llms.will.clone()).prompt(include_str!("prompts/will_prompt.txt"));
+    let will = Will::new(llms.will.clone())
+        .name("Will")
+        .prompt(include_str!("prompts/will_prompt.txt"));
     let window = will.window_arc();
     let latest = will.latest_instant_arc();
     let will_task = tokio::spawn(run_will(

--- a/psyche-rs/src/combobulator.rs
+++ b/psyche-rs/src/combobulator.rs
@@ -37,6 +37,12 @@ impl<T> Combobulator<T> {
         }
     }
 
+    /// Sets the agent name used for logging.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.wit = self.wit.name(name);
+        self
+    }
+
     /// Overrides the prompt template.
     pub fn prompt(mut self, template: impl Into<String>) -> Self {
         self.wit = self.wit.prompt(template);
@@ -76,6 +82,12 @@ impl<T: Clone> Combobulator<T> {
     /// Mutable variant of [`prompt`].
     pub fn set_prompt(&mut self, template: impl Into<String>) -> &mut Self {
         self.wit = self.wit.clone().prompt(template);
+        self
+    }
+
+    /// Mutable variant of [`name`].
+    pub fn set_name(&mut self, name: impl Into<String>) -> &mut Self {
+        self.wit = self.wit.clone().name(name);
         self
     }
 

--- a/psyche-rs/src/voice.rs
+++ b/psyche-rs/src/voice.rs
@@ -115,7 +115,7 @@ impl Voice {
                     trace!(agent=%name, %system_prompt, "voice system prompt");
                     let mut msgs = convo.lock().unwrap().tail();
                     msgs.insert(0, ChatMessage::system(system_prompt));
-                    debug!(agent=%name, "Voice LLM call started");
+                    debug!(agent=%name, "LLM request START");
                     match llm.chat_stream(&msgs).await {
                         Ok(mut llm_stream) => {
                             let (tok_tx, tok_rx) = unbounded_channel();

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -449,7 +449,7 @@ impl<T> Will<T> {
                         let name_clone = name.clone();
                         if let Some(h) = llm_handle.take() { drop(h); }
                         llm_handle = Some(AbortGuard::new(tokio::spawn(async move {
-                            debug!(agent = %name_clone, "LLM call started");
+                            debug!(agent = %name_clone, "LLM request START");
                             match llm_clone.chat_stream(&msgs).await {
                                 Ok(stream) => {
                                     crate::llm_parser::drive_llm_stream(

--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -223,7 +223,7 @@ where
                         let last_frame_clone = last_frame.clone();
                         let name_clone = name.clone();
                         tokio::spawn(async move {
-                            debug!(agent = %name_clone, "LLM call started");
+                            debug!(agent = %name_clone, "LLM request START");
                             match llm_clone.chat_stream(&msgs).await {
                                 Ok(mut stream) => {
                                     let mut text = String::new();


### PR DESCRIPTION
## Summary
- allow builder methods on wrappers to have `set_*` variants
- log LLM request start consistently
- label Quick, Combobulator, Will, and Voice agents
- expose name setters on `Combobulator`

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6864bb4181048320be8dc76033316537