### PR TITLE
Add CLI log level sharing and whisper model option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "daemon-common"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1297,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "daemon-common",
  "serde",
  "serde_json",
  "tempfile",
@@ -2484,6 +2493,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "daemon-common",
  "indexmap 2.10.0",
  "neo4rs",
  "psyche",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["psyche", "psyched", "heard"]
+members = ["psyche", "psyched", "heard", "daemon-common"]
 resolver = "2"

--- a/daemon-common/Cargo.toml
+++ b/daemon-common/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "daemon-common"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+tracing-subscriber = "0.3"

--- a/daemon-common/src/lib.rs
+++ b/daemon-common/src/lib.rs
@@ -1,0 +1,28 @@
+use clap::ValueEnum;
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Default for LogLevel {
+    fn default() -> Self {
+        LogLevel::Info
+    }
+}
+
+impl From<LogLevel> for tracing_subscriber::filter::LevelFilter {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Error => tracing_subscriber::filter::LevelFilter::ERROR,
+            LogLevel::Warn => tracing_subscriber::filter::LevelFilter::WARN,
+            LogLevel::Info => tracing_subscriber::filter::LevelFilter::INFO,
+            LogLevel::Debug => tracing_subscriber::filter::LevelFilter::DEBUG,
+            LogLevel::Trace => tracing_subscriber::filter::LevelFilter::TRACE,
+        }
+    }
+}

--- a/heard/Cargo.toml
+++ b/heard/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 serde = { version = "1", features = ["derive"] }
@@ -14,6 +14,7 @@ whisper-rs = "0.14"
 webrtc-vad = "0.4"
 async-trait = "0.1"
 anyhow = "1"
+daemon-common = { path = "../daemon-common" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/heard/src/main.rs
+++ b/heard/src/main.rs
@@ -1,32 +1,6 @@
-use clap::{Parser, ValueEnum};
+use clap::Parser;
+use daemon_common::LogLevel;
 use std::path::PathBuf;
-
-#[derive(Copy, Clone, Debug, ValueEnum)]
-enum LogLevel {
-    Error,
-    Warn,
-    Info,
-    Debug,
-    Trace,
-}
-
-impl Default for LogLevel {
-    fn default() -> Self {
-        LogLevel::Info
-    }
-}
-
-impl From<LogLevel> for tracing_subscriber::filter::LevelFilter {
-    fn from(level: LogLevel) -> Self {
-        match level {
-            LogLevel::Error => tracing_subscriber::filter::LevelFilter::ERROR,
-            LogLevel::Warn => tracing_subscriber::filter::LevelFilter::WARN,
-            LogLevel::Info => tracing_subscriber::filter::LevelFilter::INFO,
-            LogLevel::Debug => tracing_subscriber::filter::LevelFilter::DEBUG,
-            LogLevel::Trace => tracing_subscriber::filter::LevelFilter::TRACE,
-        }
-    }
-}
 
 #[derive(Parser, Debug)]
 #[command(name = "heard", about = "Audio ingestion and transcription daemon")]
@@ -38,6 +12,10 @@ struct Cli {
     /// Path to the input socket to listen for PCM audio
     #[arg(long)]
     listen: PathBuf,
+
+    /// Path to whisper model
+    #[arg(long, env = "WHISPER_MODEL")]
+    whisper_model: PathBuf,
 
     /// Logging verbosity level
     #[arg(long, default_value = "info")]
@@ -51,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_max_level(tracing_subscriber::filter::LevelFilter::from(cli.log_level))
         .init();
-    heard::run(cli.socket, cli.listen).await
+    heard::run(cli.socket, cli.listen, cli.whisper_model).await
 }
 
 #[cfg(test)]
@@ -60,14 +38,29 @@ mod tests {
 
     #[test]
     fn cli_defaults_to_info_log_level() {
-        let cli = Cli::try_parse_from(["heard", "--listen", "in.sock"]).unwrap();
+        let cli = Cli::try_parse_from([
+            "heard",
+            "--listen",
+            "in.sock",
+            "--whisper-model",
+            "model.bin",
+        ])
+        .unwrap();
         assert!(matches!(cli.log_level, LogLevel::Info));
     }
 
     #[test]
     fn parses_debug_log_level() {
-        let cli =
-            Cli::try_parse_from(["heard", "--listen", "in.sock", "--log-level", "debug"]).unwrap();
+        let cli = Cli::try_parse_from([
+            "heard",
+            "--listen",
+            "in.sock",
+            "--whisper-model",
+            "model.bin",
+            "--log-level",
+            "debug",
+        ])
+        .unwrap();
         assert!(matches!(cli.log_level, LogLevel::Debug));
     }
 }

--- a/heard/src/test_helpers.rs
+++ b/heard/src/test_helpers.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use crate::{Stt, audio_segmenter::AudioSegmenter, send_transcription};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{UnixListener, UnixStream};
+use tokio::io::AsyncReadExt;
+use tokio::net::UnixListener;
 use tokio::sync::mpsc;
 use tracing::debug;
 

--- a/psyched/Cargo.toml
+++ b/psyched/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4", features = ["derive"] }
 qdrant-client = "1"
 neo4rs = "0.9.0-rc.6"
 indexmap = { version = "2", features = ["serde"] }
+daemon-common = { path = "../daemon-common" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/psyched/src/main.rs
+++ b/psyched/src/main.rs
@@ -1,4 +1,5 @@
-use clap::{Parser, ValueEnum};
+use clap::Parser;
+use daemon_common::LogLevel;
 use std::path::PathBuf;
 use tokio::fs;
 use toml;
@@ -34,27 +35,6 @@ pub struct Cli {
     /// Logging verbosity level
     #[arg(long, default_value = "info")]
     pub log_level: LogLevel,
-}
-
-#[derive(Copy, Clone, Debug, ValueEnum)]
-pub enum LogLevel {
-    Error,
-    Warn,
-    Info,
-    Debug,
-    Trace,
-}
-
-impl From<LogLevel> for tracing_subscriber::filter::LevelFilter {
-    fn from(level: LogLevel) -> Self {
-        match level {
-            LogLevel::Error => tracing_subscriber::filter::LevelFilter::ERROR,
-            LogLevel::Warn => tracing_subscriber::filter::LevelFilter::WARN,
-            LogLevel::Info => tracing_subscriber::filter::LevelFilter::INFO,
-            LogLevel::Debug => tracing_subscriber::filter::LevelFilter::DEBUG,
-            LogLevel::Trace => tracing_subscriber::filter::LevelFilter::TRACE,
-        }
-    }
 }
 
 #[tokio::main]

--- a/scripts/heard.sh
+++ b/scripts/heard.sh
@@ -4,4 +4,4 @@ if [ -z "$1" ]; then
     set -- "layka"
 fi
 
-WHISPER_MODEL=whisper-base.en.bin cargo run -p heard -- --socket ./quick.sock --listen ./ear.sock
+cargo run -p heard -- --socket ./quick.sock --listen ./ear.sock --whisper-model whisper-base.en.bin


### PR DESCRIPTION
## Summary
- add `daemon-common` crate for common CLI args
- allow `heard` to accept `--whisper-model` flag and env var
- use shared `LogLevel` in `heard` and `psyched`
- update helper script
- update Cargo.lock

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6879d6d147dc832084e31be8eb9e76fc