### PR TITLE
Add multi-LLM dispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,6 +1650,7 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
+ "serde",
 ]
 
 [[package]]
@@ -2445,6 +2446,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "indexmap 2.10.0",
  "neo4rs",
  "psyche",
  "qdrant-client",

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -10,6 +10,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 anyhow = "1"
 async-trait = "0.1"
 tokio-stream = "0.1"
+tokio = { version = "1", features = ["sync"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 futures-util = "0.3"
 async-stream = "0.3"

--- a/psyche/src/llm/limited.rs
+++ b/psyche/src/llm/limited.rs
@@ -1,0 +1,49 @@
+use super::{CanChat, LlmProfile};
+use async_trait::async_trait;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_stream::Stream;
+
+/// Wrapper that limits concurrent access to an inner [`CanChat`].
+pub struct LimitedChat {
+    inner: Arc<dyn CanChat>,
+    semaphore: Arc<Semaphore>,
+}
+
+impl LimitedChat {
+    pub fn new(inner: Arc<dyn CanChat>, semaphore: Arc<Semaphore>) -> Self {
+        Self { inner, semaphore }
+    }
+}
+
+struct PermitStream<S> {
+    stream: S,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl<S: Stream + Unpin> Stream for PermitStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.stream).poll_next(cx)
+    }
+}
+
+#[async_trait(?Send)]
+impl CanChat for LimitedChat {
+    async fn chat_stream(
+        &self,
+        profile: &LlmProfile,
+        system: &str,
+        user: &str,
+    ) -> anyhow::Result<Box<dyn Stream<Item = String> + Unpin>> {
+        let permit = self.semaphore.clone().acquire_owned().await?;
+        let stream = self.inner.chat_stream(profile, system, user).await?;
+        Ok(Box::new(PermitStream {
+            stream,
+            _permit: permit,
+        }))
+    }
+}

--- a/psyche/src/llm/mock_chat.rs
+++ b/psyche/src/llm/mock_chat.rs
@@ -21,3 +21,30 @@ impl CanChat for MockChat {
         Ok(Box::new(iter([resp])))
     }
 }
+
+/// Mock chat that returns its configured name as the response.
+#[derive(Clone)]
+pub struct NamedMockChat {
+    /// The text returned for any prompt.
+    pub name: String,
+}
+
+impl Default for NamedMockChat {
+    fn default() -> Self {
+        Self {
+            name: "mock".into(),
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl CanChat for NamedMockChat {
+    async fn chat_stream(
+        &self,
+        _profile: &LlmProfile,
+        _system: &str,
+        _user: &str,
+    ) -> anyhow::Result<Box<dyn Stream<Item = String> + Unpin>> {
+        Ok(Box::new(iter([self.name.clone()])))
+    }
+}

--- a/psyche/src/llm/mod.rs
+++ b/psyche/src/llm/mod.rs
@@ -1,5 +1,6 @@
 pub mod chat;
 pub mod embed;
+pub mod limited;
 pub mod mock_chat;
 pub mod mock_embed;
 pub mod ollama;
@@ -57,4 +58,20 @@ pub struct LlmRegistry {
     pub chat: Box<dyn CanChat>,
     /// Embedding implementation.
     pub embed: Box<dyn CanEmbed>,
+}
+
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+/// Runtime handle to a specific LLM instance with concurrency limits.
+#[derive(Clone)]
+pub struct LlmInstance {
+    /// Human friendly name used in configuration overrides.
+    pub name: String,
+    /// Chat implementation for this LLM.
+    pub chat: Arc<dyn CanChat>,
+    /// Profile describing the model.
+    pub profile: Arc<LlmProfile>,
+    /// Semaphore limiting concurrent usage.
+    pub semaphore: Arc<Semaphore>,
 }

--- a/psyche/tests/basic.rs
+++ b/psyche/tests/basic.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use psyche::distiller::{link_sources, Distiller, DistillerConfig};
 use psyche::llm::mock_chat::MockChat;
+use psyche::llm::{LlmCapability, LlmProfile};
 use psyche::models::MemoryEntry;
 use serde_json::json;
 use uuid::Uuid;
@@ -18,6 +19,11 @@ async fn combobulator_config_distills_chat() {
     let mut d = Distiller {
         config: cfg,
         llm: Box::new(MockChat::default()),
+        profile: LlmProfile {
+            provider: "mock".into(),
+            model: "mock".into(),
+            capabilities: vec![LlmCapability::Chat],
+        },
     };
     let entry = MemoryEntry {
         id: entry_id,
@@ -45,6 +51,11 @@ async fn prefix_filter_matches_subkind() {
     let mut d = Distiller {
         config: cfg,
         llm: Box::new(MockChat::default()),
+        profile: LlmProfile {
+            provider: "mock".into(),
+            model: "mock".into(),
+            capabilities: vec![LlmCapability::Chat],
+        },
     };
     let entry = MemoryEntry {
         id: entry_id,
@@ -72,6 +83,11 @@ async fn memory_config_distills_instant() {
     let mut d = Distiller {
         config: cfg,
         llm: Box::new(MockChat::default()),
+        profile: LlmProfile {
+            provider: "mock".into(),
+            model: "mock".into(),
+            capabilities: vec![LlmCapability::Chat],
+        },
     };
     let entry1 = MemoryEntry {
         id: id1,

--- a/psyched/Cargo.toml
+++ b/psyched/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "0.4", features = ["serde", "clock"] }
 clap = { version = "4", features = ["derive"] }
 qdrant-client = "1"
 neo4rs = "0.9.0-rc.6"
+indexmap = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/psyched/src/llm_config.rs
+++ b/psyched/src/llm_config.rs
@@ -6,6 +6,9 @@ use std::path::Path;
 pub struct LlmProviderConfig {
     /// Provider name like `"ollama"` or `"openai"`.
     pub provider: String,
+    /// Optional unique name used for selecting this provider.
+    #[serde(default)]
+    pub name: Option<String>,
     /// Base URL for the service if applicable (e.g. Ollama).
     #[serde(default)]
     pub base_url: Option<String>,
@@ -17,6 +20,9 @@ pub struct LlmProviderConfig {
     /// Supported capabilities such as `"chat"` or `"embedding"`.
     #[serde(default)]
     pub capabilities: Vec<String>,
+    /// Maximum concurrent requests allowed.
+    #[serde(default)]
+    pub concurrency: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -79,4 +85,58 @@ pub async fn load_first_llm(
         other => anyhow::bail!("unsupported provider: {}", other),
     };
     Ok((registry, profile))
+}
+
+/// Loads all LLM providers from `path` returning initialized instances.
+pub async fn load_llms(path: &Path) -> anyhow::Result<Vec<psyche::llm::LlmInstance>> {
+    use tokio::fs;
+    let text = fs::read_to_string(path).await?;
+    let cfg: LlmConfigFile = toml::from_str(&text)?;
+    let mut out = Vec::new();
+    for (idx, prov) in cfg.llms.into_iter().enumerate() {
+        let model = prov
+            .models
+            .first()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("no models for provider"))?;
+        let capabilities = if prov.capabilities.is_empty() {
+            vec![psyche::llm::LlmCapability::Chat]
+        } else {
+            prov.capabilities
+                .iter()
+                .filter_map(|c| match c.as_str() {
+                    "chat" => Some(psyche::llm::LlmCapability::Chat),
+                    "embedding" => Some(psyche::llm::LlmCapability::Embedding),
+                    _ => None,
+                })
+                .collect()
+        };
+        let profile = std::sync::Arc::new(psyche::llm::LlmProfile {
+            provider: prov.provider.clone(),
+            model: model.clone(),
+            capabilities,
+        });
+        let chat: std::sync::Arc<dyn psyche::llm::CanChat> = match prov.provider.as_str() {
+            "ollama" => std::sync::Arc::new(psyche::llm::ollama::OllamaChat {
+                base_url: prov
+                    .base_url
+                    .unwrap_or_else(|| "http://localhost:11434".into()),
+                model,
+            }),
+            "mock" => std::sync::Arc::new(psyche::llm::mock_chat::MockChat::default()),
+            other => anyhow::bail!("unsupported provider: {}", other),
+        };
+        let name = prov
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("{}{}", prov.provider, idx));
+        let concurrency = prov.concurrency.unwrap_or(1);
+        out.push(psyche::llm::LlmInstance {
+            name,
+            chat,
+            profile,
+            semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency)),
+        });
+    }
+    Ok(out)
 }

--- a/psyched/src/wit.rs
+++ b/psyched/src/wit.rs
@@ -14,4 +14,7 @@ pub struct WitConfig {
     /// Optional name of another Wit to receive this Wit’s output as input.
     #[serde(default)]
     pub feedback: Option<String>,
+    /// Optional name of the LLM profile this Wit should use.
+    #[serde(default)]
+    pub llm: Option<String>,
 }

--- a/psyched/tests/basic_vertical.rs
+++ b/psyched/tests/basic_vertical.rs
@@ -34,6 +34,12 @@ async fn sensation_results_in_instant() {
         model: "mock".into(),
         capabilities: vec![psyche::llm::LlmCapability::Chat],
     });
+    let instance = std::sync::Arc::new(psyche::llm::LlmInstance {
+        name: "mock".into(),
+        chat: std::sync::Arc::new(psyche::llm::mock_chat::MockChat::default()),
+        profile: profile.clone(),
+        semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+    });
     let server = local.spawn_local(psyched::run(
         socket.clone(),
         soul_dir.clone(),
@@ -41,6 +47,7 @@ async fn sensation_results_in_instant() {
         std::time::Duration::from_millis(50),
         registry.clone(),
         profile.clone(),
+        vec![instance.clone()],
         async move {
             let _ = rx.await;
         },

--- a/psyched/tests/full_loop.rs
+++ b/psyched/tests/full_loop.rs
@@ -36,6 +36,12 @@ async fn quick_to_combobulator_generates_situation() {
     });
 
     let (tx, rx) = tokio::sync::oneshot::channel();
+    let instance = std::sync::Arc::new(psyche::llm::LlmInstance {
+        name: "mock".into(),
+        chat: std::sync::Arc::new(psyche::llm::mock_chat::MockChat::default()),
+        profile: profile.clone(),
+        semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+    });
     let local = LocalSet::new();
     let server = local.spawn_local(psyched::run(
         socket.clone(),
@@ -44,6 +50,7 @@ async fn quick_to_combobulator_generates_situation() {
         std::time::Duration::from_millis(50),
         registry.clone(),
         profile.clone(),
+        vec![instance.clone()],
         async move {
             let _ = rx.await;
         },

--- a/psyched/tests/llm_config.rs
+++ b/psyched/tests/llm_config.rs
@@ -11,7 +11,7 @@ async fn load_first_llm_picks_first_provider() {
         .await
         .unwrap();
 
-    let (_reg, prof) = psyched::llm_config::load_first_llm(&path).await.unwrap();
-    assert_eq!(prof.provider, "ollama");
-    assert_eq!(prof.model, "x");
+    let llms = psyched::llm_config::load_llms(&path).await.unwrap();
+    assert_eq!(llms.first().unwrap().profile.provider, "ollama");
+    assert_eq!(llms.first().unwrap().profile.model, "x");
 }

--- a/psyched/tests/nonblocking.rs
+++ b/psyched/tests/nonblocking.rs
@@ -33,6 +33,12 @@ async fn injection_returns_immediately() {
     });
 
     let (tx, rx) = tokio::sync::oneshot::channel();
+    let instance = std::sync::Arc::new(psyche::llm::LlmInstance {
+        name: "mock".into(),
+        chat: std::sync::Arc::new(psyche::llm::mock_chat::MockChat::default()),
+        profile: profile.clone(),
+        semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+    });
     let local = LocalSet::new();
     let server = local.spawn_local(psyched::run(
         socket.clone(),
@@ -41,6 +47,7 @@ async fn injection_returns_immediately() {
         std::time::Duration::from_millis(50),
         registry.clone(),
         profile.clone(),
+        vec![instance.clone()],
         async move {
             let _ = rx.await;
         },

--- a/psyched/tests/wit.rs
+++ b/psyched/tests/wit.rs
@@ -32,6 +32,12 @@ async fn wit_produces_output() {
     });
 
     let (tx, rx) = tokio::sync::oneshot::channel();
+    let instance = std::sync::Arc::new(psyche::llm::LlmInstance {
+        name: "mock".into(),
+        chat: std::sync::Arc::new(psyche::llm::mock_chat::MockChat::default()),
+        profile: profile.clone(),
+        semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+    });
     let local = LocalSet::new();
     let server = local.spawn_local(psyched::run(
         socket.clone(),
@@ -40,6 +46,7 @@ async fn wit_produces_output() {
         std::time::Duration::from_millis(50),
         registry.clone(),
         profile.clone(),
+        vec![instance.clone()],
         async move {
             let _ = rx.await;
         },
@@ -99,6 +106,12 @@ async fn feedback_forwards_output() {
     });
 
     let (tx, rx) = tokio::sync::oneshot::channel();
+    let instance = std::sync::Arc::new(psyche::llm::LlmInstance {
+        name: "mock".into(),
+        chat: std::sync::Arc::new(psyche::llm::mock_chat::MockChat::default()),
+        profile: profile.clone(),
+        semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+    });
     let local = LocalSet::new();
     let server = local.spawn_local(psyched::run(
         socket.clone(),
@@ -107,6 +120,7 @@ async fn feedback_forwards_output() {
         std::time::Duration::from_millis(50),
         registry.clone(),
         profile.clone(),
+        vec![instance.clone()],
         async move {
             let _ = rx.await;
         },

--- a/psyched/tests/wit_from_config.rs
+++ b/psyched/tests/wit_from_config.rs
@@ -32,6 +32,12 @@ async fn wit_from_config_runs() {
     });
 
     let (tx, rx) = tokio::sync::oneshot::channel();
+    let instance = std::sync::Arc::new(psyche::llm::LlmInstance {
+        name: "mock".into(),
+        chat: std::sync::Arc::new(psyche::llm::mock_chat::MockChat::default()),
+        profile: profile.clone(),
+        semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+    });
     let local = LocalSet::new();
     let server = local.spawn_local(psyched::run(
         socket.clone(),
@@ -40,6 +46,7 @@ async fn wit_from_config_runs() {
         std::time::Duration::from_millis(50),
         registry.clone(),
         profile.clone(),
+        vec![instance.clone()],
         async move {
             let _ = rx.await;
         },


### PR DESCRIPTION
## Summary
- implement `LlmInstance` and `LimitedChat` wrappers
- load multiple LLM providers from `llm.toml`
- bind Wits to LLMs via round-robin with first reserved
- throttle chat concurrency per LLM
- update tests for new orchestration

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68798c85722083209062288edd7c76b3