### PR TITLE
Collapse quick into combobulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,7 @@ Available options (see `main.rs`):
 * `--language-id`: Language identifier for TTS (optional)
 * `--speaker-id`: Speaker ID for TTS (default: `p234`)
 
-`daringsby` always feeds raw sensations into the Quick wit first to form
-an **instant**. Impressions of each instant are then collected by the
-Combobulator to create a **moment**. Moments loop back through the
-Combobulator so higher level impressions continue to build over time.
+`daringsby` feeds raw sensations directly into the Combobulator, which summarizes them into moments. Moments loop back through the Combobulator so higher level impressions continue to build over time.
 
 ### Supervising genii
 


### PR DESCRIPTION
## Summary
- remove the quick wit stage and send its sensors directly to the Combobulator
- adjust Combobulator to accept raw sensor input
- update README to describe the simplified pipeline

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686abadc2bfc8320b791559a6ecb5869