### PR TITLE
Add CLI to psyched

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +360,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "cmake"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +407,12 @@ checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
@@ -709,6 +805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1590,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "psyche",
  "serde",
  "serde_json",
@@ -2425,6 +2540,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/psyched/Cargo.toml
+++ b/psyched/Cargo.toml
@@ -14,6 +14,7 @@ tracing-subscriber = "0.3"
 uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde", "clock"] }
+clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/psyched/src/main.rs
+++ b/psyched/src/main.rs
@@ -1,11 +1,54 @@
+use clap::Parser;
 use std::path::PathBuf;
-use tokio::sync::oneshot;
+
+/// `psyched` — the orchestrator for psycheOS
+#[derive(Parser)]
+#[command(
+    name = "psyched",
+    version,
+    about = "Core orchestrator for a psycheOS instance"
+)]
+pub struct Cli {
+    /// Path to the Unix domain socket for sensation input
+    #[arg(long, default_value = "/run/quick.sock")]
+    pub socket: PathBuf,
+
+    /// Path to the raw sensation log
+    #[arg(long, default_value = "memory/sensation.jsonl")]
+    pub memory: PathBuf,
+
+    /// Path to TOML file describing distillation pipeline
+    #[arg(long, default_value = "psyche.toml")]
+    pub config: PathBuf,
+
+    /// Beat interval (in milliseconds)
+    #[arg(long, default_value_t = 50)]
+    pub beat_ms: u64,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let socket = PathBuf::from("/run/quick.sock");
-    let memory = PathBuf::from("soul/memory");
-    let (_tx, rx) = oneshot::channel();
-    psyched::run(socket, memory, rx).await
+    let cli = Cli::parse();
+    let shutdown = shutdown_signal();
+    psyched::run(
+        cli.socket,
+        cli.memory,
+        cli.config,
+        std::time::Duration::from_millis(cli.beat_ms),
+        shutdown,
+    )
+    .await
+}
+
+fn shutdown_signal() -> impl std::future::Future<Output = ()> {
+    use tokio::signal::unix::{signal, SignalKind};
+    async {
+        let mut sigint = signal(SignalKind::interrupt()).unwrap();
+        let mut sigterm = signal(SignalKind::terminate()).unwrap();
+        tokio::select! {
+            _ = sigint.recv() => {},
+            _ = sigterm.recv() => {},
+        }
+    }
 }

--- a/psyched/tests/basic_vertical.rs
+++ b/psyched/tests/basic_vertical.rs
@@ -2,13 +2,13 @@ use std::path::PathBuf;
 use tempfile::tempdir;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
-use tokio::sync::oneshot;
 use tokio::task::LocalSet;
 
 #[tokio::test(flavor = "current_thread")]
 async fn sensation_results_in_instant() {
     let dir = tempdir().unwrap();
     let socket = dir.path().join("quick.sock");
+    let memory_path = dir.path().join("sensation.jsonl");
     let memory_dir = dir.path().to_path_buf();
     let config_path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/configs/sample.toml");
@@ -16,9 +16,17 @@ async fn sensation_results_in_instant() {
         .await
         .unwrap();
 
-    let (tx, rx) = oneshot::channel();
+    let (tx, rx) = tokio::sync::oneshot::channel();
     let local = LocalSet::new();
-    let server = local.spawn_local(psyched::run(socket.clone(), memory_dir.clone(), rx));
+    let server = local.spawn_local(psyched::run(
+        socket.clone(),
+        memory_path.clone(),
+        memory_dir.join("psyche.toml"),
+        std::time::Duration::from_millis(50),
+        async move {
+            let _ = rx.await;
+        },
+    ));
 
     local
         .run_until(async {
@@ -38,7 +46,7 @@ async fn sensation_results_in_instant() {
             tx.send(()).unwrap();
             server.await.unwrap().unwrap();
 
-            let sensation_path = memory_dir.join("sensation.jsonl");
+            let sensation_path = memory_path.clone();
             let content = tokio::fs::read_to_string(&sensation_path).await.unwrap();
             let lines: Vec<_> = content.lines().collect();
             assert_eq!(lines.len(), 1);
@@ -60,4 +68,21 @@ async fn sensation_results_in_instant() {
             assert_eq!(situation.kind, "situation");
         })
         .await;
+}
+
+#[tokio::test]
+async fn cli_flags_work() {
+    let exe = env!("CARGO_BIN_EXE_psyched");
+    let status = tokio::process::Command::new(exe)
+        .arg("--version")
+        .status()
+        .await
+        .unwrap();
+    assert!(status.success());
+    let status = tokio::process::Command::new(exe)
+        .arg("--help")
+        .status()
+        .await
+        .unwrap();
+    assert!(status.success());
 }


### PR DESCRIPTION
## Summary
- introduce `clap` for argument parsing
- add `Cli` struct and use it in `main`
- allow runtime configuration for socket, memory, config and beat interval
- pass custom beat duration to `run`
- test `--help` and `--version` CLI flags

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6877fd44d8a883208f868b455d5a0312