### PR TITLE
Install rustls CryptoProvider early

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "daringsby"
 version = "0.1.0"
 dependencies = [
@@ -905,6 +915,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "ctor",
  "futures",
  "hound",
  "http-body-util",

--- a/daringsby/Cargo.toml
+++ b/daringsby/Cargo.toml
@@ -43,6 +43,7 @@ image = { version = "0.24" }
 ort = { version = "2.0.0-rc.10" }
 opencv = "0.95.0"
 rustls = { version = "0.23", features = ["ring"] }
+ctor = "0.2"
 
 [dev-dependencies]
 httpmock = "0.7"

--- a/daringsby/src/crypto.rs
+++ b/daringsby/src/crypto.rs
@@ -1,0 +1,10 @@
+use ctor::ctor;
+use rustls::crypto::CryptoProvider;
+
+/// Installs the rustls CryptoProvider early during program startup.
+#[ctor]
+fn install_crypto_provider() {
+    let provider = CryptoProvider::get_default()
+        .expect("No default CryptoProvider found. Did you enable the `ring` feature?");
+    CryptoProvider::install_default(provider).expect("Failed to install CryptoProvider");
+}

--- a/daringsby/src/lib.rs
+++ b/daringsby/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod battery_motor;
 pub mod battery_sensor;
 pub mod canvas_stream;
+mod crypto;
 pub mod development_status;
 pub mod ear;
 pub mod face_clustering_service;


### PR DESCRIPTION
## Summary
- install ctor crate and auto-install rustls CryptoProvider

## Testing
- `cargo test --no-default-features` *(fails: Failed to find installed OpenCV package)*

------
https://chatgpt.com/codex/tasks/task_e_686f072f8b648320b5b893697bd364a8