### PR TITLE
refactor to async reqwest client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -25,7 +25,7 @@ quick-xml = "0.31"
 rand = "0.8"
 sha2 = "0.10"
 anyhow = "1"
-reqwest = { version = "0.12", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json"] }
 uuid = { version = "1", features = ["v4"] }
 url = "2"
 once_cell = "1"


### PR DESCRIPTION
## Summary
- use `reqwest::Client` in the NeoQdrant store
- run async HTTP calls via `block_on`
- drop `blocking` feature from reqwest

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686698749f448320b78142da4aae8b94