### PR TITLE
Swap in NeoQdrant memory store

### DIFF
--- a/daringsby/src/args.rs
+++ b/daringsby/src/args.rs
@@ -17,6 +17,14 @@ pub struct Args {
     pub will_model: String,
     #[arg(long = "memory-model", default_value = "gemma3:27b")]
     pub memory_model: String,
+    #[arg(long, default_value = "http://localhost:7474")]
+    pub neo4j_url: String,
+    #[arg(long, default_value = "neo4j")]
+    pub neo4j_user: String,
+    #[arg(long, default_value = "password")]
+    pub neo4j_pass: String,
+    #[arg(long, default_value = "http://localhost:6333")]
+    pub qdrant_url: String,
     #[arg(long, default_value = "0.0.0.0")]
     pub host: String,
     #[arg(long, default_value_t = 3000)]

--- a/daringsby/src/canvas_motor.rs
+++ b/daringsby/src/canvas_motor.rs
@@ -33,6 +33,12 @@ use crate::canvas_stream::CanvasStream;
 ///             let stream = async_stream::stream! { yield Ok(String::new()) };
 ///             Ok(Box::pin(stream))
 ///         }
+///         async fn embed(
+///             &self,
+///             _text: &str,
+///         ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+///             Ok(vec![0.0])
+///         }
 ///     }
 ///     let llm = Arc::new(DummyLLM);
 ///     let (tx, _rx) = unbounded_channel();

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -16,8 +16,8 @@ use futures::StreamExt;
 use futures::stream::BoxStream;
 use psyche_rs::MemoryStore;
 use psyche_rs::{
-    Combobulator, Impression, ImpressionStreamSensor, InMemoryStore, Motor, MotorExecutor, Sensor,
-    Voice, Will, Wit, shutdown_signal,
+    Combobulator, Impression, ImpressionStreamSensor, Motor, MotorExecutor, NeoQdrantMemoryStore,
+    Sensor, Voice, Will, Wit, shutdown_signal,
 };
 use tokio::sync::mpsc::unbounded_channel;
 
@@ -92,7 +92,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let canvas = Arc::new(CanvasStream::default());
     let server_handle = run_server(stream.clone(), vision.clone(), canvas.clone(), &args).await;
 
-    let store = Arc::new(InMemoryStore::new());
+    let store = Arc::new(NeoQdrantMemoryStore::new(
+        &args.neo4j_url,
+        &args.neo4j_user,
+        &args.neo4j_pass,
+        &args.qdrant_url,
+        llms.memory.clone(),
+    ));
     let (motors, _motor_map) = build_motors(
         &llms,
         mouth.clone(),

--- a/daringsby/src/motor_helpers.rs
+++ b/daringsby/src/motor_helpers.rs
@@ -2,7 +2,7 @@ use crate::{
     CanvasMotor, CanvasStream, LogMemoryMotor, LoggingMotor, Mouth, RecallMotor, SourceReadMotor,
     SourceSearchMotor, SourceTreeMotor, SvgMotor, VisionMotor, VisionSensor,
 };
-use psyche_rs::{InMemoryStore, LLMClient, Motor, Sensation};
+use psyche_rs::{LLMClient, MemoryStore, Motor, Sensation};
 use std::{collections::HashMap, sync::Arc};
 
 /// Container for the four LLM clients used by Daringsby.
@@ -21,7 +21,7 @@ pub fn build_motors(
     mouth: Arc<Mouth>,
     vision: Arc<VisionSensor>,
     canvas: Arc<CanvasStream>,
-    store: Arc<InMemoryStore>,
+    store: Arc<dyn MemoryStore + Send + Sync>,
 ) -> (Vec<Arc<dyn Motor>>, Arc<HashMap<String, Arc<dyn Motor>>>) {
     use tokio::sync::mpsc::unbounded_channel;
 

--- a/daringsby/tests/canvas_motor.rs
+++ b/daringsby/tests/canvas_motor.rs
@@ -18,6 +18,13 @@ impl LLMClient for DummyLLM {
         };
         Ok(Box::pin(stream))
     }
+
+    async fn embed(
+        &self,
+        _text: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(vec![0.0])
+    }
 }
 
 #[tokio::test]

--- a/daringsby/tests/vision_motor.rs
+++ b/daringsby/tests/vision_motor.rs
@@ -16,6 +16,13 @@ impl LLMClient for DummyLLM {
         };
         Ok(Box::pin(stream))
     }
+
+    async fn embed(
+        &self,
+        _text: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(vec![0.0])
+    }
 }
 
 #[tokio::test]

--- a/psyche-rs/src/cluster_analyzer.rs
+++ b/psyche-rs/src/cluster_analyzer.rs
@@ -24,6 +24,12 @@ use std::sync::Arc;
 ///         let stream = futures::stream::once(async { Ok("echo".to_string()) });
 ///         Ok(Box::pin(stream))
 ///     }
+///     async fn embed(
+///         &self,
+///         _t: &str,
+///     ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+///         Ok(vec![0.0])
+///     }
 /// }
 /// let store = InMemoryStore::new();
 /// let llm = Arc::new(EchoLLM);
@@ -121,6 +127,13 @@ mod tests {
         {
             let reply = self.reply.clone();
             Ok(Box::pin(stream::once(async move { Ok(reply) })))
+        }
+
+        async fn embed(
+            &self,
+            _text: &str,
+        ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+            Ok(vec![0.0])
         }
     }
 

--- a/psyche-rs/src/fair_llm.rs
+++ b/psyche-rs/src/fair_llm.rs
@@ -55,6 +55,19 @@ where
             }
         }
     }
+
+    async fn embed(
+        &self,
+        text: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+        let _permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("permit");
+        self.client.embed(text).await
+    }
 }
 
 /// Spawn a task that collects the entire response from a [`FairLLM`].
@@ -75,6 +88,12 @@ where
 ///         _msgs: &[ChatMessage],
 ///     ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
 ///         Ok(Box::pin(stream::once(async { Ok("hi".to_string()) })))
+///     }
+///     async fn embed(
+///         &self,
+///         _text: &str,
+///     ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+///         Ok(vec![0.0])
 ///     }
 /// }
 /// # tokio_test::block_on(async {

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -107,6 +107,13 @@ mod tests {
                     Ok("ping event".to_string())
                 })))
             }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
+            }
         }
 
         let llm = Arc::new(StaticLLM);
@@ -149,6 +156,13 @@ mod tests {
                 Ok(Box::pin(stream::once(async {
                     Ok("ping event".to_string())
                 })))
+            }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
             }
         }
 

--- a/psyche-rs/src/llm_client.rs
+++ b/psyche-rs/src/llm_client.rs
@@ -16,6 +16,10 @@ pub trait LLMClient: Send + Sync {
         &self,
         messages: &[ChatMessage],
     ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>>;
+
+    /// Generate an embedding vector for the provided text.
+    async fn embed(&self, text: &str)
+    -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>>;
 }
 
 /// Spawn a task that collects the entire response from `llm` into a `String`.
@@ -36,6 +40,12 @@ pub trait LLMClient: Send + Sync {
 ///         _: &[ChatMessage],
 ///     ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
 ///         Ok(Box::pin(stream::once(async { Ok("hello ".to_string()) })))
+///     }
+///     async fn embed(
+///         &self,
+///         _text: &str,
+///     ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+///         Ok(vec![0.0])
 ///     }
 /// }
 /// # tokio_test::block_on(async {

--- a/psyche-rs/src/llm_client/tests.rs
+++ b/psyche-rs/src/llm_client/tests.rs
@@ -19,6 +19,13 @@ impl LLMClient for RecordLLM {
         self.log.lock().unwrap().push(self.id);
         Ok(Box::pin(stream::empty()))
     }
+
+    async fn embed(
+        &self,
+        _text: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(vec![self.id as f32])
+    }
 }
 
 #[derive(Clone)]
@@ -30,6 +37,16 @@ impl LLMClient for FailingLLM {
         &self,
         _msgs: &[ChatMessage],
     ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "fail",
+        )))
+    }
+
+    async fn embed(
+        &self,
+        _text: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
         Err(Box::new(std::io::Error::new(
             std::io::ErrorKind::Other,
             "fail",
@@ -54,6 +71,14 @@ impl LLMClient for DelayLLM {
             Ok::<_, Box<dyn std::error::Error + Send + Sync>>("done".into())
         });
         Ok(Box::pin(s))
+    }
+
+    async fn embed(
+        &self,
+        _text: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+        tokio::time::sleep(std::time::Duration::from_millis(self.delay)).await;
+        Ok(vec![0.0])
     }
 }
 

--- a/psyche-rs/src/ollama_llm.rs
+++ b/psyche-rs/src/ollama_llm.rs
@@ -56,6 +56,21 @@ impl LLMClient for OllamaLLM {
         let stream = self.client.send_chat_messages_stream(req).await?;
         Ok(map_stream(stream))
     }
+
+    async fn embed(
+        &self,
+        text: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+        use ollama_rs::generation::embeddings::request::GenerateEmbeddingsRequest;
+        let res = self
+            .client
+            .generate_embeddings(GenerateEmbeddingsRequest::new(
+                self.model.clone(),
+                text.into(),
+            ))
+            .await?;
+        Ok(res.embeddings.into_iter().next().unwrap_or_default())
+    }
 }
 
 #[cfg(test)]

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -59,6 +59,12 @@ impl<T> Sensor<T> for SharedSensor<T> {
 ///     ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
 ///         Ok(Box::pin(stream::empty()))
 ///     }
+///     async fn embed(
+///         &self,
+///         _text: &str,
+///     ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+///         Ok(vec![0.0])
+///     }
 /// }
 /// struct DummySensor;
 /// impl Sensor<String> for DummySensor {
@@ -329,6 +335,13 @@ mod tests {
                 let tokens = vec!["<log>".to_string(), "hi".to_string(), "</log>".to_string()];
                 Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
             }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
+            }
         }
 
         let count = Arc::new(AtomicUsize::new(0));
@@ -358,6 +371,13 @@ mod tests {
                 use futures::stream;
                 let tokens = vec!["<log>".to_string(), "hi".to_string(), "</log>".to_string()];
                 Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
+            }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
             }
         }
 
@@ -398,6 +418,13 @@ mod tests {
                     "</log>".to_string(),
                 ];
                 Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
+            }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
             }
         }
 
@@ -472,6 +499,13 @@ mod tests {
                 ];
                 Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
             }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
+            }
         }
 
         struct DummySensor;
@@ -540,6 +574,13 @@ mod tests {
                 let toks = vec!["<a>".to_string(), "hi".to_string(), "</a>".to_string()];
                 Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
             }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
+            }
         }
 
         #[derive(Clone)]
@@ -554,6 +595,13 @@ mod tests {
                 use futures::stream;
                 let toks = vec!["<b>".to_string(), "bye".to_string(), "</b>".to_string()];
                 Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
+            }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
             }
         }
 
@@ -624,6 +672,14 @@ mod tests {
                 Ok(Box::pin(stream::once(async {
                     Ok("<log></log>".to_string())
                 })))
+            }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                self.0.wait().await;
+                Ok(vec![0.0])
             }
         }
 

--- a/psyche-rs/src/test_helpers.rs
+++ b/psyche-rs/src/test_helpers.rs
@@ -32,6 +32,13 @@ impl LLMClient for StaticLLM {
         let s = stream::iter(words.into_iter().map(Result::Ok));
         Ok(Box::pin(s))
     }
+
+    async fn embed(
+        &self,
+        _text: &str,
+    ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(vec![0.0])
+    }
 }
 
 /// Simple sensor yielding a single [`Impression<String>`].

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -595,6 +595,13 @@ mod tests {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(Box::pin(futures::stream::empty()))
             }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
+            }
         }
 
         let calls = Arc::new(AtomicUsize::new(0));

--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -93,6 +93,12 @@ impl<T> Wit<T> {
     ///     ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
     ///         Ok(Box::pin(futures::stream::empty()))
     ///     }
+    ///     async fn embed(
+    ///         &self,
+    ///         _text: &str,
+    ///     ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+    ///         Ok(vec![0.0])
+    ///     }
     /// }
     ///
     /// let llm = Arc::new(DummyLLM);
@@ -341,6 +347,13 @@ mod tests {
             let stream = stream::iter(words.into_iter().map(Result::Ok));
             Ok(Box::pin(stream))
         }
+
+        async fn embed(
+            &self,
+            _text: &str,
+        ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(vec![0.0])
+        }
     }
 
     struct TestSensor;
@@ -385,6 +398,13 @@ mod tests {
             ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(Box::pin(stream::once(async { Ok("done".to_string()) })))
+            }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
             }
         }
 
@@ -456,6 +476,13 @@ mod tests {
             ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.prompts.lock().unwrap().push(msgs[0].content.clone());
                 Ok(Box::pin(stream::once(async { Ok("frame".to_string()) })))
+            }
+
+            async fn embed(
+                &self,
+                _text: &str,
+            ) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(vec![0.0])
             }
         }
 


### PR DESCRIPTION
## Summary
- extend `LLMClient` with async `embed` for vector generation
- implement embedding in all LLM wrappers and tests
- rework `NeoQdrantMemoryStore` to use LLM embeddings
- replace in-memory store with `NeoQdrantMemoryStore` in `daringsby`
- add connection arguments for Neo4j and Qdrant

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6865dcf41d608320be4a83a5f0f27c29