### PR TITLE
Add warnings for broadcast send errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,4 @@
 - Pass interlocutor utterances to the voice module as plain text without
   wrapping them in narrative phrasing.
 - Remove obsolete feature flags when the codebase no longer relies on them.
+- Use `tracing-test` with the `no-env-filter` feature when verifying log output.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "url",
  "uuid",
 ]
@@ -3025,6 +3026,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -44,6 +44,7 @@ tower = { version = "0.4", features = ["util"] }
 tokio-tungstenite = "0.21"
 tempfile = "3"
 serial_test = "2"
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 
 [features]
 logging-motor = []


### PR DESCRIPTION
## Summary
- warn when broadcast messages fail in speech stream, vision sensor, canvas stream and mouth
- handle PsycheSupervisor shutdown failures
- capture broadcast send logs in tests
- note use of no-env-filter in AGENTS instructions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869f9a94e688320a55e4b568ae751a6