### PR TITLE
Log voice prompt messages

### DIFF
--- a/psyche-rs/src/voice.rs
+++ b/psyche-rs/src/voice.rs
@@ -115,6 +115,7 @@ impl Voice {
                     trace!(agent=%name, %system_prompt, "voice system prompt");
                     let mut msgs = convo.lock().unwrap().tail();
                     msgs.insert(0, ChatMessage::system(system_prompt));
+                    trace!(agent=%name, ?msgs, "voice llm messages");
                     debug!(agent=%name, "LLM request START");
                     match llm.chat_stream(&msgs).await {
                         Ok(mut llm_stream) => {


### PR DESCRIPTION
## Summary
- add trace logging for full chat messages before LLM request

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6865874b1a2c83209330f304c7f6cccb