### PR TITLE
Fix memory question output

### DIFF
--- a/daringsby/src/prompts/combobulator_prompt.txt
+++ b/daringsby/src/prompts/combobulator_prompt.txt
@@ -3,7 +3,5 @@ In the last moment, this was happening:
 {last_frame}
 In the past instant, these things have taken place:
 {template}
-Relevant memories:
 {memories}
-What's relevant among these memories?
 Narrate that story in natural language. Concisely in about one sentence, in the first person (from the perspective of the character), based on the timeline above, what's happening?

--- a/daringsby/src/prompts/will_prompt.txt
+++ b/daringsby/src/prompts/will_prompt.txt
@@ -10,9 +10,7 @@ SITUATION:
 Latest instant: {latest_instant}
 Latest moment: {latest_moment}
 {situation}
-Relevant memories:
 {memories}
-What's relevant among this? 
 
 AVAILABLE MOTORS:
 {motors}

--- a/psyche-rs/src/will.rs
+++ b/psyche-rs/src/will.rs
@@ -484,12 +484,20 @@ impl<T> Will<T> {
                             latest_moment: &'a str,
                             memories: &'a str,
                         }
+                        let memory_section = if neighbor_text.is_empty() {
+                            String::new()
+                        } else {
+                            format!(
+                                "Relevant memories:\n{}\nWhat's relevant among this?",
+                                neighbor_text
+                            )
+                        };
                         let ctx = Ctx {
                             situation: &situation,
                             motors: &motor_text,
                             latest_instant: &last_instant,
                             latest_moment: &last_moment,
-                            memories: &neighbor_text,
+                            memories: &memory_section,
                         };
                         let prompt = render_template(&template, &ctx).unwrap_or_else(|e| {
                             warn!(error=?e, "template render failed");

--- a/psyche-rs/src/wit.rs
+++ b/psyche-rs/src/wit.rs
@@ -273,7 +273,15 @@ where
                             template: &'a str,
                             memories: &'a str,
                         }
-                        let ctx = Ctx { last_frame: &lf, template: &timeline, memories: &neighbor_text };
+                        let memory_section = if neighbor_text.is_empty() {
+                            String::new()
+                        } else {
+                            format!(
+                                "Relevant memories:\n{}\nWhat's relevant among these memories?",
+                                neighbor_text
+                            )
+                        };
+                        let ctx = Ctx { last_frame: &lf, template: &timeline, memories: &memory_section };
                         let prompt = render_template(&template, &ctx).unwrap_or_else(|e| {
                             trace!(error=?e, "template render failed");
                             template.clone()


### PR DESCRIPTION
## Summary
- avoid prompting about relevant memories when none are found
- adapt memory prompts accordingly

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ddecb4d9083208f5db19a5dfb38d5