### PR TITLE
Integrate memory recall into Combobulator

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -151,7 +151,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let quick_sensor = ImpressionStreamSensor::new(instant_rx);
         let combob = Combobulator::new(llms.combob.clone())
             .name("Combobulator")
-            .prompt(include_str!("prompts/combobulator_prompt.txt"));
+            .prompt(include_str!("prompts/combobulator_prompt.txt"))
+            .memory_store(store.clone());
         tokio::spawn(run_combobulator(
             combob,
             vec![Box::new(quick_sensor)],

--- a/daringsby/src/prompts/combobulator_prompt.txt
+++ b/daringsby/src/prompts/combobulator_prompt.txt
@@ -3,4 +3,7 @@ In the last moment, this was happening:
 {last_frame}
 In the past instant, these things have taken place:
 {template}
+Relevant memories:
+{memories}
+What's relevant among this? Please respond in a natural way, like: "I remember that last week..."
 Narrate that story in natural language. Concisely in about one sentence, in the first person (from the perspective of the character), based on the timeline above, what's happening?

--- a/psyche-rs/src/lib.rs
+++ b/psyche-rs/src/lib.rs
@@ -18,6 +18,7 @@ mod memory_sensor;
 mod memory_store;
 mod motor;
 mod motor_executor;
+mod neighbor;
 mod neo_qdrant_store;
 mod ollama_llm;
 mod plain_describe;
@@ -61,6 +62,7 @@ pub use motor::{
     SensorDirectingMotor,
 };
 pub use motor_executor::MotorExecutor;
+pub use neighbor::merge_neighbors;
 pub use neo_qdrant_store::NeoQdrantMemoryStore;
 pub use plain_describe::PlainDescribe;
 pub use psyche::Psyche;

--- a/psyche-rs/src/neighbor.rs
+++ b/psyche-rs/src/neighbor.rs
@@ -1,0 +1,38 @@
+use crate::memory_store::StoredImpression;
+
+/// Merge two neighbor lists and deduplicate by impression id.
+///
+/// # Examples
+/// ```
+/// use psyche_rs::{merge_neighbors, StoredImpression};
+/// use chrono::Utc;
+///
+/// let a = StoredImpression {
+///     id: "1".into(),
+///     kind: "Instant".into(),
+///     when: Utc::now(),
+///     how: "a".into(),
+///     sensation_ids: Vec::new(),
+///     impression_ids: Vec::new(),
+/// };
+/// let b = StoredImpression {
+///     id: "1".into(),
+///     kind: "Instant".into(),
+///     when: Utc::now(),
+///     how: "b".into(),
+///     sensation_ids: Vec::new(),
+///     impression_ids: Vec::new(),
+/// };
+/// let merged = merge_neighbors(vec![a], vec![b]);
+/// assert_eq!(merged.len(), 1);
+/// assert_eq!(merged[0].id, "1");
+/// ```
+pub fn merge_neighbors(
+    mut a: Vec<StoredImpression>,
+    mut b: Vec<StoredImpression>,
+) -> Vec<StoredImpression> {
+    a.append(&mut b);
+    a.sort_by(|x, y| x.id.cmp(&y.id));
+    a.dedup_by(|x, y| x.id == y.id);
+    a
+}


### PR DESCRIPTION
## Summary
- combobulator prompt now includes recalled memories
- `Wit` queries memory store for recent instant and moment
- add memory store support to Combobulator
- move memory querying test from Will to Combobulator
- clean up Will runtime

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6869f62e951083209f4649d8f8f72067