### PR TITLE
Add face clustering service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,4 @@
 - Prefer `smartcore` over `linfa` for ML tasks to avoid heavy dependencies.
 - Gate heavy dependencies like OpenCV behind optional Cargo features to keep
   compile times manageable.
+- When OpenCV isn't available, run tests with `--no-default-features`.

--- a/daringsby/src/face_clustering_service.rs
+++ b/daringsby/src/face_clustering_service.rs
@@ -1,0 +1,219 @@
+use std::{collections::HashSet, time::Duration};
+
+use anyhow::Result;
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{self, RetrievedPoint, ScrollPointsBuilder, point_id};
+use reqwest::Client;
+use smartcore::cluster::kmeans::{KMeans, KMeansParameters};
+use smartcore::linalg::basic::{arrays::Array, matrix::DenseMatrix};
+use tokio::time::interval;
+use tracing::{info, warn};
+use url::Url;
+
+use psyche_rs::AbortGuard;
+
+/// Periodically clusters face embeddings that have not been named.
+///
+/// # Example
+/// ```no_run
+/// use daringsby::face_clustering_service::FaceClusteringService;
+/// use qdrant_client::Qdrant;
+/// use url::Url;
+/// use reqwest::Client;
+/// let service = FaceClusteringService::new(
+///     Qdrant::from_url("http://localhost:6333").build().unwrap(),
+///     Client::new(),
+///     Url::parse("http://localhost:7474").unwrap(),
+///     "neo4j",
+///     "password",
+///     std::time::Duration::from_secs(60),
+/// );
+/// let _guard = service.spawn();
+/// ```
+pub struct FaceClusteringService {
+    qdrant: Qdrant,
+    client: Client,
+    neo4j_url: Url,
+    neo_user: String,
+    neo_pass: String,
+    interval: Duration,
+}
+
+impl FaceClusteringService {
+    /// Create a new service.
+    pub fn new(
+        qdrant: Qdrant,
+        client: Client,
+        neo4j_url: Url,
+        neo_user: impl Into<String>,
+        neo_pass: impl Into<String>,
+        interval: Duration,
+    ) -> Self {
+        Self {
+            qdrant,
+            client,
+            neo4j_url,
+            neo_user: neo_user.into(),
+            neo_pass: neo_pass.into(),
+            interval,
+        }
+    }
+
+    /// Spawn the clustering loop.
+    pub fn spawn(self) -> AbortGuard {
+        let handle = tokio::spawn(async move { self.run().await });
+        AbortGuard::new(handle)
+    }
+
+    async fn run(self) {
+        let mut ticker = interval(self.interval);
+        loop {
+            ticker.tick().await;
+            if let Err(e) = self.run_once().await {
+                warn!(error=?e, "face clustering failed");
+            }
+        }
+    }
+
+    async fn run_once(&self) -> Result<()> {
+        let named = self.fetch_named_faces().await?;
+        let points = self.fetch_points().await?;
+        let mut ids = Vec::new();
+        let mut vectors = Vec::new();
+        for p in points {
+            let id = match p.id.unwrap().point_id_options.unwrap() {
+                point_id::PointIdOptions::Uuid(u) => u,
+                point_id::PointIdOptions::Num(n) => n.to_string(),
+            };
+            if named.contains(&id) {
+                continue;
+            }
+            let vec = match p.vectors.unwrap().vectors_options.unwrap() {
+                qdrant::vectors_output::VectorsOptions::Vector(v) => v.data,
+                qdrant::vectors_output::VectorsOptions::Vectors(nv) => nv
+                    .vectors
+                    .into_iter()
+                    .next()
+                    .map(|(_, d)| d.data)
+                    .unwrap_or_default(),
+            };
+            ids.push(id);
+            vectors.push(vec);
+        }
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let labels = cluster_vectors(&vectors)?;
+        self.update_neo4j(&ids, &labels).await?;
+        info!("face clustering updated");
+        Ok(())
+    }
+
+    async fn fetch_named_faces(&self) -> Result<HashSet<String>> {
+        let query = "MATCH (f:FaceEmbedding) WHERE exists(f.name) RETURN f.uuid";
+        let payload = serde_json::json!({"statements":[{"statement":query} ]});
+        let resp = self
+            .client
+            .post(self.neo4j_url.join("db/neo4j/tx/commit")?)
+            .basic_auth(&self.neo_user, Some(&self.neo_pass))
+            .json(&payload)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            warn!(status=%resp.status(), "neo4j query failed");
+            return Ok(HashSet::new());
+        }
+        #[derive(serde::Deserialize)]
+        struct NeoRes {
+            results: Vec<R1>,
+        }
+        #[derive(serde::Deserialize)]
+        struct R1 {
+            data: Vec<R2>,
+        }
+        #[derive(serde::Deserialize)]
+        struct R2 {
+            row: (String,),
+        }
+        let res: NeoRes = resp.json().await?;
+        Ok(res
+            .results
+            .into_iter()
+            .flat_map(|r| r.data)
+            .map(|r| r.row.0)
+            .collect())
+    }
+
+    async fn fetch_points(&self) -> Result<Vec<RetrievedPoint>> {
+        let mut out = Vec::new();
+        let mut offset = None;
+        loop {
+            let mut builder = ScrollPointsBuilder::new("face_embeddings")
+                .limit(256)
+                .with_vectors(true)
+                .with_payload(true);
+            if let Some(o) = offset.clone() {
+                builder = builder.offset(o);
+            }
+            let res = self.qdrant.scroll(builder).await?;
+            out.extend(res.result);
+            if let Some(next) = res.next_page_offset {
+                offset = Some(next);
+            } else {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    async fn update_neo4j(&self, ids: &[String], labels: &[usize]) -> Result<()> {
+        for (id, cluster) in ids.iter().zip(labels) {
+            let query = "MATCH (f:FaceEmbedding {uuid:$id}) SET f.cluster=$cluster";
+            let params = serde_json::json!({"id": id, "cluster": *cluster as i32});
+            let payload =
+                serde_json::json!({"statements":[{"statement":query,"parameters":params}]});
+            let resp = self
+                .client
+                .post(self.neo4j_url.join("db/neo4j/tx/commit")?)
+                .basic_auth(&self.neo_user, Some(&self.neo_pass))
+                .json(&payload)
+                .send()
+                .await?;
+            if !resp.status().is_success() {
+                warn!(status=%resp.status(), "neo4j update failed");
+            }
+        }
+        Ok(())
+    }
+}
+
+fn cluster_vectors(vectors: &[Vec<f32>]) -> Result<Vec<usize>> {
+    let data: Vec<Vec<f64>> = vectors
+        .iter()
+        .map(|v| v.iter().map(|&x| x as f64).collect())
+        .collect();
+    let m = DenseMatrix::from_2d_vec(&data)?;
+    let kmeans = KMeans::<f64, usize, DenseMatrix<f64>, Vec<usize>>::fit(
+        &m,
+        KMeansParameters::default().with_k(8),
+    )?;
+    let labels = kmeans.predict(&m)?;
+    Ok((0..labels.shape()).map(|i| *labels.get(i)).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clusters_vectors() {
+        let data = vec![
+            vec![1.0, 0.0],
+            vec![0.9, 0.0],
+            vec![0.0, 1.0],
+            vec![0.0, 0.9],
+        ];
+        let labels = cluster_vectors(&data).unwrap();
+        assert_eq!(labels.len(), 4);
+    }
+}

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -3,6 +3,7 @@ pub mod battery_sensor;
 pub mod canvas_stream;
 pub mod development_status;
 pub mod ear;
+pub mod face_clustering_service;
 pub mod face_embedding_service;
 pub mod face_recognition_service;
 pub mod heard_self_sensor;
@@ -48,6 +49,7 @@ pub mod motors;
 pub mod sensors;
 pub mod streams;
 
+pub use face_clustering_service::FaceClusteringService;
 pub use face_embedding_service::{FaceData, FaceEmbedder, FaceEmbeddingService};
 pub use face_recognition_service::FaceRecognitionService;
 pub use identify_motor::IdentifyMotor;

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -9,6 +9,7 @@ use daringsby::memory_helpers::{
 };
 use daringsby::{LookSensor, VisionSensor};
 use daringsby::{
+    face_clustering_service::FaceClusteringService,
     llm_helpers::{build_ollama_clients, build_voice_llm},
     logger,
     memory_graph::MemoryGraph,
@@ -134,6 +135,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _projection_guard = MemoryProjectionService::new(
         qdrant_client,
         store.clone(),
+        std::time::Duration::from_secs(60),
+    )
+    .spawn();
+    let _face_cluster_guard = FaceClusteringService::new(
+        Qdrant::from_url(&args.qdrant_url).build()?,
+        Client::new(),
+        Url::parse(&args.neo4j_url)?,
+        args.neo4j_user.clone(),
+        args.neo4j_pass.clone(),
         std::time::Duration::from_secs(60),
     )
     .spawn();


### PR DESCRIPTION
## Summary
- add `FaceClusteringService` to periodically group unnamed faces
- expose new module and spawn service in `main`
- document running tests without heavy features in `AGENTS.md`

## Testing
- `cargo test --workspace --no-default-features`
- `cargo test -p psyche-rs will::tests::waits_for_llm_stream_before_next_loop -- --nocapture`
- `cargo test --test log_memory_motor --no-default-features -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_686eb80599bc832093f246d03eeac707