### PR TITLE
Introduce shared TokenStream type

### DIFF
--- a/daringsby/src/canvas_motor.rs
+++ b/daringsby/src/canvas_motor.rs
@@ -30,8 +30,9 @@ use crate::canvas_stream::CanvasStream;
 ///         async fn chat_stream(
 ///             &self,
 ///             _msgs: &[ollama_rs::generation::chat::ChatMessage],
-///         ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
-///             let stream = async_stream::stream! { yield Ok(String::new()) };
+///         ) -> Result<psyche_rs::llm::types::TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///             use psyche_rs::llm::types::Token;
+///             let stream = async_stream::stream! { yield Token { text: String::new() } };
 ///             Ok(Box::pin(stream))
 ///         }
 ///         async fn embed(

--- a/daringsby/tests/canvas_motor.rs
+++ b/daringsby/tests/canvas_motor.rs
@@ -1,6 +1,7 @@
 use daringsby::{canvas_motor::CanvasMotor, canvas_stream::CanvasStream};
 use futures::stream::{self, StreamExt};
 use psyche_rs::{LLMClient, Motor, MotorError, SensorDirectingMotor};
+use psyche_rs::llm::types::{Token, TokenStream};
 use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
 
@@ -11,10 +12,10 @@ impl LLMClient for DummyLLM {
     async fn chat_stream(
         &self,
         _messages: &[ollama_rs::generation::chat::ChatMessage],
-    ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let reply = self.0.to_string();
         let stream = async_stream::stream! {
-            yield Ok(reply);
+            yield Token { text: reply };
         };
         Ok(Box::pin(stream))
     }

--- a/daringsby/tests/vision_motor.rs
+++ b/daringsby/tests/vision_motor.rs
@@ -1,5 +1,6 @@
 use daringsby::{vision_motor::VisionMotor, vision_sensor::VisionSensor};
 use psyche_rs::{LLMClient, MotorError, SensorDirectingMotor};
+use psyche_rs::llm::types::{Token, TokenStream};
 use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
 
@@ -10,9 +11,9 @@ impl LLMClient for DummyLLM {
     async fn chat_stream(
         &self,
         _messages: &[ollama_rs::generation::chat::ChatMessage],
-    ) -> Result<psyche_rs::LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let stream = async_stream::stream! {
-            yield Ok(String::new());
+            yield Token { text: String::new() };
         };
         Ok(Box::pin(stream))
     }

--- a/psyche-rs/src/genius.rs
+++ b/psyche-rs/src/genius.rs
@@ -1,3 +1,4 @@
+use crate::llm::types::TokenStream;
 use async_trait::async_trait;
 
 /// Trait implemented by autonomous sub-agents running as independent tasks.
@@ -11,8 +12,8 @@ pub trait Genius: Send + Sync + 'static {
     /// Human readable name used for logging.
     fn name(&self) -> &'static str;
 
-    /// Feed an input into this genius.
-    async fn feed(&self, input: Self::Input);
+    /// Process an input and stream tokens back.
+    async fn call(&self, input: Self::Input) -> TokenStream;
 
     /// Run the main loop for this genius.
     async fn run(&self);

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -9,6 +9,7 @@ mod combobulator;
 mod conversation;
 mod genius;
 mod impression;
+mod llm;
 mod llm_client;
 mod llm_parser;
 mod memory_sensor;
@@ -36,7 +37,8 @@ mod voice;
 mod will;
 mod wit;
 
-pub use crate::llm_client::{LLMClient, LLMTokenStream, spawn_llm_task};
+pub use crate::llm::types::{Token, TokenStream};
+pub use crate::llm_client::{LLMClient, spawn_llm_task};
 pub use crate::ollama_llm::OllamaLLM;
 pub use abort_guard::AbortGuard;
 pub use cluster_analyzer::ClusterAnalyzer;
@@ -101,9 +103,12 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+                use crate::llm::types::Token;
                 Ok(Box::pin(stream::once(async {
-                    Ok("ping event".to_string())
+                    Token {
+                        text: "ping event".into(),
+                    }
                 })))
             }
 
@@ -151,9 +156,12 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+                use crate::llm::types::Token;
                 Ok(Box::pin(stream::once(async {
-                    Ok("ping event".to_string())
+                    Token {
+                        text: "ping event".into(),
+                    }
                 })))
             }
 

--- a/psyche-rs/src/llm/mod.rs
+++ b/psyche-rs/src/llm/mod.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/psyche-rs/src/llm/types.rs
+++ b/psyche-rs/src/llm/types.rs
@@ -1,0 +1,14 @@
+use futures::stream::BoxStream;
+
+/// Token emitted by language model streams.
+#[derive(Debug, Clone)]
+pub struct Token {
+    /// Raw text for the token.
+    pub text: String,
+    // Additional metadata can be added here (e.g. logprobs, index).
+}
+
+/// Boxed stream of [`Token`] values produced asynchronously.
+///
+/// This stream is `Send` and `Sync`, allowing it to be passed between tasks.
+pub type TokenStream = BoxStream<'static, Token>;

--- a/psyche-rs/src/llm_parser.rs
+++ b/psyche-rs/src/llm_parser.rs
@@ -8,7 +8,8 @@ use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, trace, warn};
 
-use crate::{Action, Intention, LLMTokenStream, Sensation};
+use crate::llm::types::{Token, TokenStream};
+use crate::{Action, Intention, Sensation};
 
 static START_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^<([a-zA-Z0-9_]+)([^>]*)>").expect("valid regex"));
@@ -18,7 +19,7 @@ static ATTR_RE: Lazy<Regex> =
 
 pub async fn drive_llm_stream<T>(
     name: &str,
-    mut stream: LLMTokenStream,
+    mut stream: TokenStream,
     window: Arc<Mutex<Vec<Sensation<T>>>>,
     tx: UnboundedSender<Vec<Intention>>,
     thoughts_tx: Option<UnboundedSender<Vec<Sensation<String>>>>,
@@ -37,14 +38,10 @@ pub async fn drive_llm_stream<T>(
         tokio::select! {
             tok = stream.next() => {
                 match tok {
-                    Some(Ok(tok)) => {
-                        trace!(token = %tok, "Will received LLM token");
-                        buf.push_str(&tok);
-                        full_text.push_str(&tok);
-                    }
-                    Some(Err(e)) => {
-                        error!(?e, "llm token error");
-                        break;
+                    Some(Token { text }) => {
+                        trace!(token = %text, "Will received LLM token");
+                        buf.push_str(&text);
+                        full_text.push_str(&text);
                     }
                     None => break,
                 }
@@ -216,10 +213,14 @@ mod tests {
     #[tokio::test]
     async fn stream_bodies_include_initial_chunks() {
         let tokens = vec![
-            Ok("<log>".to_string()),
-            Ok("he".to_string()),
-            Ok("llo".to_string()),
-            Ok("</log>".to_string()),
+            Token {
+                text: "<log>".into(),
+            },
+            Token { text: "he".into() },
+            Token { text: "llo".into() },
+            Token {
+                text: "</log>".into(),
+            },
         ];
         let stream = Box::pin(stream::iter(tokens));
         let window = Arc::new(Mutex::new(Vec::<Sensation<String>>::new()));
@@ -241,7 +242,12 @@ mod _parse_speak_log_tests {
     #[tokio::test]
     async fn parses_speak_and_log_intentions() {
         let text = "<speak speaker_id=\"p234\" language_id=\"en\">hi</speak><log>done</log>";
-        let tokens = text.chars().map(|c| Ok(c.to_string())).collect::<Vec<_>>();
+        let tokens = text
+            .chars()
+            .map(|c| Token {
+                text: c.to_string(),
+            })
+            .collect::<Vec<_>>();
         let stream = Box::pin(stream::iter(tokens));
         let window = Arc::new(Mutex::new(Vec::<Sensation<String>>::new()));
         let (tx, mut rx) = unbounded_channel();

--- a/psyche-rs/src/ollama_llm.rs
+++ b/psyche-rs/src/ollama_llm.rs
@@ -1,6 +1,7 @@
-use crate::llm_client::{LLMClient, LLMTokenStream};
+use crate::llm::types::{Token, TokenStream};
+use crate::llm_client::LLMClient;
 use async_trait::async_trait;
-use futures::TryStreamExt;
+use futures::StreamExt;
 use ollama_rs::{
     Ollama,
     generation::chat::{ChatMessage, ChatMessageResponseStream, request::ChatMessageRequest},
@@ -17,15 +18,21 @@ fn build_request(model: &str, messages: &[ChatMessage]) -> ChatMessageRequest {
         .options(ModelOptions::default().temperature(temperature))
 }
 
-/// Map an Ollama response stream into an [`LLMTokenStream`].
-fn map_stream(stream: ChatMessageResponseStream) -> LLMTokenStream {
-    let mapped = stream
-        .map_err(|_| Box::<dyn std::error::Error + Send + Sync>::from("ollama stream error"))
-        .map_ok(|resp| {
-            let tok = resp.message.content;
-            tracing::trace!(%tok, "llm token");
-            tok
-        });
+/// Map an Ollama response stream into a [`TokenStream`].
+fn map_stream(stream: ChatMessageResponseStream) -> TokenStream {
+    let mapped = stream.filter_map(|res| async {
+        match res {
+            Ok(resp) => {
+                let tok = resp.message.content;
+                tracing::trace!(%tok, "llm token");
+                Some(Token { text: tok })
+            }
+            Err(e) => {
+                tracing::error!(?e, "ollama stream error");
+                None
+            }
+        }
+    });
     Box::pin(mapped)
 }
 
@@ -73,7 +80,7 @@ impl LLMClient for OllamaLLM {
     async fn chat_stream(
         &self,
         messages: &[ChatMessage],
-    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
         let req = build_request(&self.model, messages);
         let stream = self.client.send_chat_messages_stream(req).await?;
         Ok(map_stream(stream))
@@ -131,7 +138,7 @@ mod tests {
         let mut stream = llm.chat_stream(&msgs).await.unwrap();
         let mut collected = String::new();
         while let Some(tok) = stream.next().await {
-            collected.push_str(&tok.unwrap());
+            collected.push_str(&tok.text);
         }
         assert_eq!(collected, "hello");
     }

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -44,7 +44,7 @@ impl<T> Sensor<T> for SharedSensor<T> {
 /// Core orchestrator coordinating sensors, wits and motors.
 ///
 /// ```no_run
-/// use psyche_rs::{Psyche, Wit, Sensor, LLMClient, LLMTokenStream, Sensation};
+/// use psyche_rs::{Psyche, Wit, Sensor, LLMClient, TokenStream, Sensation};
 /// use async_trait::async_trait;
 /// use futures::{stream, StreamExt};
 /// use std::sync::Arc;
@@ -56,7 +56,7 @@ impl<T> Sensor<T> for SharedSensor<T> {
 ///     async fn chat_stream(
 ///         &self,
 ///         _msgs: &[ollama_rs::generation::chat::ChatMessage],
-///     ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+///     ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
 ///         Ok(Box::pin(stream::empty()))
 ///     }
 ///     async fn embed(
@@ -330,10 +330,15 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
-                let tokens = vec!["<log>".to_string(), "hi".to_string(), "</log>".to_string()];
-                Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
+                use crate::llm::types::Token;
+                let tokens = vec![
+                    Token { text: "<log>".into() },
+                    Token { text: "hi".into() },
+                    Token { text: "</log>".into() },
+                ];
+                Ok(Box::pin(stream::iter(tokens)))
             }
 
             async fn embed(
@@ -367,10 +372,15 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
-                let tokens = vec!["<log>".to_string(), "hi".to_string(), "</log>".to_string()];
-                Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
+                use crate::llm::types::Token;
+                let tokens = vec![
+                    Token { text: "<log>".into() },
+                    Token { text: "hi".into() },
+                    Token { text: "</log>".into() },
+                ];
+                Ok(Box::pin(stream::iter(tokens)))
             }
 
             async fn embed(
@@ -408,16 +418,17 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
+                use crate::llm::types::Token;
                 let tokens = vec![
-                    "<speak>".to_string(),
-                    "Hello".to_string(),
-                    "</speak><log>".to_string(),
-                    "Logging this".to_string(),
-                    "</log>".to_string(),
+                    Token { text: "<speak>".into() },
+                    Token { text: "Hello".into() },
+                    Token { text: "</speak><log>".into() },
+                    Token { text: "Logging this".into() },
+                    Token { text: "</log>".into() },
                 ];
-                Ok(Box::pin(stream::iter(tokens.into_iter().map(Ok))))
+                Ok(Box::pin(stream::iter(tokens)))
             }
 
             async fn embed(
@@ -487,17 +498,18 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
+                use crate::llm::types::Token;
                 let toks = vec![
-                    "<log>".to_string(),
-                    "1".to_string(),
-                    "</log>".to_string(),
-                    "<log>".to_string(),
-                    "2".to_string(),
-                    "</log>".to_string(),
+                    Token { text: "<log>".into() },
+                    Token { text: "1".into() },
+                    Token { text: "</log>".into() },
+                    Token { text: "<log>".into() },
+                    Token { text: "2".into() },
+                    Token { text: "</log>".into() },
                 ];
-                Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
+                Ok(Box::pin(stream::iter(toks)))
             }
 
             async fn embed(
@@ -569,10 +581,15 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
-                let toks = vec!["<a>".to_string(), "hi".to_string(), "</a>".to_string()];
-                Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
+                use crate::llm::types::Token;
+                let toks = vec![
+                    Token { text: "<a>".into() },
+                    Token { text: "hi".into() },
+                    Token { text: "</a>".into() },
+                ];
+                Ok(Box::pin(stream::iter(toks)))
             }
 
             async fn embed(
@@ -591,10 +608,15 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 use futures::stream;
-                let toks = vec!["<b>".to_string(), "bye".to_string(), "</b>".to_string()];
-                Ok(Box::pin(stream::iter(toks.into_iter().map(Ok))))
+                use crate::llm::types::Token;
+                let toks = vec![
+                    Token { text: "<b>".into() },
+                    Token { text: "bye".into() },
+                    Token { text: "</b>".into() },
+                ];
+                Ok(Box::pin(stream::iter(toks)))
             }
 
             async fn embed(
@@ -666,11 +688,12 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ollama_rs::generation::chat::ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.0.wait().await;
                 use futures::stream;
+                use crate::llm::types::Token;
                 Ok(Box::pin(stream::once(async {
-                    Ok("<log></log>".to_string())
+                    Token { text: "<log></log>".into() }
                 })))
             }
 

--- a/psyche-rs/src/test_helpers.rs
+++ b/psyche-rs/src/test_helpers.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
-use crate::{Impression, LLMClient, LLMTokenStream, Sensation, Sensor};
+use crate::llm::types::{Token, TokenStream};
+use crate::{Impression, LLMClient, Sensation, Sensor};
 use async_trait::async_trait;
 use futures::stream::{self, BoxStream};
 
@@ -23,13 +24,15 @@ impl LLMClient for StaticLLM {
     async fn chat_stream(
         &self,
         _msgs: &[ollama_rs::generation::chat::ChatMessage],
-    ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
-        let words: Vec<String> = self
+    ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
+        let words: Vec<Token> = self
             .reply
             .split_whitespace()
-            .map(|w| format!("{} ", w))
+            .map(|w| Token {
+                text: format!("{} ", w),
+            })
             .collect();
-        let s = stream::iter(words.into_iter().map(Result::Ok));
+        let s = stream::iter(words);
         Ok(Box::pin(s))
     }
 

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -479,10 +479,9 @@ impl<T> Will<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::types::{Token, TokenStream};
     use crate::{
-        ActionResult, Intention, MotorError,
-        llm_client::{LLMClient, LLMTokenStream},
-        test_helpers::StaticLLM,
+        ActionResult, Intention, MotorError, llm_client::LLMClient, test_helpers::StaticLLM,
     };
     use ollama_rs::generation::chat::ChatMessage;
     use std::sync::Arc;
@@ -591,7 +590,7 @@ mod tests {
             async fn chat_stream(
                 &self,
                 _msgs: &[ChatMessage],
-            ) -> Result<LLMTokenStream, Box<dyn std::error::Error + Send + Sync>> {
+            ) -> Result<TokenStream, Box<dyn std::error::Error + Send + Sync>> {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(Box::pin(futures::stream::empty()))
             }


### PR DESCRIPTION
## Summary
- define `llm::types::{Token, TokenStream}`
- update Genius trait to return `TokenStream`
- adapt LLM client API and Ollama wrapper
- update tests and docs for new token type

## Testing
- `cargo test`
- `cargo test --doc`

------
https://chatgpt.com/codex/tasks/task_e_68699d9a77ac832086fb3061f7ae9073