### PR TITLE
Improve distiller input filtering

### DIFF
--- a/psyche/src/distiller.rs
+++ b/psyche/src/distiller.rs
@@ -53,7 +53,10 @@ impl Distiller {
         // Filter by input kind
         let entries: Vec<_> = input
             .into_iter()
-            .filter(|e| e.kind == self.config.input_kind)
+            .filter(|e| {
+                e.kind == self.config.input_kind
+                    || e.kind.starts_with(&format!("{}/", self.config.input_kind))
+            })
             .collect();
 
         if entries.is_empty() {

--- a/psyche/tests/basic.rs
+++ b/psyche/tests/basic.rs
@@ -33,6 +33,32 @@ async fn combobulator_config_distills_chat() {
 }
 
 #[tokio::test]
+async fn prefix_filter_matches_subkind() {
+    let entry_id = Uuid::new_v4();
+    let cfg = DistillerConfig {
+        name: "combobulator".into(),
+        input_kind: "sensation".into(),
+        output_kind: "instant".into(),
+        prompt_template: "{input}".into(),
+        post_process: Some(link_sources),
+    };
+    let mut d = Distiller {
+        config: cfg,
+        llm: Box::new(MockChat::default()),
+    };
+    let entry = MemoryEntry {
+        id: entry_id,
+        kind: "sensation/chat".into(),
+        when: Utc::now(),
+        what: json!("I feel tired"),
+        how: String::new(),
+    };
+    let out = d.distill(vec![entry]).await.unwrap();
+    assert_eq!(out[0].kind, "instant");
+    assert_eq!(out[0].what, json!([entry_id]));
+}
+
+#[tokio::test]
 async fn memory_config_distills_instant() {
     let id1 = Uuid::new_v4();
     let id2 = Uuid::new_v4();

--- a/psyched/src/file_memory.rs
+++ b/psyched/src/file_memory.rs
@@ -46,8 +46,15 @@ impl FileMemory {
         slice
             .iter()
             .filter_map(|l| {
-                if kind.starts_with("sensation/") {
-                    serde_json::from_str::<Sensation>(l).ok().map(|s| s.text)
+                if kind.starts_with("sensation") {
+                    serde_json::from_str::<Sensation>(l).ok().and_then(|s| {
+                        let entry_kind = format!("sensation{}", s.path);
+                        if entry_kind.starts_with(kind) {
+                            Some(s.text)
+                        } else {
+                            None
+                        }
+                    })
                 } else {
                     serde_json::from_str::<MemoryEntry>(l).ok().map(|e| {
                         if !e.how.is_empty() {

--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -170,15 +170,18 @@ impl LoadedDistiller {
             let lines: Vec<_> = content.lines().collect();
             if *offset < lines.len() {
                 for line in &lines[*offset..] {
-                    if kind.starts_with("sensation/") {
+                    if kind.starts_with("sensation") {
                         let s: Sensation = serde_json::from_str(line)?;
-                        out.push(MemoryEntry {
-                            id: Uuid::parse_str(&s.id)?,
-                            kind: kind.clone(),
-                            when: Utc::now(),
-                            what: json!(s.text),
-                            how: String::new(),
-                        });
+                        let entry_kind = format!("sensation{}", s.path);
+                        if entry_kind.starts_with(kind) {
+                            out.push(MemoryEntry {
+                                id: Uuid::parse_str(&s.id)?,
+                                kind: entry_kind,
+                                when: Utc::now(),
+                                what: json!(s.text),
+                                how: String::new(),
+                            });
+                        }
                     } else {
                         let mut e: MemoryEntry = serde_json::from_str(line)?;
                         e.kind = kind.clone();


### PR DESCRIPTION
## Summary
- support prefix matching for distiller input kinds
- collect sensations by prefix and surface their original subkinds
- return only matching items from FileMemory when using a prefix
- test that prefix filters work

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687957e4cc88832089d0ffe3d6f9728c