### PR TITLE
Lower verbosity of audio logs

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -96,7 +96,7 @@ function sendHeard() {
     );
   }
   pendingText = null;
-  console.log("Queue length", queue.length, "Texts length", texts.length);
+  console.debug("Queue length", queue.length, "Texts length", texts.length);
 }
 
 function sendMessage(ev) {
@@ -136,7 +136,7 @@ function pcmToWav(pcm) {
 
 function play() {
   if (playing || !queue.length) return;
-  console.log('Queue length', queue.length, 'Texts length', texts.length);
+  console.debug('Queue length', queue.length, 'Texts length', texts.length);
   playing = true;
   const pcm = queue.shift();
   if (pcm.length === 0) {


### PR DESCRIPTION
## Summary
- downgrade browser audio queue logs to `console.debug`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867270a4e748320a9e0e7bdd0de5f1d