### PR TITLE
Introduce modular LLM capability traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +94,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "getrandom"
@@ -262,8 +279,13 @@ dependencies = [
 name = "psyche"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
  "uuid",
 ]
 
@@ -477,6 +499,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -7,3 +7,10 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+anyhow = "1"
+async-trait = "0.1"
+tokio-stream = "0.1"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate hosts memory models and simple distillers. It is OS neutral.
 
 pub mod distiller;
+pub mod llm;
 pub mod models;
 
 /// Example helper that adds two numbers.

--- a/psyche/src/llm/chat.rs
+++ b/psyche/src/llm/chat.rs
@@ -1,0 +1,21 @@
+use super::{CanChat, LlmProfile};
+use async_trait::async_trait;
+use tokio_stream::{iter, Stream};
+
+/// Simple echo chat implementation useful for tests.
+#[derive(Default)]
+pub struct EchoChat;
+
+#[async_trait(?Send)]
+impl CanChat for EchoChat {
+    async fn chat_stream(
+        &self,
+        _profile: &LlmProfile,
+        _system: &str,
+        user: &str,
+    ) -> anyhow::Result<Box<dyn Stream<Item = String> + Unpin>> {
+        // In a real implementation this would call an API.
+        let resp = format!("Echo: {}", user);
+        Ok(Box::new(iter([resp.to_string()])))
+    }
+}

--- a/psyche/src/llm/embed.rs
+++ b/psyche/src/llm/embed.rs
@@ -1,0 +1,14 @@
+use super::{CanEmbed, LlmProfile};
+use async_trait::async_trait;
+
+/// Generates a fixed embedding useful for tests.
+#[derive(Default)]
+pub struct StaticEmbed;
+
+#[async_trait(?Send)]
+impl CanEmbed for StaticEmbed {
+    async fn embed(&self, _profile: &LlmProfile, text: &str) -> anyhow::Result<Vec<f32>> {
+        // Very naive embedding: length of text as a single value.
+        Ok(vec![text.len() as f32])
+    }
+}

--- a/psyche/src/llm/mock_chat.rs
+++ b/psyche/src/llm/mock_chat.rs
@@ -1,0 +1,19 @@
+use super::{CanChat, LlmProfile};
+use async_trait::async_trait;
+use tokio_stream::{iter, Stream};
+
+/// Mock chat client returning a fixed response.
+#[derive(Default)]
+pub struct MockChat;
+
+#[async_trait(?Send)]
+impl CanChat for MockChat {
+    async fn chat_stream(
+        &self,
+        _profile: &LlmProfile,
+        _system: &str,
+        _user: &str,
+    ) -> anyhow::Result<Box<dyn Stream<Item = String> + Unpin>> {
+        Ok(Box::new(iter(["mock response".to_string()])))
+    }
+}

--- a/psyche/src/llm/mock_embed.rs
+++ b/psyche/src/llm/mock_embed.rs
@@ -1,0 +1,13 @@
+use super::{CanEmbed, LlmProfile};
+use async_trait::async_trait;
+
+/// Mock embedder returning zeros.
+#[derive(Default)]
+pub struct MockEmbed;
+
+#[async_trait(?Send)]
+impl CanEmbed for MockEmbed {
+    async fn embed(&self, _profile: &LlmProfile, _text: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0, 0.0, 0.0])
+    }
+}

--- a/psyche/src/llm/mod.rs
+++ b/psyche/src/llm/mod.rs
@@ -1,0 +1,58 @@
+pub mod chat;
+pub mod embed;
+pub mod mock_chat;
+pub mod mock_embed;
+
+use async_trait::async_trait;
+use tokio_stream::Stream;
+
+/// Supported capabilities for a language model backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LlmCapability {
+    /// Conversational text generation.
+    Chat,
+    /// Text embedding vectors.
+    Embedding,
+    /// Image generation or understanding.
+    Image,
+    /// Tool use / function calling.
+    ToolUse,
+}
+
+/// Description of a specific language model profile.
+#[derive(Debug, Clone)]
+pub struct LlmProfile {
+    /// Provider name such as "ollama" or "openai".
+    pub provider: String,
+    /// Model identifier like "llama3" or "gpt-4o".
+    pub model: String,
+    /// Capabilities supported by this model.
+    pub capabilities: Vec<LlmCapability>,
+}
+
+/// Interface for models capable of chatting.
+#[async_trait(?Send)]
+pub trait CanChat {
+    /// Streams the model\'s chat completion as individual tokens.
+    async fn chat_stream(
+        &self,
+        profile: &LlmProfile,
+        system: &str,
+        user: &str,
+    ) -> anyhow::Result<Box<dyn Stream<Item = String> + Unpin>>;
+}
+
+/// Interface for models capable of producing embeddings.
+#[async_trait(?Send)]
+pub trait CanEmbed {
+    /// Returns an embedding vector for the supplied text.
+    async fn embed(&self, profile: &LlmProfile, text: &str) -> anyhow::Result<Vec<f32>>;
+}
+
+/// Registry holding implementations for each capability.
+pub struct LlmRegistry {
+    /// Chat implementation.
+    pub chat: Box<dyn CanChat>,
+    /// Embedding implementation.
+    pub embed: Box<dyn CanEmbed>,
+}

--- a/psyche/tests/llm.rs
+++ b/psyche/tests/llm.rs
@@ -1,0 +1,39 @@
+use psyche::llm::{
+    mock_chat::MockChat, mock_embed::MockEmbed, LlmCapability, LlmProfile, LlmRegistry,
+};
+use tokio_stream::StreamExt;
+
+#[tokio::test]
+async fn mock_chat_streams() {
+    let profile = LlmProfile {
+        provider: "mock".into(),
+        model: "mock".into(),
+        capabilities: vec![LlmCapability::Chat],
+    };
+    let registry = LlmRegistry {
+        chat: Box::new(MockChat::default()),
+        embed: Box::new(MockEmbed::default()),
+    };
+    let stream = registry
+        .chat
+        .chat_stream(&profile, "", "hello")
+        .await
+        .expect("stream");
+    let collected: Vec<String> = stream.collect().await;
+    assert_eq!(collected, vec!["mock response".to_string()]);
+}
+
+#[tokio::test]
+async fn mock_embed_returns_vector() {
+    let profile = LlmProfile {
+        provider: "mock".into(),
+        model: "mock".into(),
+        capabilities: vec![LlmCapability::Embedding],
+    };
+    let registry = LlmRegistry {
+        chat: Box::new(MockChat::default()),
+        embed: Box::new(MockEmbed::default()),
+    };
+    let vec = registry.embed.embed(&profile, "test").await.expect("embed");
+    assert_eq!(vec, vec![0.0, 0.0, 0.0]);
+}


### PR DESCRIPTION
## Summary
- define capability-aware LLM API under `psyche::llm`
- provide echo and static implementations
- add mock chat/embed modules and tests
- expose new module from crate root
- depend on async traits and tokio stream

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6877dc6c7e488320bfc83612e5c000b3