### PR TITLE
Integrate LLM registry into Wit scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,6 +1596,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/psyched/Cargo.toml
+++ b/psyched/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 psyche = { path = "../psyche" }
 tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"

--- a/psyched/src/file_memory.rs
+++ b/psyched/src/file_memory.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio::sync::Mutex;
+
+use chrono::Utc;
+use psyche::models::{MemoryEntry, Sensation};
+use serde_json::Value;
+use uuid::Uuid;
+
+/// Simple JSONL-backed memory store for Wit scheduling.
+#[derive(Clone)]
+pub struct FileMemory {
+    dir: PathBuf,
+    offsets: Arc<Mutex<HashMap<String, usize>>>,
+}
+
+use std::sync::Arc;
+
+impl FileMemory {
+    /// Create a new memory store rooted at `dir`.
+    pub fn new(dir: PathBuf) -> Self {
+        Self {
+            dir,
+            offsets: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Return newly appended items for `kind` since the last call.
+    pub async fn query_latest(&self, kind: &str) -> Vec<String> {
+        let path = self
+            .dir
+            .join(format!("{}.jsonl", kind.split('/').next().unwrap_or(kind)));
+        let content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
+        let lines: Vec<_> = content.lines().collect();
+        let mut offsets = self.offsets.lock().await;
+        let start = offsets.entry(kind.to_string()).or_insert(0);
+        let slice = if *start < lines.len() {
+            &lines[*start..]
+        } else {
+            &[]
+        };
+        *start = lines.len();
+        slice
+            .iter()
+            .filter_map(|l| {
+                if kind.starts_with("sensation/") {
+                    serde_json::from_str::<Sensation>(l).ok().map(|s| s.text)
+                } else {
+                    serde_json::from_str::<MemoryEntry>(l).ok().map(|e| {
+                        if !e.how.is_empty() {
+                            e.how
+                        } else {
+                            e.what.to_string()
+                        }
+                    })
+                }
+            })
+            .collect()
+    }
+
+    /// Append a new text value under the given `kind`.
+    pub async fn store(&self, kind: &str, text: &str) -> anyhow::Result<()> {
+        let entry = MemoryEntry {
+            id: Uuid::new_v4(),
+            kind: kind.to_string(),
+            when: Utc::now(),
+            what: Value::String(text.to_string()),
+            how: text.to_string(),
+        };
+        self.append(kind, &entry).await
+    }
+
+    async fn append(&self, kind: &str, value: &MemoryEntry) -> anyhow::Result<()> {
+        let path = self.dir.join(format!("{}.jsonl", kind));
+        let mut file = tokio::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&path)
+            .await?;
+        let line = serde_json::to_string(value)?;
+        use tokio::io::AsyncWriteExt;
+        file.write_all(line.as_bytes()).await?;
+        file.write_all(b"\n").await?;
+        Ok(())
+    }
+}

--- a/psyched/src/main.rs
+++ b/psyched/src/main.rs
@@ -30,12 +30,23 @@ pub struct Cli {
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let cli = Cli::parse();
+    let registry = std::sync::Arc::new(psyche::llm::LlmRegistry {
+        chat: Box::new(psyche::llm::mock_chat::MockChat::default()),
+        embed: Box::new(psyche::llm::mock_embed::MockEmbed::default()),
+    });
+    let profile = std::sync::Arc::new(psyche::llm::LlmProfile {
+        provider: "ollama".into(),
+        model: "llama3".into(),
+        capabilities: vec![psyche::llm::LlmCapability::Chat],
+    });
     let shutdown = shutdown_signal();
     psyched::run(
         cli.socket,
         cli.memory,
         cli.config,
         std::time::Duration::from_millis(cli.beat_ms),
+        registry,
+        profile,
         shutdown,
     )
     .await

--- a/psyched/src/wit.rs
+++ b/psyched/src/wit.rs
@@ -1,0 +1,14 @@
+use serde::Deserialize;
+
+/// Configuration for a single Wit used by `psyched`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WitConfig {
+    /// Memory kind this Wit consumes.
+    pub input: String,
+    /// Memory kind this Wit outputs.
+    pub output: String,
+    /// System prompt passed to the language model.
+    pub prompt: String,
+    /// Number of beats between each execution.
+    pub every: usize,
+}

--- a/psyched/tests/basic_vertical.rs
+++ b/psyched/tests/basic_vertical.rs
@@ -18,11 +18,22 @@ async fn sensation_results_in_instant() {
 
     let (tx, rx) = tokio::sync::oneshot::channel();
     let local = LocalSet::new();
+    let registry = std::sync::Arc::new(psyche::llm::LlmRegistry {
+        chat: Box::new(psyche::llm::mock_chat::MockChat::default()),
+        embed: Box::new(psyche::llm::mock_embed::MockEmbed::default()),
+    });
+    let profile = std::sync::Arc::new(psyche::llm::LlmProfile {
+        provider: "mock".into(),
+        model: "mock".into(),
+        capabilities: vec![psyche::llm::LlmCapability::Chat],
+    });
     let server = local.spawn_local(psyched::run(
         socket.clone(),
         memory_path.clone(),
         memory_dir.join("psyche.toml"),
         std::time::Duration::from_millis(50),
+        registry.clone(),
+        profile.clone(),
         async move {
             let _ = rx.await;
         },

--- a/psyched/tests/wit.rs
+++ b/psyched/tests/wit.rs
@@ -1,0 +1,68 @@
+use tempfile::tempdir;
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+use tokio::task::LocalSet;
+
+#[tokio::test(flavor = "current_thread")]
+async fn wit_produces_output() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("quick.sock");
+    let memory_path = dir.path().join("sensation.jsonl");
+    let memory_dir = dir.path().to_path_buf();
+    let config_path = memory_dir.join("psyche.toml");
+    tokio::fs::write(
+        &config_path,
+        "[distiller]\n\n[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\nevery = 1\n",
+    )
+    .await
+    .unwrap();
+
+    let registry = std::sync::Arc::new(psyche::llm::LlmRegistry {
+        chat: Box::new(psyche::llm::mock_chat::MockChat::default()),
+        embed: Box::new(psyche::llm::mock_embed::MockEmbed::default()),
+    });
+    let profile = std::sync::Arc::new(psyche::llm::LlmProfile {
+        provider: "mock".into(),
+        model: "mock".into(),
+        capabilities: vec![psyche::llm::LlmCapability::Chat],
+    });
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let local = LocalSet::new();
+    let server = local.spawn_local(psyched::run(
+        socket.clone(),
+        memory_path.clone(),
+        config_path,
+        std::time::Duration::from_millis(50),
+        registry.clone(),
+        profile.clone(),
+        async move {
+            let _ = rx.await;
+        },
+    ));
+
+    local
+        .run_until(async {
+            // directly append a sensation instead of using the socket
+            let sens = psyche::models::Sensation {
+                id: uuid::Uuid::new_v4().to_string(),
+                path: "/chat".into(),
+                text: "hello".into(),
+            };
+            let line = serde_json::to_string(&sens).unwrap();
+            tokio::fs::write(&memory_path, format!("{}\n", line))
+                .await
+                .unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            tx.send(()).unwrap();
+            server.await.unwrap().unwrap();
+
+            let path = memory_dir.join("reply.jsonl");
+            let content = tokio::fs::read_to_string(&path).await.unwrap();
+            let lines: Vec<_> = content.lines().collect();
+            assert_eq!(lines.len(), 1);
+            let entry: psyche::models::MemoryEntry = serde_json::from_str(lines[0]).unwrap();
+            assert_eq!(entry.how, "mock response");
+        })
+        .await;
+}


### PR DESCRIPTION
## Summary
- provide `LlmRegistry` and `LlmProfile` in `psyched::main`
- implement `FileMemory` and `WitConfig`
- schedule wits in the main loop using `CanChat::chat_stream`
- add regression test for wit scheduling

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6878057da8588320bbded059f71e16e0