### PR TITLE
Introduce async TokenStream for Genius and LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ use psyche_rs::{RoundRobinLLM, LLMClient};
 # struct Dummy;
 # #[async_trait]
 # impl LLMClient for Dummy {
-#     async fn chat_stream(&self, _msgs: &[ChatMessage]) -> Result<psyche_rs::LLMTokenStream, Box<dyn Error + Send + Sync>> {
-#         Ok(Box::pin(stream::empty()))
+#     async fn chat_stream(&self, _msgs: &[ChatMessage]) -> Result<psyche_rs::TokenStream, Box<dyn Error + Send + Sync>> {
+#         Ok(Box::pin(stream::empty::<psyche_rs::Token>()))
 #     }
 # }
 let pool = RoundRobinLLM::new(vec![Arc::new(Dummy)]);

--- a/daringsby/src/canvas_motor.rs
+++ b/daringsby/src/canvas_motor.rs
@@ -30,8 +30,8 @@ use crate::canvas_stream::CanvasStream;
 ///         async fn chat_stream(
 ///             &self,
 ///             _msgs: &[ollama_rs::generation::chat::ChatMessage],
-///         ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
-///             let stream = async_stream::stream! { yield Ok(String::new()) };
+///         ) -> Result<psyche_rs::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///             let stream = async_stream::stream! { yield psyche_rs::Token { text: String::new() } };
 ///             Ok(Box::pin(stream))
 ///         }
 ///         async fn embed(
@@ -103,9 +103,9 @@ The snapshot image is also delivered to any `CanvasStream` subscribers."
             .await
             .map_err(|e| MotorError::Failed(e.to_string()))?;
         let mut desc = String::new();
-        while let Some(Ok(tok)) = stream.next().await {
-            trace!(%tok, "llm token");
-            desc.push_str(&tok);
+        while let Some(tok) = stream.next().await {
+            trace!(token = %tok.text, "llm token");
+            desc.push_str(&tok.text);
         }
         let when = Local::now();
         let sensation = Sensation {

--- a/daringsby/src/recall_motor.rs
+++ b/daringsby/src/recall_motor.rs
@@ -75,9 +75,8 @@ impl<M: MemoryStore + Send + Sync> RecallMotor<M> {
             .map_err(|e| MotorError::Failed(e.to_string()))?;
         let mut out = String::new();
         while let Some(tok) = stream.next().await {
-            let tok = tok.map_err(|e| MotorError::Failed(e.to_string()))?;
-            trace!(%tok, "neighbor_llm_token");
-            out.push_str(&tok);
+            trace!(token = %tok.text, "neighbor_llm_token");
+            out.push_str(&tok.text);
         }
         let summary = out.trim();
         if summary.is_empty() {

--- a/daringsby/src/vision_motor.rs
+++ b/daringsby/src/vision_motor.rs
@@ -70,9 +70,9 @@ sent to any `VisionSensor` subscribers."
             .await
             .map_err(|e| MotorError::Failed(e.to_string()))?;
         let mut desc = String::new();
-        while let Some(Ok(tok)) = stream.next().await {
-            trace!(%tok, "llm token");
-            desc.push_str(&tok);
+        while let Some(tok) = stream.next().await {
+            trace!(token = %tok.text, "llm token");
+            desc.push_str(&tok.text);
         }
         let when = Local::now();
         let sensation = Sensation {

--- a/daringsby/tests/canvas_motor.rs
+++ b/daringsby/tests/canvas_motor.rs
@@ -11,10 +11,10 @@ impl LLMClient for DummyLLM {
     async fn chat_stream(
         &self,
         _messages: &[ollama_rs::generation::chat::ChatMessage],
-    ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<psyche_rs::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let reply = self.0.to_string();
         let stream = async_stream::stream! {
-            yield Ok(reply);
+            yield psyche_rs::Token { text: reply };
         };
         Ok(Box::pin(stream))
     }

--- a/daringsby/tests/vision_motor.rs
+++ b/daringsby/tests/vision_motor.rs
@@ -10,9 +10,9 @@ impl LLMClient for DummyLLM {
     async fn chat_stream(
         &self,
         _messages: &[ollama_rs::generation::chat::ChatMessage],
-    ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<psyche_rs::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let stream = async_stream::stream! {
-            yield Ok(String::new());
+            yield psyche_rs::Token { text: String::new() };
         };
         Ok(Box::pin(stream))
     }

--- a/psyche-rs/src/genius.rs
+++ b/psyche-rs/src/genius.rs
@@ -5,14 +5,12 @@ use async_trait::async_trait;
 pub trait Genius: Send + Sync + 'static {
     /// Input type handled by this genius.
     type Input: Send + Sync + 'static;
-    /// Output type produced by this genius.
-    type Output: Send + Sync + 'static;
 
     /// Human readable name used for logging.
     fn name(&self) -> &'static str;
 
-    /// Feed an input into this genius.
-    async fn feed(&self, input: Self::Input);
+    /// Invoke this genius with the provided input returning a stream of tokens.
+    async fn call(&self, input: Self::Input) -> crate::TokenStream;
 
     /// Run the main loop for this genius.
     async fn run(&self);

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -12,6 +12,7 @@ mod genius;
 mod impression;
 mod llm_client;
 mod llm_parser;
+mod llm_types;
 mod memory_sensor;
 mod memory_store;
 mod motor;
@@ -36,9 +37,10 @@ pub mod text_util;
 mod timeline;
 mod voice;
 mod will;
+
 mod wit;
 
-pub use crate::llm_client::{LLMClient, LLMTokenStream, spawn_llm_task};
+pub use crate::llm_client::{LLMClient, spawn_llm_task};
 pub use crate::ollama_llm::OllamaLLM;
 pub use abort_guard::AbortGuard;
 pub use cluster_analyzer::ClusterAnalyzer;
@@ -48,6 +50,7 @@ pub use fair_llm::FairLLM;
 pub use fair_llm::spawn_fair_llm_task;
 pub use genius::Genius;
 pub use impression::Impression;
+pub use llm_types::{Token, TokenStream};
 pub use memory_sensor::MemorySensor;
 pub use memory_store::{InMemoryStore, MemoryStore, StoredImpression, StoredSensation};
 pub use motor::{
@@ -106,10 +109,13 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
-                Ok(Box::pin(stream::once(async {
-                    Ok("ping event".to_string())
-                })))
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+                let s = stream::once(async {
+                    Token {
+                        text: "ping event".into(),
+                    }
+                });
+                Ok(Box::pin(s))
             }
 
             async fn embed(
@@ -156,10 +162,13 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
-                Ok(Box::pin(stream::once(async {
-                    Ok("ping event".to_string())
-                })))
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+                let s = stream::once(async {
+                    Token {
+                        text: "ping event".into(),
+                    }
+                });
+                Ok(Box::pin(s))
             }
 
             async fn embed(

--- a/psyche-rs/src/llm_client.rs
+++ b/psyche-rs/src/llm_client.rs
@@ -1,12 +1,9 @@
 use async_trait::async_trait;
-use futures::{Stream, StreamExt};
-use std::{pin::Pin, sync::Arc};
+use futures::StreamExt;
+use std::sync::Arc;
 
+use crate::llm_types::TokenStream;
 use ollama_rs::generation::chat::ChatMessage;
-
-/// Stream of LLM-generated text fragments.
-pub type LLMTokenStream =
-    Pin<Box<dyn Stream<Item = Result<String, Box<dyn std::error::Error + Send + Sync>>> + Send>>;
 
 /// Common interface for chat-based LLMs.
 #[async_trait]
@@ -15,7 +12,7 @@ pub trait LLMClient: Send + Sync {
     async fn chat_stream(
         &self,
         messages: &[ChatMessage],
-    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>>;
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>>;
 
     /// Generate an embedding vector for the provided text.
     async fn embed(&self, text: &str)
@@ -38,8 +35,9 @@ pub trait LLMClient: Send + Sync {
 ///     async fn chat_stream(
 ///         &self,
 ///         _: &[ChatMessage],
-///     ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
-///         Ok(Box::pin(stream::once(async { Ok("hello ".to_string()) })))
+///     ) -> Result<psyche_rs::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///         let stream = stream::once(async { psyche_rs::Token { text: "hello ".into() } });
+///         Ok(Box::pin(stream))
 ///     }
 ///     async fn embed(
 ///         &self,
@@ -63,7 +61,7 @@ pub async fn spawn_llm_task(
         let mut stream = llm.chat_stream(&msgs).await?;
         let mut out = String::new();
         while let Some(tok) = stream.next().await {
-            out.push_str(&tok?);
+            out.push_str(&tok.text);
         }
         tracing::debug!(%out, "llm full response");
         Ok(out)

--- a/psyche-rs/src/llm_types.rs
+++ b/psyche-rs/src/llm_types.rs
@@ -1,0 +1,11 @@
+use futures::stream::BoxStream;
+
+/// Text token emitted by an LLM.
+#[derive(Debug, Clone)]
+pub struct Token {
+    /// Token text as provided by the model.
+    pub text: String,
+}
+
+/// Stream of [`Token`] values.
+pub type TokenStream = BoxStream<'static, Token>;

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -44,7 +44,7 @@ impl<T> Sensor<T> for SharedSensor<T> {
 /// Core orchestrator coordinating sensors, wits and motors.
 ///
 /// ```no_run
-/// use psyche_rs::{Psyche, Wit, Sensor, LLMClient, LLMTokenStream, Sensation};
+/// use psyche_rs::{Psyche, Wit, Sensor, LLMClient, TokenStream, Sensation};
 /// use async_trait::async_trait;
 /// use futures::{stream, StreamExt};
 /// use std::sync::Arc;
@@ -56,7 +56,7 @@ impl<T> Sensor<T> for SharedSensor<T> {
 ///     async fn chat_stream(
 ///         &self,
 ///         _msgs: &[ollama_rs::generation::chat::ChatMessage],
-///     ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///     ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
 ///         Ok(Box::pin(stream::empty()))
 ///     }
 ///     async fn embed(
@@ -330,10 +330,14 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
-                let tokens = vec!["<log>".to_string(), "hi".to_string(), "</log>".to_string()];
-                Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
+                let tokens = vec![
+                    Token { text: "<log>".into() },
+                    Token { text: "hi".into() },
+                    Token { text: "</log>".into() },
+                ];
+                Ok(Box::pin(stream::iter(tokens)))
             }
 
             async fn embed(
@@ -367,10 +371,14 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
-                let tokens = vec!["<log>".to_string(), "hi".to_string(), "</log>".to_string()];
-                Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
+                let tokens = vec![
+                    Token { text: "<log>".into() },
+                    Token { text: "hi".into() },
+                    Token { text: "</log>".into() },
+                ];
+                Ok(Box::pin(stream::iter(tokens)))
             }
 
             async fn embed(
@@ -408,16 +416,16 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
                 let tokens = vec![
-                    "<speak>".to_string(),
-                    "Hello".to_string(),
-                    "</speak><log>".to_string(),
-                    "Logging this".to_string(),
-                    "</log>".to_string(),
+                    Token { text: "<speak>".into() },
+                    Token { text: "Hello".into() },
+                    Token { text: "</speak><log>".into() },
+                    Token { text: "Logging this".into() },
+                    Token { text: "</log>".into() },
                 ];
-                Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
+                Ok(Box::pin(stream::iter(tokens)))
             }
 
             async fn embed(
@@ -487,17 +495,17 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
                 let toks = vec![
-                    "<log>".to_string(),
-                    "1".to_string(),
-                    "</log>".to_string(),
-                    "<log>".to_string(),
-                    "2".to_string(),
-                    "</log>".to_string(),
+                    Token { text: "<log>".into() },
+                    Token { text: "1".into() },
+                    Token { text: "</log>".into() },
+                    Token { text: "<log>".into() },
+                    Token { text: "2".into() },
+                    Token { text: "</log>".into() },
                 ];
-                Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
+                Ok(Box::pin(stream::iter(toks)))
             }
 
             async fn embed(
@@ -569,10 +577,14 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
-                let toks = vec!["<a>".to_string(), "hi".to_string(), "</a>".to_string()];
-                Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
+                let toks = vec![
+                    Token { text: "<a>".into() },
+                    Token { text: "hi".into() },
+                    Token { text: "</a>".into() },
+                ];
+                Ok(Box::pin(stream::iter(toks)))
             }
 
             async fn embed(
@@ -591,10 +603,14 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
-                let toks = vec!["<b>".to_string(), "bye".to_string(), "</b>".to_string()];
-                Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
+                let toks = vec![
+                    Token { text: "<b>".into() },
+                    Token { text: "bye".into() },
+                    Token { text: "</b>".into() },
+                ];
+                Ok(Box::pin(stream::iter(toks)))
             }
 
             async fn embed(
@@ -666,12 +682,11 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.0.wait().await;
                 use futures::stream;
-                Ok(Box::pin(stream::once(async {
-                    Ok("<log></log>".to_string())
-                })))
+                let stream = stream::once(async { crate::Token { text: "<log></log>".into() } });
+                Ok(Box::pin(stream))
             }
 
             async fn embed(

--- a/psyche-rs/src/round_robin_llm.rs
+++ b/psyche-rs/src/round_robin_llm.rs
@@ -5,7 +5,7 @@ use std::sync::{
 
 use async_trait::async_trait;
 
-use crate::llm_client::{LLMClient, LLMTokenStream};
+use crate::{LLMClient, TokenStream};
 use ollama_rs::generation::chat::ChatMessage;
 
 /// Round-robin pool of [`LLMClient`] implementations.
@@ -25,7 +25,7 @@ use ollama_rs::generation::chat::ChatMessage;
 /// # struct Dummy;
 /// # #[async_trait]
 /// # impl LLMClient for Dummy {
-/// #   async fn chat_stream(&self, _: &[ChatMessage]) -> Result<psyche_rs::LLMTokenStream, Box<dyn Error + Send + Sync>> {
+/// #   async fn chat_stream(&self, _: &[ChatMessage]) -> Result<psyche_rs::TokenStream, Box<dyn Error + Send + Sync>> {
 /// #       Ok(Box::pin(stream::empty()))
 /// #   }
 /// #   async fn embed(&self, _text: &str) -> Result<Vec<f32>, Box<dyn Error + Send + Sync>> {
@@ -63,7 +63,7 @@ impl LLMClient for RoundRobinLLM {
     async fn chat_stream(
         &self,
         messages: &[ChatMessage],
-    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let len = self.clients.len();
         for _ in 0..len {
             let client = self.pick();

--- a/psyche-rs/src/test_helpers.rs
+++ b/psyche-rs/src/test_helpers.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{Impression, LLMClient, LLMTokenStream, Sensation, Sensor};
+use crate::{Impression, LLMClient, Sensation, Sensor, Token, TokenStream};
 use async_trait::async_trait;
 use futures::stream::{self, BoxStream};
 
@@ -23,14 +23,15 @@ impl LLMClient for StaticLLM {
     async fn chat_stream(
         &self,
         _msgs: &[ollama_rs::generation::chat::ChatMessage],
-    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
-        let words: Vec<String> = self
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        let tokens: Vec<Token> = self
             .reply
             .split_whitespace()
-            .map(|w| format!("{} ", w))
+            .map(|w| Token {
+                text: format!("{} ", w),
+            })
             .collect();
-        let s = stream::iter(words.into_iter().map(Result::Ok));
-        Ok(Box::pin(s))
+        Ok(Box::pin(stream::iter(tokens)))
     }
 
     async fn embed(

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -480,9 +480,7 @@ impl<T> Will<T> {
 mod tests {
     use super::*;
     use crate::{
-        ActionResult, Intention, MotorError,
-        llm_client::{LLMClient, LLMTokenStream},
-        test_helpers::StaticLLM,
+        ActionResult, Intention, LLMClient, MotorError, Token, TokenStream, test_helpers::StaticLLM,
     };
     use ollama_rs::generation::chat::ChatMessage;
     use std::sync::Arc;
@@ -591,9 +589,9 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.0.fetch_add(1, Ordering::SeqCst);
-                Ok(Box::pin(futures::stream::empty()))
+                Ok(Box::pin(futures::stream::empty::<Token>()))
             }
 
             async fn embed(


### PR DESCRIPTION
## Summary
- add `Token` and `TokenStream` types for streaming LLM output
- update `Genius` trait to return a `TokenStream`
- adapt `QuickGenius` and LLM clients to emit `Token`
- revise tests and docs for new streaming type

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6869981f4374832088bb6d2bfa1943b1