### PR TITLE
custom qdrant channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.21.0",
+ "tonic",
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -37,6 +37,7 @@ axum-server = { version = "0.7", features = ["tls-rustls"] }
 rcgen = "0.11"
 hyper = "1"
 qdrant-client = "1"
+tonic = "0.12"
 smartcore = "0.4"
 num-traits = "0.2"
 image = { version = "0.24", optional = true }

--- a/daringsby/src/main.rs
+++ b/daringsby/src/main.rs
@@ -25,10 +25,22 @@ use psyche_rs::{
     Combobulator, Impression, ImpressionStreamSensor, Motor, MotorExecutor, NeoQdrantMemoryStore,
     SensationSensor, Sensor, Voice, Will, shutdown_signal,
 };
-use qdrant_client::Qdrant;
+use qdrant_client::qdrant::points_client::PointsClient;
 use reqwest::Client;
+use std::time::Duration;
 use tokio::sync::mpsc::unbounded_channel;
+use tonic::transport::{Channel, Endpoint};
 use url::Url;
+
+async fn connect_qdrant(url: &str) -> anyhow::Result<Channel> {
+    let endpoint = Endpoint::from_shared(url.to_string())?
+        .keep_alive_timeout(Duration::from_secs(30))
+        .keep_alive_while_idle(true)
+        .initial_connection_window_size(Some(2 * 1024 * 1024))
+        .initial_stream_window_size(Some(2 * 1024 * 1024));
+    let channel = endpoint.connect().await?;
+    Ok(channel)
+}
 
 async fn run_sensor_loop<I>(
     mut stream: BoxStream<'static, Vec<I>>,
@@ -129,10 +141,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await;
     let qdrant_url = Url::parse(&args.qdrant_url)?;
     ensure_impressions_collection_exists(&Client::new(), &qdrant_url).await?;
-    let qdrant_client = Qdrant::from_url(&args.qdrant_url).build()?;
-    ensure_face_embeddings_collection_exists(&qdrant_client).await?;
+    let channel = connect_qdrant(&args.qdrant_url).await?;
+    ensure_face_embeddings_collection_exists(&channel).await?;
     let _projection_guard = MemoryProjectionService::new(
-        qdrant_client,
+        PointsClient::new(channel.clone()),
         store.clone(),
         std::time::Duration::from_secs(60),
     )

--- a/daringsby/src/memory_helpers.rs
+++ b/daringsby/src/memory_helpers.rs
@@ -1,10 +1,14 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use psyche_rs::{Impression, MemoryStore, StoredImpression, StoredSensation};
-use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};
-use qdrant_client::{Qdrant, QdrantError};
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CollectionExistsRequest, CreateCollectionBuilder, Distance, VectorParamsBuilder,
+    collections_client::CollectionsClient,
+};
 use reqwest::Client;
 use serde_json::json;
+use tonic::transport::Channel;
 use tracing::{debug, error, info};
 use url::Url;
 
@@ -126,6 +130,27 @@ impl FaceCollectionClient for Qdrant {
         .await
         .map(|_| ())
         .map_err(|e| anyhow::Error::new(e))
+    }
+}
+
+#[async_trait]
+impl FaceCollectionClient for Channel {
+    async fn collection_exists(&self) -> anyhow::Result<bool> {
+        let mut client = CollectionsClient::new(self.clone());
+        let req = CollectionExistsRequest {
+            collection_name: "face_embeddings".to_string(),
+        };
+        let res = client.collection_exists(req).await?;
+        Ok(res.into_inner().result.map(|r| r.exists).unwrap_or(false))
+    }
+
+    async fn create_collection(&self) -> anyhow::Result<()> {
+        let mut client = CollectionsClient::new(self.clone());
+        let req = CreateCollectionBuilder::new("face_embeddings")
+            .vectors_config(VectorParamsBuilder::new(512, Distance::Cosine))
+            .build();
+        client.create(req).await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- build Qdrant gRPC channel manually with HTTP/2 tuning
- use PointsClient in memory projection service
- expose Channel as FaceCollectionClient

## Testing
- `cargo test --workspace --no-default-features --no-run`

------
https://chatgpt.com/codex/tasks/task_e_686eba5ffcfc83209309b1d54395211a