### PR TITLE
Fix Neo4j sensation id parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@
 - Remove obsolete feature flags when the codebase no longer relies on them.
 - Use `tracing-test` with the `no-env-filter` feature when verifying log output.
 - Ensure `persist_impression` checks for existing sensations via `find_sensation` to avoid duplicates.
+- When mapping Neo4j nodes to structs, alias the `uuid` property to the `id` field.

--- a/psyche-rs/src/memory_store.rs
+++ b/psyche-rs/src/memory_store.rs
@@ -7,6 +7,9 @@ use async_trait::async_trait;
 /// Represents a sensation stored in memory.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StoredSensation {
+    /// Unique identifier for the sensation. Neo4j stores this under the `uuid`
+    /// property so we alias that name for deserialisation.
+    #[serde(alias = "uuid")]
     pub id: String,
     pub kind: String,
     pub when: DateTime<Utc>,


### PR DESCRIPTION
## Summary
- alias `uuid` to `id` in `StoredSensation`
- document Neo4j `uuid` alias rule in `AGENTS.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686adc589e2483208a9f85f4ea98f571