### PR TITLE
refactor memory store to async

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -45,7 +45,7 @@ async fn run_impression_loop<T: serde::Serialize + Clone + Send + 'static>(
     tracing::debug!("{} task started", name);
     while let Some(batch) = stream.next().await {
         for imp in &batch {
-            if let Err(e) = persist_impression(store.as_ref(), imp, kind) {
+            if let Err(e) = persist_impression(store.as_ref(), imp, kind).await {
                 tracing::warn!(error=?e, "persist failed");
             }
         }

--- a/psyche-rs/src/memory_sensor.rs
+++ b/psyche-rs/src/memory_sensor.rs
@@ -30,10 +30,11 @@ impl<M: MemoryStore> MemorySensor<M> {
     > {
         let related = self
             .store
-            .retrieve_related_impressions(current_how, self.top_k)?;
+            .retrieve_related_impressions(current_how, self.top_k)
+            .await?;
         let mut out = Vec::new();
         for imp in related {
-            let data = self.store.load_full_impression(&imp.id)?;
+            let data = self.store.load_full_impression(&imp.id).await?;
             tracing::debug!(?data, "related impression");
             out.push(data);
         }
@@ -56,7 +57,7 @@ mod tests {
             when: Utc::now(),
             data: "{}".into(),
         };
-        store.store_sensation(&sensation).unwrap();
+        store.store_sensation(&sensation).await.unwrap();
         let impression = StoredImpression {
             id: "i1".into(),
             kind: "Situation".into(),
@@ -65,7 +66,7 @@ mod tests {
             sensation_ids: vec!["s1".into()],
             impression_ids: Vec::new(),
         };
-        store.store_impression(&impression).unwrap();
+        store.store_impression(&impression).await.unwrap();
 
         let sensor = MemorySensor::new(store, 1);
         let res = sensor.sense_related_memory("example").await.unwrap();

--- a/psyche-rs/src/motor_executor.rs
+++ b/psyche-rs/src/motor_executor.rs
@@ -56,7 +56,7 @@ impl MotorExecutor {
                                 sensation_ids: Vec::new(),
                                 impression_ids: Vec::new(),
                             };
-                            if let Err(e) = store.store_impression(&stored_imp) {
+                            if let Err(e) = store.store_impression(&stored_imp).await {
                                 warn!(?e, "failed to store intention as impression");
                             }
                         }
@@ -73,7 +73,8 @@ impl MotorExecutor {
                                                     when: s.when.with_timezone(&chrono::Utc),
                                                     data,
                                                 };
-                                                if let Err(e) = store.store_sensation(&stored) {
+                                                if let Err(e) = store.store_sensation(&stored).await
+                                                {
                                                     warn!(?e, "failed to store motor sensation");
                                                 }
                                             }


### PR DESCRIPTION
## Summary
- make MemoryStore async with `async_trait`
- update NeoQdrantMemoryStore to await HTTP and LLM calls
- refactor helper modules and tests for async API

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68670c03a6d8832093106f483854cc08