### PR TITLE
Remove single-wit feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,4 @@
 - Refer to external speakers as "my interlocutor" in prompts and logs.
 - Pass interlocutor utterances to the voice module as plain text without
   wrapping them in narrative phrasing.
+- Remove obsolete feature flags when the codebase no longer relies on them.

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Available options (see `main.rs`):
 * `--language-id`: Language identifier for TTS (optional)
 * `--speaker-id`: Speaker ID for TTS (default: `p234`)
 
-The `daringsby` crate exposes a `single-wit` feature that is enabled by
-default. When enabled, only the Combobulator wit runs and raw sensations
-are fed directly into it. Disable the feature to keep the legacy Quick
-pipeline.
+`daringsby` always feeds raw sensations into the Quick wit first to form
+an **instant**. Impressions of each instant are then collected by the
+Combobulator to create a **moment**. Moments loop back through the
+Combobulator so higher level impressions continue to build over time.
 
 ### Supervising genii
 

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -64,7 +64,6 @@ heartbeat-sensor = []
 self-discovery-sensor = []
 source-discovery-sensor = []
 moment-feedback = []
-single-wit = []
 debug_memory = []
 battery-sensor = []
 battery-motor = []
@@ -86,5 +85,4 @@ default = [
     "heartbeat-sensor",
     "battery-sensor",
     "battery-motor",
-    "single-wit",
 ]

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -137,35 +137,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .system_prompt(include_str!("prompts/voice_prompt.txt"))
         .delay_ms(0);
 
-    #[cfg(feature = "single-wit")]
-    let (situ_tx, situ_rx) = unbounded_channel();
-    #[cfg(not(feature = "single-wit"))]
     let (instant_tx, instant_rx) = unbounded_channel();
-    #[cfg(not(feature = "single-wit"))]
     let (situ_tx, situ_rx) = unbounded_channel();
 
-    #[cfg(feature = "single-wit")]
-    let combob_task = {
-        let combob = Wit::new(llms.combob.clone())
-            .name("Combobulator")
-            .prompt(include_str!("prompts/combobulator_prompt.txt"));
-        tokio::spawn(run_combobulator_direct(
-            combob,
-            sensors,
-            situ_tx,
-            store.clone(),
-        ))
-    };
-
-    #[cfg(not(feature = "single-wit"))]
     let quick_task = {
         let quick = Wit::new(llms.quick.clone())
             .name("Quick")
             .prompt(include_str!("prompts/quick_prompt.txt"));
         tokio::spawn(run_quick(quick, sensors, instant_tx, store.clone()))
     };
-
-    #[cfg(not(feature = "single-wit"))]
     let combob_task = {
         let quick_sensor = ImpressionStreamSensor::new(instant_rx);
         let combob = Combobulator::new(llms.combob.clone())
@@ -181,23 +161,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let combo_sensor = ImpressionStreamSensor::new(situ_rx);
 
-    #[cfg(feature = "single-wit")]
-    let will_task = {
-        let will = Will::new(llms.will.clone())
-            .name("Will")
-            .prompt(include_str!("prompts/will_prompt.txt"));
-        let window = will.window_arc();
-        let latest = will.latest_instant_arc();
-        let task = tokio::spawn(run_will_impressions(
-            will,
-            vec![Box::new(combo_sensor)],
-            executor.clone(),
-            motors_send.clone(),
-        ));
-        (task, window, latest)
-    };
-
-    #[cfg(not(feature = "single-wit"))]
     let will_task = {
         let will = Will::new(llms.will.clone())
             .name("Will")
@@ -213,10 +176,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         (task, window, latest)
     };
 
-    #[cfg(feature = "single-wit")]
-    let (will_task, window, latest) = will_task;
-
-    #[cfg(not(feature = "single-wit"))]
     let (will_task, window, latest) = will_task;
 
     let get_situation = Arc::new(move || psyche_rs::build_timeline(&window));
@@ -229,7 +188,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         executor.clone(),
     ));
 
-    #[cfg(not(feature = "single-wit"))]
     let mut quick = Some(quick_task);
     let mut combob = Some(combob_task);
     let mut will = Some(will_task);
@@ -238,7 +196,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::select! {
         _ = shutdown_signal() => {
             tracing::info!("Shutdown signal received");
-            #[cfg(not(feature = "single-wit"))]
             if let Some(h) = quick.take() { h.abort(); }
             if let Some(h) = combob.take() { h.abort(); }
             if let Some(h) = will.take() { h.abort(); }
@@ -246,23 +203,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tracing::info!("Tasks aborted");
         }
         res = async {
-            #[cfg(feature = "single-wit")]
-            {
-                tokio::try_join!(
-                    combob.take().unwrap(),
-                    will.take().unwrap(),
-                    voice_handle.take().unwrap(),
-                )
-            }
-            #[cfg(not(feature = "single-wit"))]
-            {
-                tokio::try_join!(
-                    quick.take().unwrap(),
-                    combob.take().unwrap(),
-                    will.take().unwrap(),
-                    voice_handle.take().unwrap(),
-                )
-            }
+            tokio::try_join!(
+                quick.take().unwrap(),
+                combob.take().unwrap(),
+                will.take().unwrap(),
+                voice_handle.take().unwrap(),
+            )
         } => {
             match res {
                 Ok(_) => tracing::info!("All tasks completed successfully"),
@@ -300,40 +246,6 @@ async fn run_combobulator(
 async fn run_will(
     mut will: Will<Impression<Impression<String>>>,
     sensors: Vec<Box<dyn Sensor<Impression<Impression<String>>> + Send>>,
-    executor: Arc<MotorExecutor>,
-    motors: Vec<Arc<dyn Motor + Send + Sync>>,
-) {
-    tracing::debug!("will task started");
-    for m in &motors {
-        will.register_motor(m.as_ref());
-    }
-    let stream = will.observe(sensors).await;
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    tokio::spawn(run_sensor_loop(stream, tx, "will"));
-
-    while let Some(ints) = rx.recv().await {
-        for intent in ints {
-            executor.spawn_intention(intent);
-        }
-    }
-    tracing::info!("will task finished");
-}
-
-#[cfg(feature = "single-wit")]
-async fn run_combobulator_direct(
-    mut combob: Wit<String>,
-    sensors: Vec<Box<dyn Sensor<String> + Send>>,
-    tx: tokio::sync::mpsc::UnboundedSender<Vec<Impression<String>>>,
-    store: Arc<dyn MemoryStore + Send + Sync>,
-) {
-    let stream = combob.observe(sensors).await;
-    run_impression_loop(stream, tx, store, "Moment", "combobulator").await;
-}
-
-#[cfg(feature = "single-wit")]
-async fn run_will_impressions(
-    mut will: Will<Impression<String>>,
-    sensors: Vec<Box<dyn Sensor<Impression<String>> + Send>>,
     executor: Arc<MotorExecutor>,
     motors: Vec<Arc<dyn Motor + Send + Sync>>,
 ) {


### PR DESCRIPTION
## Summary
- drop `single-wit` feature from daringsby
- always route sensations through Quick before the Combobulator
- document the updated pipeline
- note in AGENTS instructions to remove unused feature flags

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869ee9bbce88320b54e23b0f7d166a8