### PR TITLE
Add identify motor and link face embeddings

### DIFF
--- a/daringsby/src/identify_motor.rs
+++ b/daringsby/src/identify_motor.rs
@@ -1,0 +1,154 @@
+use async_trait::async_trait;
+use chrono::Local;
+use serde_json::json;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::debug;
+use url::Url;
+
+use psyche_rs::{ActionResult, Completion, Intention, Motor, MotorError, Sensation};
+
+/// Motor that assigns a name to a detected face.
+///
+/// The `identify` action links a face node to a `Person` in Neo4j and emits
+/// a `face.named` sensation.
+pub struct IdentifyMotor {
+    client: reqwest::Client,
+    neo4j_url: Url,
+    neo_user: String,
+    neo_pass: String,
+    tx: UnboundedSender<Vec<Sensation<serde_json::Value>>>,
+}
+
+impl IdentifyMotor {
+    /// Create a new motor configured with Neo4j credentials.
+    pub fn new(
+        client: reqwest::Client,
+        neo4j_url: Url,
+        neo_user: impl Into<String>,
+        neo_pass: impl Into<String>,
+        tx: UnboundedSender<Vec<Sensation<serde_json::Value>>>,
+    ) -> Self {
+        Self {
+            client,
+            neo4j_url,
+            neo_user: neo_user.into(),
+            neo_pass: neo_pass.into(),
+            tx,
+        }
+    }
+
+    async fn link_face(&self, face_id: &str, name: &str) -> Result<(), MotorError> {
+        let query = "MERGE (f:FaceEmbedding {uuid:$face})\nSET f.name=$name\nMERGE (p:Person {name:$name})\nMERGE (f)-[:REPRESENTS]->(p)";
+        let params = json!({"face": face_id, "name": name});
+        let payload = json!({"statements":[{"statement":query,"parameters":params}]});
+        let url = self
+            .neo4j_url
+            .join("db/neo4j/tx/commit")
+            .map_err(|e| MotorError::Failed(e.to_string()))?;
+        let resp = self
+            .client
+            .post(url)
+            .basic_auth(&self.neo_user, Some(&self.neo_pass))
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| MotorError::Failed(e.to_string()))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            Err(MotorError::Failed(format!("neo4j error {status}: {text}")))
+        }
+    }
+}
+
+#[async_trait]
+impl Motor for IdentifyMotor {
+    fn description(&self) -> &'static str {
+        "Associate a name with a detected face.\n\
+Parameters: `face` and `name`.\n\
+Example:\n\
+<identify face=\"abc_face0\" name=\"Travis\"/>\n\
+Explanation:\n\
+Links the face node to a Person node in Neo4j and emits a `face.named` sensation."
+    }
+
+    fn name(&self) -> &'static str {
+        "identify"
+    }
+
+    async fn perform(&self, intention: Intention) -> Result<ActionResult, MotorError> {
+        if intention.action.name != "identify" {
+            return Err(MotorError::Unrecognized);
+        }
+        let action = intention.action;
+        let face_id = action
+            .params
+            .get("face")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| MotorError::Failed("missing face".into()))?
+            .to_string();
+        let name = action
+            .params
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| MotorError::Failed("missing name".into()))?
+            .to_string();
+        self.link_face(&face_id, &name).await?;
+        let completion = Completion::of_action(action);
+        debug!(?completion, "action completed");
+        let sensation = Sensation {
+            kind: "face.named".into(),
+            when: Local::now(),
+            what: json!({"face_id": face_id, "name": name}),
+            source: None,
+        };
+        let _ = self.tx.send(vec![sensation.clone()]);
+        Ok(ActionResult {
+            sensations: vec![sensation],
+            completed: true,
+            completion: Some(completion),
+            interruption: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{StreamExt, stream};
+    use httpmock::prelude::*;
+    use psyche_rs::{Action, Intention, Motor};
+    use serde_json::Value;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    #[tokio::test]
+    async fn links_face_and_emits_sensation() {
+        let neo = MockServer::start();
+        let neo_mock = neo.mock(|when, then| {
+            when.method(POST).path("/db/neo4j/tx/commit");
+            then.status(200);
+        });
+        let (tx, mut rx) = unbounded_channel::<Vec<Sensation<serde_json::Value>>>();
+        let motor = IdentifyMotor::new(
+            reqwest::Client::new(),
+            Url::parse(&neo.url("")).unwrap(),
+            "u",
+            "p",
+            tx,
+        );
+        let body = stream::empty().boxed();
+        let mut params = serde_json::Map::new();
+        params.insert("face".into(), Value::String("f1".into()));
+        params.insert("name".into(), Value::String("Travis".into()));
+        let action = Action::new("identify", Value::Object(params), body);
+        let intent = Intention::to(action).assign("identify");
+        let res = motor.perform(intent).await.unwrap();
+        assert!(res.completed);
+        let batch = rx.recv().await.unwrap();
+        assert_eq!(batch[0].kind, "face.named");
+        assert_eq!(batch[0].what["name"], "Travis");
+        neo_mock.assert();
+    }
+}

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -8,6 +8,7 @@ pub mod face_recognition_service;
 pub mod heard_self_sensor;
 pub mod heard_user_sensor;
 pub mod heartbeat;
+pub mod identify_motor;
 pub mod log_file;
 pub mod log_memory_motor;
 pub mod log_sensation_layer;
@@ -49,6 +50,7 @@ pub mod streams;
 
 pub use face_embedding_service::{FaceData, FaceEmbedder, FaceEmbeddingService};
 pub use face_recognition_service::FaceRecognitionService;
+pub use identify_motor::IdentifyMotor;
 pub use memory_graph::MemoryGraph;
 pub use memory_projection::MemoryProjectionService;
 pub use motors::*;

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -137,8 +137,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::time::Duration::from_secs(60),
     )
     .spawn();
-    let (motors, _motor_map, consolidation_status, mut look_rx) =
-        build_motors(&llms, mouth.clone(), vision.clone(), store.clone());
+    let (motors, _motor_map, consolidation_status, mut look_rx) = build_motors(
+        &llms,
+        mouth.clone(),
+        vision.clone(),
+        store.clone(),
+        Url::parse(&args.neo4j_url)?,
+        args.neo4j_user.clone(),
+        args.neo4j_pass.clone(),
+    );
     let motors_send: Vec<Arc<dyn Motor + Send + Sync>> = motors
         .iter()
         .cloned()

--- a/daringsby/src/motors.rs
+++ b/daringsby/src/motors.rs
@@ -1,4 +1,5 @@
 pub use crate::battery_motor::BatteryMotor;
+pub use crate::identify_motor::IdentifyMotor;
 pub use crate::log_memory_motor::LogMemoryMotor;
 /// Motor implementations used by the Daringsby binary.
 ///


### PR DESCRIPTION
## Summary
- implement `IdentifyMotor` for linking names to face nodes in Neo4j
- wire new motor into runtime
- link face embeddings to snapshots in Neo4j
- expose new motor from library
- update face embedding service tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686eb3861a388320867c805695ebd73e