### PR TITLE
Expand motor queue

### DIFF
--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -135,10 +135,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .cloned()
         .map(|m| m as Arc<dyn Motor + Send + Sync>)
         .collect();
+    // Increased worker pool and queue capacity to handle bursts of
+    // intentions without dropping them.
     let executor = Arc::new(MotorExecutor::new(
         motors_send.clone(),
-        4,
-        16,
+        8,
+        64,
         Some(store.clone()),
         None,
     ));

--- a/psyche-rs/src/psyche.rs
+++ b/psyche-rs/src/psyche.rs
@@ -186,10 +186,12 @@ where
         for m in self.motors.iter() {
             will.register_motor(m.as_ref());
         }
+        // Use a larger worker pool and queue to reduce dropped intentions when
+        // motors are slow to respond.
         let executor = crate::MotorExecutor::new(
             self.motors.clone(),
-            4,
-            16,
+            8,
+            64,
             self.store.clone(),
             Some(action_log.clone()),
         );


### PR DESCRIPTION
## Summary
- extend motor executor worker pool and queue capacity

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686dda99360483209a3328fa8a9eeb27