### PR TITLE
Implement layered distillation skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ name = "psyched"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "psyche",
  "serde",
  "serde_json",
@@ -2422,6 +2423,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 anyhow = "1"
 async-trait = "0.1"
 tokio-stream = "0.1"

--- a/psyche/src/models.rs
+++ b/psyche/src/models.rs
@@ -21,3 +21,19 @@ pub struct Instant {
     /// References to related sensations by id.
     pub what: Vec<String>,
 }
+
+/// Generalized memory entry passed between distillers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryEntry {
+    /// Unique identifier for this entry.
+    pub id: uuid::Uuid,
+    /// Kind of entry such as `"sensation/speech"` or `"instant"`.
+    pub kind: String,
+    /// When the entry was recorded.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub when: chrono::DateTime<chrono::Utc>,
+    /// Rich payload from the previous layer.
+    pub what: serde_json::Value,
+    /// One sentence summary.
+    pub how: String,
+}

--- a/psyched/Cargo.toml
+++ b/psyched/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
+chrono = { version = "0.4", features = ["serde", "clock"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
-use psyche::distiller::distill;
-use psyche::models::Sensation;
+use chrono::Utc;
+use psyche::distiller::{Combobulator, Distiller};
+use psyche::models::{MemoryEntry, Sensation};
 use serde::Serialize;
+use serde_json::json;
 use std::path::PathBuf;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -28,9 +30,6 @@ async fn handle_stream(stream: UnixStream, memory: PathBuf) -> Result<()> {
         text,
     };
     append(&memory, &sensation).await?;
-    if let Some(instant) = distill(&sensation) {
-        append(&memory, &instant).await?;
-    }
     Ok(())
 }
 
@@ -46,6 +45,23 @@ async fn append<T: Serialize>(path: &PathBuf, value: &T) -> Result<()> {
     Ok(())
 }
 
+async fn append_all<T: Serialize>(path: &PathBuf, values: &[T]) -> Result<()> {
+    if values.is_empty() {
+        return Ok(());
+    }
+    let mut file = tokio::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path)
+        .await?;
+    for v in values {
+        let line = serde_json::to_string(v)?;
+        file.write_all(line.as_bytes()).await?;
+        file.write_all(b"\n").await?;
+    }
+    Ok(())
+}
+
 /// Runs the psyched daemon until `shutdown` is triggered.
 pub async fn run(
     socket: PathBuf,
@@ -54,11 +70,36 @@ pub async fn run(
 ) -> Result<()> {
     let _ = std::fs::remove_file(&socket);
     let listener = UnixListener::bind(&socket)?;
+    let instant_path = memory.with_file_name("instant.jsonl");
+    let mut combobulator = Combobulator;
+    let mut processed = 0usize;
+    let mut beat = tokio::time::interval(std::time::Duration::from_millis(50));
     loop {
         tokio::select! {
             _ = &mut shutdown => break,
             Ok((stream, _)) = listener.accept() => {
                 handle_stream(stream, memory.clone()).await?;
+            }
+            _ = beat.tick() => {
+                let content = tokio::fs::read_to_string(&memory).await.unwrap_or_default();
+                let lines: Vec<_> = content.lines().collect();
+                if processed < lines.len() {
+                    let new_lines = &lines[processed..];
+                    processed = lines.len();
+                    let mut input = Vec::new();
+                    for line in new_lines {
+                        let s: Sensation = serde_json::from_str(line)?;
+                        input.push(MemoryEntry {
+                            id: Uuid::parse_str(&s.id)?,
+                            kind: "sensation/chat".to_string(),
+                            when: Utc::now(),
+                            what: json!(s.text),
+                            how: String::new(),
+                        });
+                    }
+                    let out = combobulator.distill(input).await?;
+                    append_all(&instant_path, &out).await?;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `MemoryEntry` model for generic memory items
- introduce async `Distiller` trait with `Combobulator` implementation
- orchestrate distillers in `psyched` using a beat loop
- test integration harness with updated expectations

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6877f101285083208853d797e928fb8e