### PR TITLE
Add configurable embedding model

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Available options (see `main.rs`):
 * `--combob-model`: Model used for Combobulator tasks (default: `gemma3:27b`)
 * `--will-model`: Model used for Will tasks (default: `gemma3:27b`)
 * `--memory-model`: Model used for memory operations (default: `gemma3:27b`)
+* `--embedding-model`: Model used for embeddings (default: `nomic-embed-text`)
 * `--tts-url`: Coqui TTS base URL (default: `http://localhost:5002`)
 * `--language-id`: Language identifier for TTS (optional)
 * `--speaker-id`: Speaker ID for TTS (default: `p234`)

--- a/daringsby/src/args.rs
+++ b/daringsby/src/args.rs
@@ -17,6 +17,9 @@ pub struct Args {
     pub will_model: String,
     #[arg(long = "memory-model", default_value = "gemma3:27b")]
     pub memory_model: String,
+    /// Model used when generating embeddings.
+    #[arg(long = "embedding-model", default_value = "nomic-embed-text")]
+    pub embedding_model: String,
     #[arg(long, default_value = "http://localhost:7474")]
     pub neo4j_url: String,
     #[arg(long, default_value = "neo4j")]


### PR DESCRIPTION
## Summary
- allow passing a separate embedding model to `OllamaLLM`
- wire embedding model option through CLI helpers
- document `--embedding-model` flag
- test custom embedding model support

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68671dd687d883208c5abeafe0c9b590