### PR TITLE
Enforce one sentence `how` fields

### DIFF
--- a/psyche/src/distiller.rs
+++ b/psyche/src/distiller.rs
@@ -1,5 +1,6 @@
 use crate::llm::{CanChat, LlmProfile};
 use crate::models::{Instant, MemoryEntry, Sensation};
+use crate::utils::{first_sentence, parse_json_or_string};
 use chrono::Utc;
 use serde_json::Value;
 use tokio_stream::StreamExt;
@@ -95,7 +96,7 @@ impl Distiller {
         let value = if let Some(pp) = self.config.post_process {
             pp(&entries, &resp)?
         } else {
-            Value::String(resp.clone())
+            parse_json_or_string(&resp)
         };
 
         Ok(vec![MemoryEntry {
@@ -103,7 +104,7 @@ impl Distiller {
             kind: self.config.output_kind.clone(),
             when: Utc::now(),
             what: value,
-            how: resp,
+            how: first_sentence(&resp),
         }])
     }
 }

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -6,3 +6,4 @@ pub mod distiller;
 pub mod llm;
 pub mod memory;
 pub mod models;
+pub mod utils;

--- a/psyche/src/utils.rs
+++ b/psyche/src/utils.rs
@@ -1,0 +1,36 @@
+use serde_json::Value;
+
+/// Return the first sentence of `text` including the ending punctuation.
+///
+/// Splits on '.', '!' or '?' and returns the substring up to and including the
+/// first such character. If none are found, the entire string is returned.
+///
+/// # Examples
+///
+/// ```
+/// use psyche::utils::first_sentence;
+/// assert_eq!(first_sentence("Hello world. Second."), "Hello world.");
+/// assert_eq!(first_sentence("No punctuation"), "No punctuation");
+/// ```
+pub fn first_sentence(text: &str) -> String {
+    for (i, c) in text.char_indices() {
+        if matches!(c, '.' | '!' | '?') {
+            return text[..=i].trim().to_string();
+        }
+    }
+    text.trim().to_string()
+}
+
+/// Attempt to parse `text` as JSON, falling back to a string value.
+///
+/// # Examples
+///
+/// ```
+/// use serde_json::json;
+/// use psyche::utils::parse_json_or_string;
+/// assert_eq!(parse_json_or_string("{\"a\":1}"), json!({"a":1}));
+/// assert_eq!(parse_json_or_string("text"), json!("text"));
+/// ```
+pub fn parse_json_or_string(text: &str) -> Value {
+    serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.to_string()))
+}

--- a/psyche/tests/memory.rs
+++ b/psyche/tests/memory.rs
@@ -58,6 +58,32 @@ async fn generates_summary_with_llm() {
     assert_eq!(stored.experience.how, "mock response");
 }
 
+#[tokio::test]
+async fn provided_summary_truncated() {
+    let profile = LlmProfile {
+        provider: "mock".into(),
+        model: "mock".into(),
+        capabilities: vec![LlmCapability::Chat, LlmCapability::Embedding],
+    };
+    let registry = LlmRegistry {
+        chat: Box::new(MockChat::default()),
+        embed: Box::new(MockEmbed::default()),
+    };
+    let backend = InMemoryBackend::default();
+    let memorizer = Memorizer {
+        chat: Some(&*registry.chat),
+        embed: &*registry.embed,
+        profile: &profile,
+        backend: &backend,
+        prompter: PromptHelper::default(),
+    };
+    let stored = memorizer
+        .memorize("full text", Some("Short. Extra."), false, vec![])
+        .await
+        .unwrap();
+    assert_eq!(stored.experience.how, "Short.");
+}
+
 use async_trait::async_trait;
 use std::sync::Mutex;
 use tokio_stream::{iter, Stream};

--- a/psyche/tests/utils.rs
+++ b/psyche/tests/utils.rs
@@ -1,0 +1,15 @@
+use serde_json::json;
+
+#[test]
+fn first_sentence_extracts_sentence() {
+    assert_eq!(psyche::utils::first_sentence("Hello. World."), "Hello.");
+}
+
+#[test]
+fn parse_json_or_string_parses_json() {
+    assert_eq!(
+        psyche::utils::parse_json_or_string("{\"a\":1}"),
+        json!({"a":1})
+    );
+    assert_eq!(psyche::utils::parse_json_or_string("hi"), json!("hi"));
+}

--- a/psyched/src/db_memory.rs
+++ b/psyched/src/db_memory.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use psyche::llm::{CanEmbed, LlmProfile};
 use psyche::memory::{Experience, MemoryBackend, QdrantNeo4j};
 use psyche::models::{MemoryEntry, Sensation};
+use psyche::utils::{first_sentence, parse_json_or_string};
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -63,8 +64,8 @@ impl<'a> DbMemory<'a> {
             id: Uuid::new_v4(),
             kind: kind.to_string(),
             when: Utc::now(),
-            what: Value::String(text.to_string()),
-            how: text.to_string(),
+            what: parse_json_or_string(text),
+            how: first_sentence(text),
         };
         self.append_entries(&[entry]).await
     }
@@ -106,8 +107,8 @@ impl<'a> DbMemory<'a> {
         if let Some(backend) = &self.backend {
             let vector = self.embed.embed(self.profile, &sens.text).await?;
             let exp = Experience {
-                how: sens.text.clone(),
-                what: Value::String(sens.text.clone()),
+                how: first_sentence(&sens.text),
+                what: parse_json_or_string(&sens.text),
                 when: Utc::now(),
                 tags: vec![sens.path.clone()],
             };

--- a/psyched/src/file_memory.rs
+++ b/psyched/src/file_memory.rs
@@ -4,6 +4,7 @@ use tokio::sync::Mutex;
 
 use chrono::Utc;
 use psyche::models::{MemoryEntry, Sensation};
+use psyche::utils::{first_sentence, parse_json_or_string};
 use serde_json::Value;
 use tracing::{debug, trace};
 use uuid::Uuid;
@@ -75,8 +76,8 @@ impl FileMemory {
             id: Uuid::new_v4(),
             kind: kind.to_string(),
             when: Utc::now(),
-            what: Value::String(text.to_string()),
-            how: text.to_string(),
+            what: parse_json_or_string(text),
+            how: first_sentence(text),
         };
         self.append(kind, &entry).await
     }


### PR DESCRIPTION
## Summary
- enforce trimming of summaries to the first sentence
- parse incoming text as JSON when possible
- add utility helpers for sentence extraction and JSON parsing
- update memory store logic and tests

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6879dbf0d3608320806a01ea19b44317