### PR TITLE
Add core affinity and per-genius config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1708,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +1978,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
+ "core_affinity",
  "futures",
  "httpmock",
  "ollama-rs",

--- a/README.md
+++ b/README.md
@@ -126,6 +126,29 @@ let ctx = ThreadLocalContext {
 };
 ```
 
+### Thread management and configuration
+
+Pin each genius to a CPU core and configure its clients separately.
+
+```rust
+use psyche_rs::{PsycheSupervisor, QuickGenius, Wit, Will, InMemoryStore, OllamaLLM};
+use std::sync::Arc;
+use tokio::sync::mpsc::unbounded_channel;
+
+let (out_tx, _out_rx) = unbounded_channel();
+let (quick, _tx) = QuickGenius::with_capacity(1, out_tx);
+let quick = Arc::new(quick);
+
+let llm = Arc::new(OllamaLLM::default());
+let store = Arc::new(InMemoryStore::new());
+let wit = Wit::new(llm.clone()).memory_store(store.clone());
+let will = Will::new(llm.clone()).memory_store(store);
+
+let mut sup = PsycheSupervisor::new();
+sup.add_genius_on_core(quick, Some(0));
+sup.start(None);
+```
+
 ---
 
 

--- a/psyche-rs/Cargo.toml
+++ b/psyche-rs/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { version = "0.12", features = ["json"] }
 uuid = { version = "1", features = ["v4"] }
 url = "2"
 once_cell = "1"
+core_affinity = "0.8"
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/psyche-rs/tests/genius_load.rs
+++ b/psyche-rs/tests/genius_load.rs
@@ -64,7 +64,7 @@ async fn load_test_throughput() {
         let (tx, rx) = bounded_channel(8, "dummy");
         let genius = Arc::new(DummyGenius::new(rx, latencies.clone(), processed.clone()));
         senders.push(tx);
-        handles.push(launch_genius(genius, Some(0)));
+        handles.push(launch_genius(genius, Some(0), None));
     }
 
     let start = Instant::now();


### PR DESCRIPTION
## Summary
- add `core_affinity` dependency and pin genius threads to cores
- allow configuring LLM and memory store in `Wit` and `Will`
- extend `PsycheSupervisor` with `add_genius_on_core`
- document thread management and configuration options
- update examples and tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869d84747f483209022da8e8c0803f4