### PR TITLE
Avoid noise when segmenter receives only silence

### DIFF
--- a/heard/src/audio_segmenter.rs
+++ b/heard/src/audio_segmenter.rs
@@ -83,7 +83,9 @@ impl AudioSegmenter {
                     return Some(spoken);
                 } else {
                     self.discarded += spoken.len();
-                    debug!(samples = spoken.len(), "discarding short segment");
+                    if !spoken.is_empty() {
+                        debug!(samples = spoken.len(), "discarding short segment");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- suppress debug logs for discarded segments with no voiced audio

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6879db701d888320bcb0ef452db049e2