### PR TITLE
Add battery sensor and motor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "battery"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b624268937c0e0a3edb7c27843f9e547c320d730c610d3b8e6e8e95b2026e4"
+dependencies = [
+ "cfg-if",
+ "core-foundation 0.7.0",
+ "lazycell",
+ "libc",
+ "mach",
+ "nix",
+ "num-traits",
+ "uom",
+ "winapi",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +487,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -604,13 +627,29 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -669,6 +708,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.21.7",
+ "battery",
  "bytes",
  "chrono",
  "clap",
@@ -1304,7 +1344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "iana-time-zone-haiku",
  "js-sys",
  "log",
@@ -1560,6 +1600,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "levenshtein"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,7 +1623,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "libc",
 ]
 
@@ -1610,6 +1656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1689,6 +1744,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,7 +1830,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2061,7 +2128,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2208,7 +2275,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2315,9 +2382,9 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys 0.8.7",
  "libc",
  "security-framework-sys",
 ]
@@ -2328,7 +2395,7 @@ version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
 
@@ -2609,8 +2676,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
- "core-foundation",
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2620,7 +2687,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
 
@@ -2874,7 +2941,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -3026,6 +3093,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76503e636584f1e10b9b3b9498538279561adcef5412927ba00c2b32c4ce5ed"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "url"
@@ -3481,7 +3558,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -32,6 +32,7 @@ axum = { version = "0.7", features = ["macros", "ws"] }
 hound = "3"
 base64 = "0.21"
 anyhow = "1"
+battery = "0.7"
 
 [dev-dependencies]
 httpmock = "0.7"
@@ -65,6 +66,8 @@ source-discovery-sensor = []
 moment-feedback = []
 single-wit = []
 debug_memory = []
+battery-sensor = []
+battery-motor = []
 default = [
     "logging-motor",
     "canvas-motor",
@@ -81,5 +84,7 @@ default = [
     "heard-self-sensor",
     "heard-user-sensor",
     "heartbeat-sensor",
+    "battery-sensor",
+    "battery-motor",
     "single-wit",
 ]

--- a/daringsby/src/battery_motor.rs
+++ b/daringsby/src/battery_motor.rs
@@ -1,0 +1,83 @@
+use async_trait::async_trait;
+use battery::Manager;
+use chrono::Local;
+use psyche_rs::{ActionResult, Completion, Intention, Motor, MotorError, Sensation};
+
+/// Format a battery status message.
+///
+/// # Examples
+/// ```
+/// use daringsby::battery_motor::battery_message;
+/// assert_eq!(battery_message(5), "My host battery is at 5% charge.");
+/// ```
+pub fn battery_message(pct: u8) -> String {
+    format!("My host battery is at {}% charge.", pct)
+}
+
+/// Read the current system battery percentage.
+pub fn system_battery_percentage() -> Result<u8, MotorError> {
+    let manager = Manager::new().map_err(|e| MotorError::Failed(e.to_string()))?;
+    let mut bats = manager
+        .batteries()
+        .map_err(|e| MotorError::Failed(e.to_string()))?;
+    match bats.next() {
+        Some(Ok(b)) => Ok((b.state_of_charge().value * 100.0).round() as u8),
+        Some(Err(e)) => Err(MotorError::Failed(e.to_string())),
+        None => Err(MotorError::Failed("no battery found".into())),
+    }
+}
+
+/// Motor that reports the host battery status on demand.
+#[derive(Default)]
+pub struct BatteryMotor;
+
+#[async_trait]
+impl Motor for BatteryMotor {
+    fn description(&self) -> &'static str {
+        "Check the host machine battery level.\n\
+Parameters: none.\n\
+Example:\n\
+<battery></battery>\n\
+Explanation:\n\
+The Will reads the system battery level and emits a `battery.status` sensation."
+    }
+
+    fn name(&self) -> &'static str {
+        "battery"
+    }
+
+    async fn perform(&self, intention: Intention) -> Result<ActionResult, MotorError> {
+        if intention.action.name != "battery" {
+            return Err(MotorError::Unrecognized);
+        }
+        let pct = system_battery_percentage()?;
+        let msg = battery_message(pct);
+        let completion = Completion::of_action(intention.action);
+        Ok(ActionResult {
+            sensations: vec![Sensation {
+                kind: "battery.status".into(),
+                when: Local::now(),
+                what: serde_json::Value::String(msg),
+                source: None,
+            }],
+            completed: true,
+            completion: Some(completion),
+            interruption: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn description_contains_example() {
+        let m = BatteryMotor::default();
+        assert!(m.description().contains("<battery>"));
+    }
+
+    #[test]
+    fn message_function() {
+        assert_eq!(battery_message(1), "My host battery is at 1% charge.");
+    }
+}

--- a/daringsby/src/battery_sensor.rs
+++ b/daringsby/src/battery_sensor.rs
@@ -1,0 +1,58 @@
+use async_stream::stream;
+use psyche_rs::{Sensation, Sensor};
+use rand::Rng;
+use tracing::debug;
+
+use crate::battery_motor::{battery_message, system_battery_percentage};
+
+fn interval_secs() -> u64 {
+    if std::env::var("FAST_TEST").is_ok() {
+        0
+    } else {
+        60
+    }
+}
+
+/// Sensor emitting the host battery level roughly every minute.
+#[derive(Default)]
+pub struct BatterySensor;
+
+impl Sensor<String> for BatterySensor {
+    fn stream(&mut self) -> futures::stream::BoxStream<'static, Vec<Sensation<String>>> {
+        let stream = stream! {
+            loop {
+                let jitter = {
+                    let mut rng = rand::thread_rng();
+                    rng.gen_range(0..60)
+                };
+                tokio::time::sleep(std::time::Duration::from_secs(interval_secs() + jitter)).await;
+                match system_battery_percentage() {
+                    Ok(pct) => {
+                        let msg = battery_message(pct);
+                        debug!(?msg, "battery sensed");
+                        yield vec![Sensation {
+                            kind: "battery.status".into(),
+                            when: chrono::Local::now(),
+                            what: msg,
+                            source: None,
+                        }];
+                    }
+                    Err(e) => {
+                        tracing::warn!(error=?e, "battery sensor failed");
+                    }
+                }
+            }
+        };
+        Box::pin(stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_message() {
+        assert_eq!(battery_message(42), "My host battery is at 42% charge.");
+    }
+}

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "battery-motor")]
+pub mod battery_motor;
+#[cfg(feature = "battery-sensor")]
+pub mod battery_sensor;
 #[cfg(feature = "canvas-motor")]
 pub mod canvas_motor;
 #[cfg(feature = "canvas-stream")]

--- a/daringsby/src/motor_helpers.rs
+++ b/daringsby/src/motor_helpers.rs
@@ -25,6 +25,8 @@ use crate::SourceReadMotor;
 #[cfg(feature = "source-search-motor")]
 use crate::SourceSearchMotor;
 
+#[cfg(feature = "battery-motor")]
+use crate::BatteryMotor;
 #[cfg(feature = "source-tree-motor")]
 use crate::SourceTreeMotor;
 
@@ -126,6 +128,13 @@ pub fn build_motors(
         let source_tree_motor = Arc::new(SourceTreeMotor::new(tree_tx));
         motors.push(source_tree_motor.clone());
         map.insert("source_tree".into(), source_tree_motor);
+    }
+
+    #[cfg(feature = "battery-motor")]
+    {
+        let battery_motor = Arc::new(BatteryMotor::default());
+        motors.push(battery_motor.clone());
+        map.insert("battery".into(), battery_motor);
     }
 
     (motors, Arc::new(map))

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "battery-motor")]
+pub use crate::battery_motor::BatteryMotor;
 #[cfg(feature = "canvas-motor")]
 pub use crate::canvas_motor::CanvasMotor;
 #[cfg(feature = "log-memory-motor")]

--- a/daringsby/src/runtime_helpers.rs
+++ b/daringsby/src/runtime_helpers.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "battery-motor")]
+use crate::BatteryMotor;
 use crate::{
     CanvasMotor, LogMemoryMotor, LoggingMotor, Mouth, RecallMotor, SourceReadMotor,
     SourceSearchMotor, SourceTreeMotor, SvgMotor, VisionMotor,
@@ -53,6 +55,7 @@ pub async fn drive_will_stream<M>(
     source_read: Arc<SourceReadMotor>,
     source_search: Arc<SourceSearchMotor>,
     source_tree: Arc<SourceTreeMotor>,
+    #[cfg(feature = "battery-motor")] battery: Arc<BatteryMotor>,
 ) where
     M: psyche_rs::MemoryStore + Send + Sync + 'static,
 {
@@ -103,6 +106,10 @@ pub async fn drive_will_stream<M>(
                         .perform(intent)
                         .await
                         .expect("source tree motor failed");
+                }
+                #[cfg(feature = "battery-motor")]
+                "battery" => {
+                    battery.perform(intent).await.expect("battery motor failed");
                 }
                 _ => {
                     tracing::warn!(motor = %intent.assigned_motor, "unknown motor");

--- a/daringsby/src/sensor_helpers.rs
+++ b/daringsby/src/sensor_helpers.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "battery-sensor")]
+use crate::BatterySensor;
 #[cfg(feature = "development-status-sensor")]
 use crate::development_status::DevelopmentStatus;
 use crate::{Ear, HeardSelfSensor, HeardUserSensor, Heartbeat, SpeechStream};
@@ -31,6 +33,10 @@ pub fn build_sensors(stream: Arc<SpeechStream>) -> Vec<Box<dyn Sensor<String> + 
         Box::new(HeardSelfSensor::new(stream.subscribe_heard())) as Box<dyn Sensor<String> + Send>,
         Box::new(HeardUserSensor::new(stream.subscribe_user())) as Box<dyn Sensor<String> + Send>,
     ];
+    #[cfg(feature = "battery-sensor")]
+    {
+        sensors.push(Box::new(BatterySensor::default()) as Box<dyn Sensor<String> + Send>);
+    }
     #[cfg(feature = "development-status-sensor")]
     {
         debug!("development status sensor plugged in");

--- a/daringsby/src/sensors.rs
+++ b/daringsby/src/sensors.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "battery-sensor")]
+pub use crate::battery_sensor::BatterySensor;
 /// Sensor-related types re-exported for convenience.
 ///
 /// # Examples


### PR DESCRIPTION
## Summary
- provide BatterySensor to monitor host battery level
- implement BatteryMotor for manual checks
- wire battery features into helpers and runtime
- expose new features and enable by default

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869e6a99adc8320b37f0216d9a7fa55