### PR TITLE
Fix handle_stream spawn

### DIFF
--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -262,18 +262,10 @@ pub async fn run(
         tokio::select! {
             _ = &mut shutdown => break,
             Ok((stream, _)) = listener.accept() => {
-              tokio::select! {
-                  _ = &mut shutdown => break,
-
-                  Ok((stream, _)) = listener.accept() => {
-                      let memory = memory_store.clone(); // Assuming Arc or Copy if needed
-                      tokio::spawn(async move {
-                          if let Err(e) = handle_stream(stream, &memory).await {
-                              tracing::error!(error = %e, "failed to handle stream");
-                          }
-                      });
-                  }
-              };
+                let memory = memory_store.clone();
+                if let Err(e) = handle_stream(stream, &memory).await {
+                    tracing::error!(error = %e, "failed to handle stream");
+                }
             }
             _ = beat.tick() => {
                 beat_counter += 1;


### PR DESCRIPTION
## Summary
- remove nested accept select loop and run `handle_stream` inline

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6878448373f08320a76c1088b9bca1f8