### PR TITLE
Implement Memory Distiller

### DIFF
--- a/features/feeling/basic_vertical.feature
+++ b/features/feeling/basic_vertical.feature
@@ -12,3 +12,4 @@ Feature: Layka receives a sensation and logs an Instant
     Then the system should append a new Sensation to soul/memory/sensation.jsonl
     And the system should distill an Instant with how = "The interlocutor feels lonely"
     And the Instant should also be appended to soul/memory/sensation.jsonl
+    And a Situation summarizing the Instant should be appended to soul/memory/situation.jsonl

--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::Utc;
-use psyche::distiller::{Combobulator, Distiller, Passthrough};
+use psyche::distiller::{Combobulator, Distiller, Memory, Passthrough};
 use psyche::models::{MemoryEntry, Sensation};
 use serde::Deserialize;
 use serde::Serialize;
@@ -88,8 +88,9 @@ struct LoadedDistiller {
 impl LoadedDistiller {
     fn new(name: String, cfg: DistillerConfig) -> Self {
         let distiller: Box<dyn Distiller + Send> = match name.as_str() {
-            "memory" => Box::new(Passthrough),
-            _ => Box::new(Combobulator),
+            "memory" => Box::new(Memory),
+            "combobulator" => Box::new(Combobulator),
+            _ => Box::new(Passthrough),
         };
         Self {
             name,
@@ -178,6 +179,16 @@ pub async fn run(
                 prompt_template: None,
                 beat_mod: 1,
                 postprocess: None,
+            },
+        );
+        map.insert(
+            "memory".into(),
+            DistillerConfig {
+                input_kinds: vec!["instant".into()],
+                output_kind: "situation".into(),
+                prompt_template: None,
+                beat_mod: 4,
+                postprocess: Some("flatten_links".into()),
             },
         );
         Config { distiller: map }

--- a/psyched/tests/basic_vertical.rs
+++ b/psyched/tests/basic_vertical.rs
@@ -42,7 +42,7 @@ async fn sensation_results_in_instant() {
             let msg = b"/chat\nI feel lonely\n---\n";
             stream.write_all(msg).await.unwrap();
 
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
             tx.send(()).unwrap();
             server.await.unwrap().unwrap();
 
@@ -66,6 +66,8 @@ async fn sensation_results_in_instant() {
             assert_eq!(slines.len(), 1);
             let situation: psyche::models::MemoryEntry = serde_json::from_str(slines[0]).unwrap();
             assert_eq!(situation.kind, "situation");
+            assert!(!situation.how.is_empty());
+            assert_eq!(situation.what, serde_json::json!([instant.id]));
         })
         .await;
 }

--- a/tests/configs/sample.toml
+++ b/tests/configs/sample.toml
@@ -8,5 +8,5 @@ beat_mod = 1
 input_kinds = ["instant"]
 output_kind = "situation"
 prompt_template = "prompts/memory.txt"
-beat_mod = 1
+beat_mod = 4
 postprocess = "flatten_links"


### PR DESCRIPTION
## Summary
- implement `Memory` distiller producing situations from instants
- register new distiller in psyched and default config
- check situation log in `basic_vertical` test
- update sample config and feature spec

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6878002b93508320ac4708294f669d33