### PR TITLE
Improve socket responsiveness by spawning server task

### DIFF
--- a/psyched/src/main.rs
+++ b/psyched/src/main.rs
@@ -71,16 +71,18 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Kick off orchestrator
-    psyched::run(
-        cli.socket,
-        soul,
-        pipeline,
-        std::time::Duration::from_millis(cli.beat_ms),
-        registry,
-        profile,
-        shutdown_signal(),
-    )
-    .await
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(psyched::run(
+            cli.socket,
+            soul,
+            pipeline,
+            std::time::Duration::from_millis(cli.beat_ms),
+            registry,
+            profile,
+            shutdown_signal(),
+        ))
+        .await
 }
 
 fn shutdown_signal() -> impl std::future::Future<Output = ()> {


### PR DESCRIPTION
## Summary
- keep the socket responsive by moving listener logic to its own task
- execute the orchestrator inside a `LocalSet` so the non-`Send` server task can run

## Testing
- `cargo test --all`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687866e53b208320be9248b4c449126e