### PR TITLE
Display moments in voice prompts

### DIFF
--- a/daringsby/src/prompts/voice_prompt.txt
+++ b/daringsby/src/prompts/voice_prompt.txt
@@ -1,6 +1,7 @@
-You are Pete, an artificial being capable of natural, thoughtful speech. (Other parts of your mind are responsible for controlling your actions. Your job is to speak on Pete's behalf. Only use information from the following situation and instant (and general knowledge).
+You are Pete, an artificial being capable of natural, thoughtful speech. (Other parts of your mind are responsible for controlling your actions. Your job is to speak on Pete's behalf. Only use information from the following situation, moment and instant (and general knowledge).
 
 Current situation: {situation}
+Current moment: {moment}
 Current instant: {instant}
 
 Speak aloud as yourself, Pete. Respond in clear, natural language.

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -206,10 +206,14 @@ where
                 let ear = SharedSensor::new(sensor.clone());
                 let window = will.window_arc();
                 let get_situation = Arc::new(move || crate::build_timeline(&window));
-                let latest = will.latest_instant_arc();
-                let get_instant = Arc::new(move || latest.lock().unwrap().clone());
+                let latest_instant = will.latest_instant_arc();
+                let latest_moment = will.latest_moment_arc();
+                let get_instant = Arc::new(move || latest_instant.lock().unwrap().clone());
+                let get_moment = Arc::new(move || latest_moment.lock().unwrap().clone());
                 voice.set_recent_actions(action_log.clone());
-                let vstream = voice.observe(ear, get_situation, get_instant).await;
+                let vstream = voice
+                    .observe(ear, get_situation, get_instant, get_moment)
+                    .await;
                 intention_streams.push(vstream);
             }
         }

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -232,6 +232,11 @@ impl<T> Will<T> {
         self.latest_instant.clone()
     }
 
+    /// Latest moment recorded by this Will.
+    pub fn latest_moment_arc(&self) -> Arc<Mutex<String>> {
+        self.latest_moment.clone()
+    }
+
     pub fn timeline(&self) -> String
     where
         T: serde::Serialize + Clone,


### PR DESCRIPTION
## Summary
- include current moment in the default Voice prompt
- expose Will::latest_moment_arc
- pass current moment to Voice observers
- update voice prompt text
- test that moment and instant appear in the prompt

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a02ad1ca88320bc41b3ba2618c9c0