### PR TITLE
Implement memory linking

### DIFF
--- a/psyche/src/memory.rs
+++ b/psyche/src/memory.rs
@@ -40,7 +40,7 @@ pub struct Experience {
 ///
 /// #[async_trait(?Send)]
 /// impl MemoryBackend for Dummy {
-///     async fn store(&self, _: &Experience, _: &[f32]) -> anyhow::Result<()> { Ok(()) }
+///     async fn store(&self, _: &Experience, _: &[f32]) -> anyhow::Result<String> { Ok("1".into()) }
 ///     async fn search(&self, _: &[f32], _: usize) -> anyhow::Result<Vec<Experience>> { Ok(vec![]) }
 ///     async fn get(&self, _: &str) -> anyhow::Result<Option<Experience>> { Ok(None) }
 ///     async fn cypher_query(&self, _: &str) -> anyhow::Result<Vec<Experience>> { Ok(vec![]) }

--- a/psyche/tests/subgraph.rs
+++ b/psyche/tests/subgraph.rs
@@ -11,8 +11,8 @@ struct SpyBackend {
 #[cfg(feature = "neo4j")]
 #[async_trait(?Send)]
 impl MemoryBackend for SpyBackend {
-    async fn store(&self, _exp: &Experience, _vector: &[f32]) -> anyhow::Result<()> {
-        Ok(())
+    async fn store(&self, _exp: &Experience, _vector: &[f32]) -> anyhow::Result<String> {
+        Ok("1".into())
     }
     async fn search(&self, _vector: &[f32], _top_k: usize) -> anyhow::Result<Vec<Experience>> {
         Ok(vec![])
@@ -23,6 +23,10 @@ impl MemoryBackend for SpyBackend {
     async fn cypher_query(&self, query: &str) -> anyhow::Result<Vec<Experience>> {
         *self.last.lock().unwrap() = Some(query.to_string());
         Ok(vec![])
+    }
+
+    async fn link_summary(&self, _summary_id: &str, _original_id: &str) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 

--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -409,10 +409,11 @@ pub async fn run(
                             response.push_str(&token);
                         }
                         drop(permit);
-                        memory_store.store(&w.cfg.output, &response).await?;
+                        let out_id = memory_store.store(&w.cfg.output, &response).await?;
                         if let Some(target) = &w.cfg.feedback {
                             if let Some(kind) = wit_inputs.get(target) {
-                                memory_store.store(kind, &response).await?;
+                                let fb_id = memory_store.store(kind, &response).await?;
+                                memory_store.link_summary(&fb_id, &out_id).await?;
                             } else {
                                 tracing::warn!(source = %w.name, target = %target, "feedback target missing");
                             }


### PR DESCRIPTION
## Summary
- add `link_summary` method to memory backend
- return stored IDs when persisting experiences
- hook up Neo4j `:SUMMARIZES` edges when storing entries
- connect feedback sensations to their source

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_687ab582d0288320a48be385a5b6fe07