### PR TITLE
Add dedicated voice LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Available options (see `main.rs`):
 * `--combob-model`: Model used for Combobulator tasks (default: `gemma3:27b`)
 * `--will-model`: Model used for Will tasks (default: `gemma3:27b`)
 * `--memory-model`: Model used for memory operations (default: `gemma3:27b`)
+* `--voice-url`: Dedicated Ollama base URL for the voice loop (default: `http://localhost:11434`)
+* `--voice-model`: Model used for the voice loop (default: `gemma3:27b`)
 * `--embedding-model`: Model used for embeddings (default: `nomic-embed-text`)
 * `--tts-url`: Coqui TTS base URL (default: `http://localhost:5002`)
 * `--language-id`: Language identifier for TTS (optional)

--- a/daringsby/src/args.rs
+++ b/daringsby/src/args.rs
@@ -17,6 +17,12 @@ pub struct Args {
     pub will_model: String,
     #[arg(long = "memory-model", default_value = "gemma3:27b")]
     pub memory_model: String,
+    /// Base URL of the Ollama server dedicated to the voice loop.
+    #[arg(long = "voice-url", default_value = "http://localhost:11434")]
+    pub voice_url: String,
+    /// Model used for voice generation.
+    #[arg(long = "voice-model", default_value = "gemma3:27b")]
+    pub voice_model: String,
     /// Model used when generating embeddings.
     #[arg(long = "embedding-model", default_value = "nomic-embed-text")]
     pub embedding_model: String,

--- a/daringsby/src/llm_helpers.rs
+++ b/daringsby/src/llm_helpers.rs
@@ -30,6 +30,18 @@ fn build_pool(base_urls: &[String], model: &str, embed_model: &str) -> Arc<dyn L
     Arc::new(FairLLM::new(rr, base_urls.len())) as Arc<dyn LLMClient>
 }
 
+/// Build an Ollama client dedicated to the voice loop.
+pub fn build_voice_llm(args: &Args) -> Arc<dyn LLMClient> {
+    let http = Client::builder()
+        .pool_max_idle_per_host(10)
+        .build()
+        .expect("ollama http client");
+    Arc::new(OllamaLLM::new(
+        build_ollama(&http, &args.voice_url),
+        args.voice_model.clone(),
+    )) as Arc<dyn LLMClient>
+}
+
 /// Build all Ollama LLM clients.
 pub fn build_ollama_clients(
     args: &Args,

--- a/daringsby/tests/args.rs
+++ b/daringsby/tests/args.rs
@@ -21,3 +21,21 @@ fn default_base_url_is_localhost() {
     let args = Args::parse_from(["test"]);
     assert_eq!(args.base_url, vec!["http://localhost:11434".to_string()]);
 }
+
+#[test]
+fn voice_url_flag_overrides_default() {
+    let args = Args::parse_from(["test", "--voice-url", "http://voice"]);
+    assert_eq!(args.voice_url, "http://voice".to_string());
+}
+
+#[test]
+fn default_voice_url_is_localhost() {
+    let args = Args::parse_from(["test"]);
+    assert_eq!(args.voice_url, "http://localhost:11434".to_string());
+}
+
+#[test]
+fn default_voice_model_is_gemma3() {
+    let args = Args::parse_from(["test"]);
+    assert_eq!(args.voice_model, "gemma3:27b".to_string());
+}


### PR DESCRIPTION
## Summary
- allow configuring a dedicated Ollama instance for the voice loop
- create a `build_voice_llm` helper
- use the new voice client in `main` and run without delay
- document CLI flags
- test CLI flag parsing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867286e2bf48320a3eb6a8fd3227732