### PR TITLE
Add chat history to web interface

### DIFF
--- a/daringsby/src/index.html
+++ b/daringsby/src/index.html
@@ -6,10 +6,29 @@
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/@picocss/pico@1.5.11/css/pico.min.css"
   />
+  <style>
+    #chat-history {
+      height: 200px;
+      overflow-y: auto;
+      border: 1px solid var(--muted-color);
+      padding: 0.5rem;
+      margin-top: 1rem;
+      margin-bottom: 1rem;
+    }
+    .chat-user {
+      text-align: right;
+      color: var(--primary);
+    }
+    .chat-assistant {
+      text-align: left;
+      color: var(--secondary);
+    }
+  </style>
   <script src="https://cdn.jsdelivr.net/npm/canvg@3.0.10/lib/umd.min.js"></script>
 </head>
 <body class="container">
 <button id="start" class="secondary">Start</button>
+<section id="chat-history"></section>
 <form id="message-form" role="form">
   <label for="message-input">Message:</label>
   <input
@@ -42,6 +61,15 @@ let queue = [];
 let texts = [];
 let playing = false;
 let pendingText = null;
+
+function appendMessage(role, text) {
+  const container = document.getElementById('chat-history');
+  const div = document.createElement('div');
+  div.className = role === 'user' ? 'chat-user' : 'chat-assistant';
+  div.textContent = text;
+  container.appendChild(div);
+  container.scrollTop = container.scrollHeight;
+}
 
 function openSocket(existing, url, binaryType) {
   if (existing && existing.readyState <= WebSocket.OPEN) return existing;
@@ -88,6 +116,7 @@ function nextPendingText() {
 function sendHeard() {
   if (pendingText && heardWs && heardWs.readyState === WebSocket.OPEN) {
     heardWs.send(pendingText);
+    appendMessage('assistant', pendingText);
   } else if (pendingText) {
     console.warn(
       "heardWs not ready or no text to send",
@@ -105,6 +134,7 @@ function sendMessage(ev) {
   const text = input.value.trim();
   if (text && userWs && userWs.readyState === WebSocket.OPEN) {
     userWs.send(text);
+    appendMessage('user', text);
   }
   input.value = '';
 }


### PR DESCRIPTION
## Summary
- show chat history with user and assistant messages
- keep scroll position pinned to the bottom

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686a63015dc88320af23adfe41e1bbb7