### PR TITLE
Reuse stored sensations for new impressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,4 @@
   wrapping them in narrative phrasing.
 - Remove obsolete feature flags when the codebase no longer relies on them.
 - Use `tracing-test` with the `no-env-filter` feature when verifying log output.
+- Ensure `persist_impression` checks for existing sensations via `find_sensation` to avoid duplicates.

--- a/psyche-rs/src/retry.rs
+++ b/psyche-rs/src/retry.rs
@@ -99,6 +99,16 @@ where
         self.policy.retry(|| self.inner.store_sensation(s)).await
     }
 
+    async fn find_sensation(
+        &self,
+        kind: &str,
+        data: &str,
+    ) -> anyhow::Result<Option<crate::memory_store::StoredSensation>> {
+        self.policy
+            .retry(|| self.inner.find_sensation(kind, data))
+            .await
+    }
+
     async fn store_impression(
         &self,
         i: &crate::memory_store::StoredImpression,


### PR DESCRIPTION
## Summary
- avoid duplicate sensations in `daringsby` helper
- expose `persist_impression` for cross-module tests
- add neo4j test covering sensation reuse
- test helper ensures reuse via `InMemoryStore`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ad73441b88320a428b258c41e36eb