### PR TITLE
Enhance WebXR memory view

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ sup.start(None);
 
 ---
 
+## 🌌 WebXR Memory Visualization
+
+The `daringsby` server exposes a VR scene showing recent memories as nodes in 3D space.
+
+1. Run `project_embeddings.py` to project Qdrant embeddings and store their 3D coordinates:
+
+   ```bash
+   python scripts/project_embeddings.py \
+     --qdrant http://localhost:6333 \
+     --neo4j http://localhost:7474 \
+     --neo-user neo4j --neo-pass password
+   ```
+
+   This generates `embedding_positions.json` and updates Neo4j nodes with `embedding3d` data.
+
+2. Start `daringsby` and open `https://<host>:<port>/memory_viz.html` in a WebXR-capable browser.
+   Use a headset or mouse to explore the grid of memories.
+
+
+
 
 ## 📝 Contributing
 

--- a/daringsby/src/memory_graph.rs
+++ b/daringsby/src/memory_graph.rs
@@ -54,7 +54,9 @@ impl MemoryGraph {
     }
 
     async fn build_graph(&self) -> anyhow::Result<Vec<Node>> {
-        let nodes = self.store.fetch_recent_impressions(100).await?;
+        // load a larger set of recent impressions so more nodes are
+        // available inside the WebXR visualization
+        let nodes = self.store.fetch_recent_impressions(500).await?;
         let pos_map = load_positions().unwrap_or_default();
         let mut out = Vec::new();
         for imp in nodes {

--- a/daringsby/src/memory_viz.html
+++ b/daringsby/src/memory_viz.html
@@ -32,8 +32,26 @@ document.body.appendChild(renderer.domElement);
 document.body.appendChild(VRButton.createButton(renderer));
 
 const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x101015);
+// simple holodeck-style grid for orientation
+const grid = new THREE.GridHelper(10, 20, 0x4444ff, 0x4444ff);
+grid.position.y = -0.01;
+scene.add(grid);
+const room = new THREE.Mesh(
+  new THREE.BoxGeometry(10, 10, 10),
+  new THREE.MeshBasicMaterial({ color: 0x080808, side: THREE.BackSide })
+);
+scene.add(room);
+const ambient = new THREE.AmbientLight(0x888888);
+scene.add(ambient);
+const dir = new THREE.DirectionalLight(0xffffff, 0.5);
+dir.position.set(1, 3, 2);
+scene.add(dir);
+// raise all nodes to this height so they appear level with the viewer
+const Y_OFFSET = 1.6;
 const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.01, 1000);
-camera.position.set(0, 0, 3);
+// place the user at typical eye height so the origin is in front
+camera.position.set(0, 1.6, 3);
 const controls = new OrbitControls(camera, renderer.domElement);
 
 const raycaster = new THREE.Raycaster();
@@ -64,7 +82,8 @@ fetch('/memory_graph.json')
       const geom = new THREE.SphereGeometry(0.02);
       const mat = new THREE.MeshBasicMaterial({ color: colors[n.cluster] });
       const mesh = new THREE.Mesh(geom, mat);
-      mesh.position.set(n.pos[0], n.pos[1], n.pos[2]);
+      // offset nodes so the current moment sits in front of the user
+      mesh.position.set(n.pos[0], n.pos[1] + Y_OFFSET, n.pos[2]);
       mesh.userData.node = n;
       scene.add(mesh);
       spheres[n.uuid] = mesh;


### PR DESCRIPTION
## Summary
- display more recent memory nodes in the VR view
- offset node positions to eye level and add holodeck grid
- document how to project embeddings for the visualization

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686e96e89f088320a2483fda08ea5fa7