### PR TITLE
Switch to plain user messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,6 @@
   skip LLM calls within `min_llm_interval_ms`; ensure tests cover this logic.
 - Keep `WillRuntimeConfig` in sync with fields used by `Will` runtimes.
 - Log all memory store errors at `error` level.
+- Refer to external speakers as "my interlocutor" in prompts and logs.
+- Pass interlocutor utterances to the voice module as plain text without
+  wrapping them in narrative phrasing.


### PR DESCRIPTION
## Summary
- updated AGENTS instructions about forwarding interlocutor text
- default `HeardUserSensor` now forwards the interlocutor's words unchanged
- adjust tests for the new behavior

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6865dd957f608320bd45d6ac99994a36