### PR TITLE
Integrate Ollama chat client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - Keep narrative prompt text under `daringsby/src` and pass it into library
   constructors instead of embedding it in `psyche-rs`.
 - Use `httpmock` for HTTP-based tests to avoid external network dependencies.
+- Set `USE_MOCK_LLM=1` in tests to force Ollama-backed distillers to use `MockChat`.
 - Keep `.rs` files focused. Create a new source file for each new type and split
   large modules like `lib.rs` into smaller pieces.
 - Provide mutable `set_*` variants when adding builder methods to wrappers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +632,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -923,6 +947,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,9 +981,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1302,6 +1344,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "neo4rs"
 version = "0.9.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,10 +1459,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1497,6 +1594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,10 +1673,13 @@ name = "psyche"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "chrono",
+ "futures-util",
  "neo4rs",
  "qdrant-client",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -1799,6 +1905,7 @@ checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
@@ -1807,9 +1914,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1820,6 +1930,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
@@ -2178,6 +2289,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,6 +2425,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2567,6 +2709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +2925,17 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -10,6 +10,9 @@ uuid = { version = "1", features = ["v4", "serde"] }
 anyhow = "1"
 async-trait = "0.1"
 tokio-stream = "0.1"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+futures-util = "0.3"
+async-stream = "0.3"
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde", "clock"] }
 

--- a/psyche/src/distiller.rs
+++ b/psyche/src/distiller.rs
@@ -110,7 +110,8 @@ impl Distiller {
 
 /// Simple post processor that stores the source entry ids as a JSON array.
 pub fn link_sources(entries: &[MemoryEntry], _resp: &str) -> anyhow::Result<Value> {
-    Ok(serde_json::json!(
-        entries.iter().map(|e| e.id).collect::<Vec<_>>()
-    ))
+    Ok(serde_json::json!(entries
+        .iter()
+        .map(|e| e.id)
+        .collect::<Vec<_>>()))
 }

--- a/psyche/src/llm/mod.rs
+++ b/psyche/src/llm/mod.rs
@@ -2,6 +2,7 @@ pub mod chat;
 pub mod embed;
 pub mod mock_chat;
 pub mod mock_embed;
+pub mod ollama;
 pub mod prompt;
 
 use async_trait::async_trait;

--- a/psyche/src/llm/ollama.rs
+++ b/psyche/src/llm/ollama.rs
@@ -1,0 +1,76 @@
+use super::{CanChat, LlmProfile};
+use async_stream::stream;
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde::Deserialize;
+use tokio_stream::Stream;
+use tracing::{debug, trace};
+
+/// Chat client that calls an Ollama instance via HTTP.
+#[derive(Clone, Debug)]
+pub struct OllamaChat {
+    /// Base URL for the Ollama server, e.g. `http://localhost:11434`.
+    pub base_url: String,
+    /// Model name such as `mistral` or `llama3`.
+    pub model: String,
+}
+
+#[derive(Deserialize)]
+struct Chunk {
+    message: Option<Message>,
+    #[allow(dead_code)]
+    done: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct Message {
+    content: String,
+}
+
+#[async_trait(?Send)]
+impl CanChat for OllamaChat {
+    async fn chat_stream(
+        &self,
+        _profile: &LlmProfile,
+        system: &str,
+        user: &str,
+    ) -> anyhow::Result<Box<dyn Stream<Item = String> + Unpin>> {
+        let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
+        let body = serde_json::json!({
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user}
+            ],
+            "stream": true
+        });
+        trace!(target = "llm", %url, body = %body, "Ollama prompt");
+        let resp = reqwest::Client::new().post(url).json(&body).send().await?;
+        let mut stream = resp.bytes_stream();
+        let out = stream! {
+            let mut full = String::new();
+            while let Some(chunk) = stream.next().await {
+                let bytes = match chunk {
+                    Ok(b) => b,
+                    Err(e) => {
+                        debug!(target = "llm", error = %e, "stream error");
+                        break;
+                    }
+                };
+                let text = String::from_utf8_lossy(&bytes);
+                for line in text.lines() {
+                    if line.trim().is_empty() { continue; }
+                    if let Ok(c) = serde_json::from_str::<Chunk>(line) {
+                        if let Some(msg) = c.message {
+                            trace!(target = "llm", token = %msg.content, "stream token");
+                            full.push_str(&msg.content);
+                            yield msg.content;
+                        }
+                    }
+                }
+            }
+            debug!(target = "llm", response = %full, "Ollama full response");
+        };
+        Ok(Box::new(Box::pin(out)) as Box<dyn Stream<Item = String> + Unpin>)
+    }
+}

--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -159,6 +159,14 @@ impl LoadedDistiller {
             ),
             _ => None,
         };
+        let default_llm: Box<dyn psyche::llm::CanChat> = if std::env::var("USE_MOCK_LLM").is_ok() {
+            Box::new(psyche::llm::mock_chat::MockChat::default())
+        } else {
+            Box::new(psyche::llm::ollama::OllamaChat {
+                base_url: "http://localhost:11434".into(),
+                model: "mistral".into(),
+            })
+        };
         let distiller = Distiller {
             config: DistillerConfig {
                 name: name.clone(),
@@ -167,7 +175,7 @@ impl LoadedDistiller {
                 prompt_template,
                 post_process: pp,
             },
-            llm: Box::new(psyche::llm::mock_chat::MockChat::default()),
+            llm: default_llm,
         };
         Self {
             name,

--- a/psyched/tests/basic_vertical.rs
+++ b/psyched/tests/basic_vertical.rs
@@ -18,6 +18,7 @@ async fn sensation_results_in_instant() {
     tokio::fs::create_dir_all(soul_dir.join("memory"))
         .await
         .unwrap();
+    std::env::set_var("USE_MOCK_LLM", "1");
     tokio::fs::copy(config_path, soul_dir.join("config/pipeline.toml"))
         .await
         .unwrap();
@@ -60,14 +61,14 @@ async fn sensation_results_in_instant() {
             stream.write_all(msg).await.unwrap();
 
             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-            tx.send(()).unwrap();
+            let _ = tx.send(());
             server.await.unwrap().unwrap();
 
             let sensation_path = memory_path.clone();
             let content = tokio::fs::read_to_string(&sensation_path).await.unwrap();
             let lines: Vec<_> = content.lines().collect();
             assert_eq!(lines.len(), 1);
-            let _sensation: psyche::models::Sensation = serde_json::from_str(lines[0]).unwrap();
+            let sensation: psyche::models::Sensation = serde_json::from_str(lines[0]).unwrap();
 
             let instant_path = soul_dir.join("memory/instant.jsonl");
             let icontent = tokio::fs::read_to_string(&instant_path).await.unwrap();


### PR DESCRIPTION
## Summary
- add new OllamaChat implementation for `CanChat`
- hook distiller startup to use Ollama or mock via `USE_MOCK_LLM`
- support new backend with reqwest/async-stream
- keep tests offline by setting `USE_MOCK_LLM`
- document mock variable in AGENTS.md

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68783ad8cfb0832089d8423955bb9cfa