### PR TITLE
Randomize LLM temperature

### DIFF
--- a/psyche-rs/src/ollama_llm.rs
+++ b/psyche-rs/src/ollama_llm.rs
@@ -4,11 +4,17 @@ use futures::TryStreamExt;
 use ollama_rs::{
     Ollama,
     generation::chat::{ChatMessage, ChatMessageResponseStream, request::ChatMessageRequest},
+    models::ModelOptions,
 };
+use rand::Rng;
 
 /// Build a chat request for the given model and messages.
 fn build_request(model: &str, messages: &[ChatMessage]) -> ChatMessageRequest {
+    let mut rng = rand::thread_rng();
+    let temperature = rng.gen_range(0.5..=1.0);
+    tracing::trace!(%temperature, "llm temperature");
     ChatMessageRequest::new(model.to_string(), messages.to_vec())
+        .options(ModelOptions::default().temperature(temperature))
 }
 
 /// Map an Ollama response stream into an [`LLMTokenStream`].


### PR DESCRIPTION
## Summary
- generate a random temperature for Ollama LLM requests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6865dd15b1ec8320826bb57c8b0413e0