### PR TITLE
Ensure impressions collection at startup

### DIFF
--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -64,6 +64,7 @@ self-discovery-sensor = []
 source-discovery-sensor = []
 moment-feedback = []
 single-wit = []
+debug_memory = []
 default = [
     "logging-motor",
     "vision",


### PR DESCRIPTION
## Summary
- create `ensure_impressions_collection_exists` helper
- call helper during startup before using memory store
- add `debug_memory` feature
- test the new helper

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686723ee60a48320a3928586c11dee53