### PR TITLE
Log full LLM text for Will

### DIFF
--- a/psyche-rs/src/llm_parser.rs
+++ b/psyche-rs/src/llm_parser.rs
@@ -64,7 +64,8 @@ pub async fn drive_llm_stream<T>(
     }
 
     flush_pending(&mut pending_text, &window, &thoughts_tx);
-    debug!(agent = %name, %full_text, "LLM call ended");
+    debug!(agent = %name, %full_text, "llm full response");
+    debug!(agent = %name, "LLM call ended");
     trace!("will llm stream finished");
 }
 


### PR DESCRIPTION
## Summary
- ensure Will LLM output is logged in full like Wit

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6865dc6082788320ac694da2d5e09bc6