### PR TITLE
Natural intention impressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pete is not merely a robot, nor a chatbot. He is:
 |------------|---------|
 | **`psyche-rs`** | Core cognitive engine: Sensation streams, Wits, Will, Motor orchestration |
 | **`daringsby`** | Pete's physical and I/O embodiment: Motors, Sensors, WebSocket streams |
-| **Motors** | Actions Pete performs (e.g., `say`, `look`, `source_tree`) |
+| **Motors** | Actions Pete performs (e.g., `speak`, `look`, `source_tree`) |
 | **Sensors** | Sources of experience (e.g., audio heard, vision snapshots, code awareness) |
 | **LLMs** | Narrative generation, decision-making, and motor command creation (via streaming) |
 

--- a/daringsby/src/motor_helpers.rs
+++ b/daringsby/src/motor_helpers.rs
@@ -66,7 +66,7 @@ pub fn build_motors(
     let mut map = HashMap::new();
     map.insert("log".into(), logging_motor as Arc<dyn Motor>);
     map.insert("look".into(), vision_motor as Arc<dyn Motor>);
-    map.insert("say".into(), mouth as Arc<dyn Motor>);
+    map.insert("speak".into(), mouth as Arc<dyn Motor>);
     map.insert("canvas".into(), canvas_motor as Arc<dyn Motor>);
     map.insert("draw".into(), svg_motor as Arc<dyn Motor>);
     map.insert("recall".into(), recall_motor as Arc<dyn Motor>);

--- a/daringsby/src/mouth.rs
+++ b/daringsby/src/mouth.rs
@@ -15,7 +15,7 @@ use psyche_rs::{ActionResult, Completion, Intention, Motor, MotorError};
 
 /// Motor that streams text-to-speech audio via HTTP.
 ///
-/// The motor responds to the `say` action name which streams audio via a
+/// The motor responds to the `speak` action name which streams audio via a
 /// TTS service.
 ///
 /// Sentences from the input body are sent to a TTS service and the
@@ -157,17 +157,17 @@ impl Motor for Mouth {
         "Speak text out loud to your interlocutor (or no one at all).\n\
 Params: `speaker_id` (required) and required `language_id`.\n\
 Example:\n\
-<say speaker_id=\"p234\" language_id=\"en\">Hello, world.</say>\n\
+<speak speaker_id=\"p234\" language_id=\"en\">Hello, world.</speak>\n\
 Explanation:\n\
 The Will sends the text to the TTS service with the given voice and language."
     }
 
     fn name(&self) -> &'static str {
-        "say"
+        "speak"
     }
 
     async fn perform(&self, intention: Intention) -> Result<ActionResult, MotorError> {
-        if intention.action.name != "say" {
+        if intention.action.name != "speak" {
             return Err(MotorError::Unrecognized);
         }
         let mut action = intention.action;
@@ -357,8 +357,8 @@ mod tests {
         let body = stream::once(async { "Hello world. How are you?".to_string() }).boxed();
         let mut map = Map::new();
         map.insert("speaker_id".into(), Value::String("p234".into()));
-        let action = Action::new("say", Value::Object(map), body);
-        let intention = Intention::to(action).assign("say");
+        let action = Action::new("speak", Value::Object(map), body);
+        let intention = Intention::to(action).assign("speak");
 
         // Act
         mouth.perform(intention).await.unwrap();
@@ -399,8 +399,8 @@ mod tests {
         let body = stream::once(async { "Hi.".to_string() }).boxed();
         let mut map = Map::new();
         map.insert("speaker_id".into(), Value::String("p234".into()));
-        let action = Action::new("say", Value::Object(map), body);
-        let intention = Intention::to(action).assign("say");
+        let action = Action::new("speak", Value::Object(map), body);
+        let intention = Intention::to(action).assign("speak");
 
         // Act
         mouth.perform(intention).await.unwrap();
@@ -442,8 +442,8 @@ mod tests {
         let mouth = Mouth::new(client, server.url(""), None);
         let mut rx = mouth.subscribe();
         let body = stream::once(async { "Hi.".to_string() }).boxed();
-        let action = Action::new("say", Map::new().into(), body);
-        let intention = Intention::to(action).assign("say");
+        let action = Action::new("speak", Map::new().into(), body);
+        let intention = Intention::to(action).assign("speak");
 
         // Act
         mouth.perform(intention).await.unwrap();
@@ -488,8 +488,8 @@ mod tests {
         let mouth = Mouth::new(client, server.url(""), None);
         let mut seg_rx = mouth.subscribe_segments();
         let body = stream::once(async { "Hi.".to_string() }).boxed();
-        let action = Action::new("say", Map::new().into(), body);
-        let intention = Intention::to(action).assign("say");
+        let action = Action::new("speak", Map::new().into(), body);
+        let intention = Intention::to(action).assign("speak");
         mouth.perform(intention).await.unwrap();
         let seg = seg_rx.recv().await.unwrap();
         assert_eq!(seg.text, "Hi.");
@@ -512,12 +512,12 @@ mod tests {
             .unwrap();
         let mouth = Mouth::new(client, server.url(""), None);
         let body = stream::once(async { "Hi.".to_string() }).boxed();
-        let action = Action::new("say", Map::new().into(), body);
-        let intention = Intention::to(action).assign("say");
+        let action = Action::new("speak", Map::new().into(), body);
+        let intention = Intention::to(action).assign("speak");
         let result = mouth.perform(intention).await.unwrap();
         assert!(result.completed);
         let completion = result.completion.unwrap();
-        assert_eq!(completion.name, "say");
+        assert_eq!(completion.name, "speak");
         assert!(completion.params.as_object().unwrap().is_empty());
     }
 }

--- a/daringsby/src/prompts/will_prompt.txt
+++ b/daringsby/src/prompts/will_prompt.txt
@@ -15,7 +15,7 @@ AVAILABLE MOTORS:
 {motors}
 
 INSTRUCTIONS:
-👉 Pete *must* produce at least one XML motor action tag (such as <say>, <log>, <look>, <read_source>, etc.) in *every output*.
+👉 Pete *must* produce at least one XML motor action tag (such as <speak>, <log>, <look>, <read_source>, etc.) in *every output*.
 👉 Pete *may not conclude* a response without such a tag.
 👉 Pete's reasoning must *lead directly* to the action. No unnecessary elaboration.
 

--- a/daringsby/src/runtime_helpers.rs
+++ b/daringsby/src/runtime_helpers.rs
@@ -68,7 +68,7 @@ pub async fn drive_will_stream<M>(
                         .await
                         .expect("look motor failed");
                 }
-                "say" => {
+                "speak" => {
                     mouth.perform(intent).await.expect("mouth motor failed");
                 }
                 "canvas" => {

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
                 "records actions into a vector"
             }
             fn name(&self) -> &'static str {
-                "say"
+                "speak"
             }
             async fn perform(&self, intention: Intention) -> Result<ActionResult, MotorError> {
                 let mut action = intention.action;
@@ -205,8 +205,8 @@ mod tests {
             for impression in batch {
                 let text = impression.how.clone();
                 let body = stream::once(async move { text }).boxed();
-                let action = Action::new("say", Value::Null, body);
-                let intention = Intention::to(action).assign("say");
+                let action = Action::new("speak", Value::Null, body);
+                let intention = Intention::to(action).assign("speak");
                 futures::executor::block_on(async {
                     motor.perform(intention).await.unwrap();
                 });

--- a/psyche-rs/src/motor.rs
+++ b/psyche-rs/src/motor.rs
@@ -6,7 +6,7 @@ use crate::sensation::Sensation;
 
 /// Represents a motor command with streaming body content.
 pub struct Action {
-    /// Action name such as `say` or `look`.
+    /// Action name such as `speak` or `look`.
     pub name: String,
     /// Parsed parameters from the action tag.
     pub params: Value,
@@ -154,6 +154,23 @@ impl std::fmt::Display for Intention {
     }
 }
 
+impl Intention {
+    /// Summarize this intention in a single English sentence.
+    ///
+    /// ```
+    /// use futures::stream::{self, StreamExt};
+    /// use psyche_rs::{Action, Intention};
+    ///
+    /// let body = stream::empty().boxed();
+    /// let intent = Intention::to(Action::new("draw", serde_json::Value::Null, body))
+    ///     .assign("canvas");
+    /// assert_eq!(intent.summary(), "I'm about to draw.");
+    /// ```
+    pub fn summary(&self) -> String {
+        format!("I'm about to {}.", self.action.name)
+    }
+}
+
 /// Metadata describing an interruption to an action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Interruption {
@@ -204,9 +221,9 @@ impl Completion {
     /// use psyche_rs::{Action, Completion};
     /// use futures::stream::{self, StreamExt};
     /// let body = stream::empty().boxed();
-    /// let action = Action::new("say", serde_json::Value::Null, body);
+    /// let action = Action::new("speak", serde_json::Value::Null, body);
     /// let c = Completion::of_action(action);
-    /// assert_eq!(c.name, "say");
+    /// assert_eq!(c.name, "speak");
     /// ```
     pub fn of_action(action: Action) -> Self {
         Self {

--- a/psyche-rs/src/motor_executor.rs
+++ b/psyche-rs/src/motor_executor.rs
@@ -52,7 +52,7 @@ impl MotorExecutor {
                                 id: uuid::Uuid::new_v4().to_string(),
                                 kind: "Intention".into(),
                                 when: chrono::Utc::now(),
-                                how: intention.to_string(),
+                                how: intention.summary(),
                                 sensation_ids: Vec::new(),
                                 impression_ids: Vec::new(),
                             };

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -411,9 +411,9 @@ mod tests {
             ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
                 let tokens = vec![
-                    "<say>".to_string(),
+                    "<speak>".to_string(),
                     "Hello".to_string(),
-                    "</say><log>".to_string(),
+                    "</speak><log>".to_string(),
                     "Logging this".to_string(),
                     "</log>".to_string(),
                 ];
@@ -461,12 +461,12 @@ mod tests {
         let llm = Arc::new(MultiLLM);
         let will = Will::new(llm.clone())
             .delay_ms(10)
-            .motor("say", "speak")
+            .motor("speak", "speak")
             .motor("log", "record");
         let psyche = Psyche::new()
             .sensor(DummySensor)
             .will(will)
-            .motor(CountingMotor(count.clone(), "say"))
+            .motor(CountingMotor(count.clone(), "speak"))
             .motor(CountingMotor(count.clone(), "log"));
 
         let _ = tokio::time::timeout(std::time::Duration::from_millis(200), psyche.run()).await;

--- a/psyche-rs/src/voice.rs
+++ b/psyche-rs/src/voice.rs
@@ -164,8 +164,8 @@ impl Voice {
                                             let body =
                                                 futures::stream::once(async move { body_text })
                                                     .boxed();
-                                            let action = Action::new("say", Value::Null, body);
-                                            let intent = Intention::to(action).assign("say");
+                                            let action = Action::new("speak", Value::Null, body);
+                                            let intent = Intention::to(action).assign("speak");
                                             let _ = tx.send(vec![intent]);
                                             if let Some(qtx) = &quick_tx {
                                                 let sens = Sensation {
@@ -192,8 +192,8 @@ impl Voice {
                                 let text = sent.clone();
                                 let body_text = text.clone();
                                 let body = futures::stream::once(async move { body_text }).boxed();
-                                let action = Action::new("say", Value::Null, body);
-                                let intent = Intention::to(action).assign("say");
+                                let action = Action::new("speak", Value::Null, body);
+                                let intent = Intention::to(action).assign("speak");
                                 let _ = tx.send(vec![intent]);
                                 if let Some(qtx) = &quick_tx {
                                     let sens = Sensation {
@@ -240,8 +240,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn emits_say_intention() {
-        let llm = Arc::new(StaticLLM::new("<say>hi</say>"));
+    async fn emits_speak_intention() {
+        let llm = Arc::new(StaticLLM::new("<speak>hi</speak>"));
         let voice = Voice::new(llm, 5).delay_ms(10);
         let ear = TestEar;
         let get_situation = Arc::new(|| "".to_string());
@@ -249,7 +249,7 @@ mod tests {
         let mut stream = voice.observe(ear, get_situation, get_instant).await;
         let batch = stream.next().await.unwrap();
         assert!(!batch.is_empty());
-        assert_eq!(batch[0].assigned_motor, "say");
+        assert_eq!(batch[0].assigned_motor, "speak");
     }
 
     #[tokio::test]
@@ -262,7 +262,7 @@ mod tests {
         let mut stream = voice.observe(ear, get_situation, get_instant).await;
         let a = stream.next().await.unwrap();
         let b = stream.next().await.unwrap();
-        assert_eq!(a[0].assigned_motor, "say");
-        assert_eq!(b[0].assigned_motor, "say");
+        assert_eq!(a[0].assigned_motor, "speak");
+        assert_eq!(b[0].assigned_motor, "speak");
     }
 }

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -489,13 +489,13 @@ mod tests {
 
     #[test]
     fn detects_motor_tag() {
-        // Given a Will with a "say" motor
+        // Given a Will with a "speak" motor
         let llm = Arc::new(StaticLLM::new(""));
         let mut will = Will::<serde_json::Value>::new(llm);
-        will = will.motor("say", "say words");
+        will = will.motor("speak", "speak words");
 
-        // When the output contains a <say> tag
-        let out = "Thinking <say mood=\"happy\">hi</say>";
+        // When the output contains a <speak> tag
+        let out = "Thinking <speak mood=\"happy\">hi</speak>";
 
         // Then the tag is detected
         assert!(will.contains_motor_action(out));
@@ -517,7 +517,7 @@ mod tests {
     fn ignores_unknown_tags() {
         // Given a Will with a single motor
         let llm = Arc::new(StaticLLM::new(""));
-        let will = Will::<serde_json::Value>::new(llm).motor("say", "");
+        let will = Will::<serde_json::Value>::new(llm).motor("speak", "");
 
         // When the output contains an unknown element
         assert!(!will.contains_motor_action("<unknown/>"));
@@ -535,12 +535,12 @@ mod tests {
 
     #[test]
     fn invalid_xml_is_ignored() {
-        // Given a Will with a "say" motor
+        // Given a Will with a "speak" motor
         let llm = Arc::new(StaticLLM::new(""));
-        let will = Will::<serde_json::Value>::new(llm).motor("say", "");
+        let will = Will::<serde_json::Value>::new(llm).motor("speak", "");
 
         // When the xml is malformed no motor should be detected
-        assert!(!will.contains_motor_action("<say"));
+        assert!(!will.contains_motor_action("<speak"));
     }
 
     struct DummyMotor;
@@ -571,11 +571,11 @@ mod tests {
         let llm = Arc::new(StaticLLM::new(""));
         let mut will = Will::<serde_json::Value>::new(llm);
         assert_eq!(will.motor_text(), "");
-        will = will.motor("say", "speak");
-        assert_eq!(will.motor_text(), "say: speak");
+        will = will.motor("speak", "speak");
+        assert_eq!(will.motor_text(), "speak: speak");
         let motor = DummyMotor;
         will.register_motor(&motor);
-        assert_eq!(will.motor_text(), "say: speak\ndum: test");
+        assert_eq!(will.motor_text(), "speak: speak\ndum: test");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- summarize `Intention` with a short English sentence
- log intentions using the summary text
- rename the `say` motor to `speak`
- update tests and docs accordingly

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68671ff5319483208cc2118026112b23