### PR TITLE
Add memory consolidation motor and sensor

### DIFF
--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -68,6 +68,8 @@ moment-feedback = []
 debug_memory = []
 battery-sensor = []
 battery-motor = []
+memory-consolidation-motor = []
+memory-consolidation-sensor = []
 default = [
     "logging-motor",
     "log-memory-motor",
@@ -91,4 +93,6 @@ default = [
     "heartbeat-sensor",
     "battery-sensor",
     "battery-motor",
+    "memory-consolidation-motor",
+    "memory-consolidation-sensor",
 ]

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -21,6 +21,10 @@ pub mod log_file;
 pub mod log_memory_motor;
 #[cfg(feature = "logging-motor")]
 pub mod logging_motor;
+#[cfg(feature = "memory-consolidation-motor")]
+pub mod memory_consolidation_motor;
+#[cfg(feature = "memory-consolidation-sensor")]
+pub mod memory_consolidation_sensor;
 pub mod memory_helpers;
 #[cfg(feature = "mouth")]
 pub mod mouth;

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -121,7 +121,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ));
     let qdrant_url = Url::parse(&args.qdrant_url)?;
     ensure_impressions_collection_exists(&Client::new(), &qdrant_url).await?;
-    let (motors, _motor_map) = build_motors(
+    let (motors, _motor_map, consolidation_status) = build_motors(
         &llms,
         mouth.clone(),
         vision.clone(),
@@ -141,7 +141,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
     ));
 
-    let sensors = build_sensors(stream.clone());
+    let sensors = build_sensors(
+        stream.clone(),
+        #[cfg(feature = "memory-consolidation-sensor")]
+        consolidation_status.clone(),
+    );
     let ear = build_ear(stream.clone());
     let voice = Voice::new(voice_llm.clone(), 10)
         .name("Voice")

--- a/daringsby/src/memory_consolidation_motor.rs
+++ b/daringsby/src/memory_consolidation_motor.rs
@@ -1,0 +1,135 @@
+use async_trait::async_trait;
+use chrono::{Local, Utc};
+use std::sync::Arc;
+use tokio::sync::{Mutex, mpsc::UnboundedSender};
+use tracing::{debug, info, warn};
+
+use psyche_rs::{
+    ActionResult, ClusterAnalyzer, Completion, Intention, LLMClient, MemoryStore, Motor,
+    MotorError, Sensation,
+};
+
+use crate::memory_consolidation_sensor::ConsolidationStatus;
+
+fn delay() -> std::time::Duration {
+    if std::env::var("FAST_TEST").is_ok() {
+        std::time::Duration::from_millis(50)
+    } else {
+        std::time::Duration::from_secs(0)
+    }
+}
+
+/// Motor that consolidates memory summaries using [`ClusterAnalyzer`].
+///
+/// The action tag `<consolidate></consolidate>` triggers consolidation.
+/// Summaries are created for recent impressions in small groups. The process
+/// runs asynchronously and its progress is reflected in
+/// [`ConsolidationStatus`].
+pub struct MemoryConsolidationMotor<M: MemoryStore + Send + Sync, C: LLMClient + ?Sized> {
+    analyzer: Arc<ClusterAnalyzer<M, C>>,
+    status: Arc<Mutex<ConsolidationStatus>>,
+    batch_size: usize,
+    cluster_size: usize,
+    tx: UnboundedSender<Vec<Sensation<String>>>,
+}
+
+impl<M: MemoryStore + Send + Sync, C: LLMClient + ?Sized> MemoryConsolidationMotor<M, C> {
+    /// Create a new motor backed by the given analyzer and status holder.
+    pub fn new(
+        analyzer: Arc<ClusterAnalyzer<M, C>>,
+        status: Arc<Mutex<ConsolidationStatus>>,
+        tx: UnboundedSender<Vec<Sensation<String>>>,
+    ) -> Self {
+        Self {
+            analyzer,
+            status,
+            batch_size: 20,
+            cluster_size: 5,
+            tx,
+        }
+    }
+
+    async fn run_consolidation(
+        analyzer: Arc<ClusterAnalyzer<M, C>>,
+        status: Arc<Mutex<ConsolidationStatus>>,
+        batch_size: usize,
+        cluster_size: usize,
+    ) {
+        {
+            let mut s = status.lock().await;
+            s.in_progress = true;
+        }
+        tokio::time::sleep(delay()).await;
+        let imps = match analyzer.store.fetch_recent_impressions(batch_size).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error=?e, "failed to fetch impressions");
+                let mut s = status.lock().await;
+                s.in_progress = false;
+                return;
+            }
+        };
+        let clusters: Vec<Vec<String>> = imps
+            .chunks(cluster_size)
+            .map(|c| c.iter().map(|i| i.id.clone()).collect())
+            .collect();
+        let count = clusters.len();
+        if let Err(e) = analyzer.summarize(clusters).await {
+            warn!(error=?e, "consolidation summarize failed");
+        }
+        {
+            let mut s = status.lock().await;
+            s.in_progress = false;
+            s.last_finished = Some(Utc::now());
+            s.cluster_count = count;
+        }
+        info!("memory consolidation complete");
+    }
+}
+
+#[async_trait]
+impl<M: MemoryStore + Send + Sync + 'static, C: LLMClient + ?Sized + 'static> Motor
+    for MemoryConsolidationMotor<M, C>
+{
+    fn description(&self) -> &'static str {
+        "Consolidate related memories into summaries.\n\
+Parameters: none.\n\
+Example:\n\
+<consolidate></consolidate>"
+    }
+
+    fn name(&self) -> &'static str {
+        "consolidate"
+    }
+
+    async fn perform(&self, intention: Intention) -> Result<ActionResult, MotorError> {
+        if intention.action.name != "consolidate" {
+            return Err(MotorError::Unrecognized);
+        }
+        let analyzer = self.analyzer.clone();
+        let status = self.status.clone();
+        let batch = self.batch_size;
+        let cluster = self.cluster_size;
+        tokio::spawn(Self::run_consolidation(analyzer, status, batch, cluster));
+        let completion = Completion::of_action(intention.action);
+        debug!(?completion, "action completed");
+        let started = Sensation {
+            kind: "memory.consolidation.started".into(),
+            when: Local::now(),
+            what: "started".to_string(),
+            source: None,
+        };
+        let _ = self.tx.send(vec![started.clone()]);
+        Ok(ActionResult {
+            sensations: vec![Sensation {
+                kind: "memory.consolidation.started".into(),
+                when: Local::now(),
+                what: serde_json::Value::String("started".into()),
+                source: None,
+            }],
+            completed: true,
+            completion: Some(completion),
+            interruption: None,
+        })
+    }
+}

--- a/daringsby/src/memory_consolidation_sensor.rs
+++ b/daringsby/src/memory_consolidation_sensor.rs
@@ -1,0 +1,47 @@
+use async_stream::stream;
+use chrono::{Local, Utc};
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use psyche_rs::{Sensation, Sensor};
+
+/// Shared status for memory consolidation tasks.
+#[derive(Default, Debug, Clone)]
+pub struct ConsolidationStatus {
+    pub in_progress: bool,
+    pub last_finished: Option<chrono::DateTime<Utc>>,
+    pub cluster_count: usize,
+}
+
+/// Sensor providing memory consolidation status snapshots.
+pub struct MemoryConsolidationSensor {
+    status: Arc<Mutex<ConsolidationStatus>>,
+}
+
+impl MemoryConsolidationSensor {
+    /// Create a new sensor reading from the provided status.
+    pub fn new(status: Arc<Mutex<ConsolidationStatus>>) -> Self {
+        Self { status }
+    }
+}
+
+impl Sensor<String> for MemoryConsolidationSensor {
+    fn stream(&mut self) -> futures::stream::BoxStream<'static, Vec<Sensation<String>>> {
+        let status = self.status.clone();
+        Box::pin(stream! {
+            let s = status.lock().await.clone();
+            let data = json!({
+                "in_progress": s.in_progress,
+                "last_finished": s.last_finished.map(|d| d.to_rfc3339()),
+                "cluster_count": s.cluster_count,
+            });
+            yield vec![Sensation {
+                kind: "memory.consolidation.status".into(),
+                when: Local::now(),
+                what: data.to_string(),
+                source: None,
+            }];
+        })
+    }
+}

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -12,6 +12,8 @@ pub use crate::log_memory_motor::LogMemoryMotor;
 /// ```
 #[cfg(feature = "logging-motor")]
 pub use crate::logging_motor::LoggingMotor;
+#[cfg(feature = "memory-consolidation-motor")]
+pub use crate::memory_consolidation_motor::MemoryConsolidationMotor;
 #[cfg(feature = "mouth")]
 pub use crate::mouth::Mouth;
 #[cfg(feature = "recall-motor")]

--- a/daringsby/src/sensor_helpers.rs
+++ b/daringsby/src/sensor_helpers.rs
@@ -2,9 +2,13 @@
 use crate::BatterySensor;
 #[cfg(feature = "development-status-sensor")]
 use crate::development_status::DevelopmentStatus;
+#[cfg(feature = "memory-consolidation-sensor")]
+use crate::memory_consolidation_sensor::{ConsolidationStatus, MemoryConsolidationSensor};
 use crate::{Ear, HeardSelfSensor, HeardUserSensor, Heartbeat, SpeechStream};
 use psyche_rs::Sensor;
 use std::sync::Arc;
+#[cfg(feature = "memory-consolidation-sensor")]
+use tokio::sync::Mutex;
 use tracing::debug;
 
 /// Build the sensors used by Daringsby.
@@ -24,10 +28,15 @@ use tracing::debug;
 /// let (_t_tx, t_rx) = broadcast::channel(1);
 /// let (_s_tx, s_rx) = broadcast::channel(1);
 /// let stream = Arc::new(SpeechStream::new(a_rx, t_rx, s_rx));
-/// let sensors = build_sensors(stream);
+/// let sensors = build_sensors(stream, None);
 /// assert!(!sensors.is_empty());
 /// ```
-pub fn build_sensors(stream: Arc<SpeechStream>) -> Vec<Box<dyn Sensor<String> + Send>> {
+pub fn build_sensors(
+    stream: Arc<SpeechStream>,
+    #[cfg(feature = "memory-consolidation-sensor")] consolidation: Option<
+        Arc<Mutex<ConsolidationStatus>>,
+    >,
+) -> Vec<Box<dyn Sensor<String> + Send>> {
     let mut sensors: Vec<Box<dyn Sensor<String> + Send>> = vec![
         Box::new(Heartbeat) as Box<dyn Sensor<String> + Send>,
         Box::new(HeardSelfSensor::new(stream.subscribe_heard())) as Box<dyn Sensor<String> + Send>,
@@ -41,6 +50,12 @@ pub fn build_sensors(stream: Arc<SpeechStream>) -> Vec<Box<dyn Sensor<String> + 
     {
         debug!("development status sensor plugged in");
         sensors.push(Box::new(DevelopmentStatus) as Box<dyn Sensor<String> + Send>);
+    }
+    #[cfg(feature = "memory-consolidation-sensor")]
+    if let Some(status) = consolidation {
+        sensors.push(
+            Box::new(MemoryConsolidationSensor::new(status)) as Box<dyn Sensor<String> + Send>
+        );
     }
     sensors
 }
@@ -64,7 +79,7 @@ mod tests {
         let (_t_tx, t_rx) = broadcast::channel(1);
         let (_s_tx, s_rx) = broadcast::channel(1);
         let stream = Arc::new(SpeechStream::new(a_rx, t_rx, s_rx));
-        let sensors = build_sensors(stream);
+        let sensors = build_sensors(stream, None);
         let mut found = false;
         for mut sensor in sensors {
             if let Some(batch) = sensor.stream().next().await {

--- a/daringsby/src/sensors.rs
+++ b/daringsby/src/sensors.rs
@@ -16,6 +16,8 @@ pub use crate::heard_self_sensor::HeardSelfSensor;
 pub use crate::heard_user_sensor::HeardUserSensor;
 #[cfg(feature = "heartbeat-sensor")]
 pub use crate::heartbeat::{Heartbeat, heartbeat_message};
+#[cfg(feature = "memory-consolidation-sensor")]
+pub use crate::memory_consolidation_sensor::MemoryConsolidationSensor;
 #[cfg(feature = "recall-motor")]
 pub use crate::recall_sensor::RecallSensor;
 #[cfg(feature = "self-discovery-sensor")]

--- a/psyche-rs/src/cluster_analyzer.rs
+++ b/psyche-rs/src/cluster_analyzer.rs
@@ -49,12 +49,12 @@ use std::sync::Arc;
 ///     analyzer.summarize(vec![vec!["i1".to_string()]]).await.unwrap();
 /// });
 /// ```
-pub struct ClusterAnalyzer<M: MemoryStore + Send + Sync, C: LLMClient> {
+pub struct ClusterAnalyzer<M: MemoryStore + Send + Sync, C: LLMClient + ?Sized> {
     pub store: M,
     llm: Arc<C>,
 }
 
-impl<M: MemoryStore + Send + Sync, C: LLMClient> ClusterAnalyzer<M, C> {
+impl<M: MemoryStore + Send + Sync, C: LLMClient + ?Sized> ClusterAnalyzer<M, C> {
     /// Create a new analyzer.
     pub fn new(store: M, llm: Arc<C>) -> Self {
         Self { store, llm }


### PR DESCRIPTION
## Summary
- implement asynchronous MemoryConsolidationMotor and status sensor
- register modules in helpers and expose default features
- allow cluster analyzer to accept unsized LLM clients

## Testing
- `cargo test` *(fails: 4 tests)*

------
https://chatgpt.com/codex/tasks/task_e_686a59728fe88320be1c07b4812d28f1