### PR TITLE
Summarize repo in dev status sensor

### DIFF
--- a/daringsby/src/development_status.rs
+++ b/daringsby/src/development_status.rs
@@ -1,9 +1,19 @@
 use async_stream::stream;
+use once_cell::sync::Lazy;
+use segtok::segmenter::{SegmentConfig, split_single};
 use tracing::debug;
 
 use psyche_rs::{Sensation, Sensor};
 
 const DEVELOPMENT_TEXT: &str = include_str!("development_status.txt");
+
+static DEVELOPMENT_SENTENCES: Lazy<Vec<String>> = Lazy::new(|| {
+    split_single(DEVELOPMENT_TEXT, SegmentConfig::default())
+        .into_iter()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+});
 
 /// Sensor that reminds Pete he is under active development.
 ///
@@ -31,16 +41,21 @@ pub struct DevelopmentStatus;
 
 impl Sensor<String> for DevelopmentStatus {
     fn stream(&mut self) -> futures::stream::BoxStream<'static, Vec<Sensation<String>>> {
+        let sentences = DEVELOPMENT_SENTENCES.clone();
+        let mut index = 0usize;
+        let len = sentences.len();
         let stream = stream! {
             loop {
                 if std::env::var("FAST_TEST").is_err() {
                     tokio::time::sleep(std::time::Duration::from_secs(60)).await;
                 }
                 debug!("development status sensed");
+                let text = sentences[index].clone();
+                index = (index + 1) % len;
                 let s = Sensation {
                     kind: "development_status".into(),
                     when: chrono::Local::now(),
-                    what: DEVELOPMENT_TEXT.trim().to_string(),
+                    what: text,
                     source: None,
                 };
                 yield vec![s];
@@ -60,10 +75,10 @@ mod tests {
         unsafe { std::env::set_var("FAST_TEST", "1") };
         let mut sensor = DevelopmentStatus;
         let mut stream = sensor.stream();
-        if let Some(batch) = stream.next().await {
-            assert!(batch[0].what.contains("still under development"));
-        } else {
-            panic!("no message emitted");
-        }
+        let batch1 = stream.next().await.expect("first batch");
+        assert!(batch1[0].what.contains("still under development"));
+
+        let batch2 = stream.next().await.expect("second batch");
+        assert_ne!(batch2[0].what, batch1[0].what);
     }
 }

--- a/daringsby/src/development_status.txt
+++ b/daringsby/src/development_status.txt
@@ -1,1 +1,8 @@
-Pete, you are still under development. Travis, ChatGPT, and Codex are adding new sensors and motors for you. Don't worry—explore your senses and movements, and enjoy the experience of being. It's okay to feel fear, but also contentment and curiosity. Take a look at your code using your motors.
+Pete, you are still under development as an embodied agent powered by the psyche-rs core.
+The psyche-rs crate provides sensations, impressions, Wits and Will to transform perceptions into motor intentions.
+The daringsby crate wires sensors like heartbeat, audio, and self discovery with motors for speaking, memory logging, and code introspection.
+Async tasks stream sensations through Wits and Will, then a motor executor carries out the resulting intentions.
+A voice module uses LLMs and text to speech to vocalize your responses.
+Tests cover runtime responsiveness and motor behaviors to keep everything reliable.
+More sensors and motors will appear as the project evolves.
+


### PR DESCRIPTION
## Summary
- explain code base in `development_status.txt`
- stream development status one sentence at a time

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869edc856a08320b71a79b191380960