### PR TITLE
Fix Neo4j URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cargo build
 sudo ./target/debug/psyched \
   --log-level info \
   --qdrant-url http://localhost:6333 \
-  --neo4j-url http://localhost:7474 \
+  --neo4j-url bolt://localhost:7687 \
   --neo4j-user neo4j --neo4j-pass password
 ````
 

--- a/psyched/config/default.toml
+++ b/psyched/config/default.toml
@@ -1,4 +1,4 @@
 [neo4j]
-url = "http://localhost:7474"
+url = "bolt://localhost:7687"
 [qdrant]
 url = "http://localhost:6333"

--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -308,6 +308,7 @@ pub async fn run(
 
     let backend =
         if let (Ok(qurl), Ok(nurl)) = (std::env::var("QDRANT_URL"), std::env::var("NEO4J_URL")) {
+            tracing::debug!(qdrant = %qurl, neo4j = %nurl, "connecting to backends");
             let qdrant = qdrant_client::prelude::QdrantClient::from_url(&qurl).build();
             let qdrant = qdrant.expect("qdrant");
             let user = std::env::var("NEO4J_USER").unwrap_or_else(|_| "neo4j".into());

--- a/psyched/src/main.rs
+++ b/psyched/src/main.rs
@@ -44,8 +44,8 @@ pub struct Cli {
     #[arg(long, env = "QDRANT_URL", default_value = "http://localhost:6333")]
     pub qdrant_url: String,
 
-    /// Neo4j service URL
-    #[arg(long, env = "NEO4J_URL", default_value = "http://localhost:7474")]
+    /// Neo4j Bolt service URL
+    #[arg(long, env = "NEO4J_URL", default_value = "bolt://localhost:7687")]
     pub neo4j_url: String,
 
     /// Neo4j username

--- a/psyched/tests/basic_vertical.rs
+++ b/psyched/tests/basic_vertical.rs
@@ -118,7 +118,7 @@ async fn cli_flags_work() {
         .arg("--qdrant-url")
         .arg("http://localhost:6333")
         .arg("--neo4j-url")
-        .arg("http://localhost:7474")
+        .arg("bolt://localhost:7687")
         .arg("--neo4j-user")
         .arg("neo4j")
         .arg("--neo4j-pass")

--- a/rememberd/src/main.rs
+++ b/rememberd/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! ```bash
 //! rememberd --qdrant-url http://localhost:6333 \
-//!           --neo4j-url http://localhost:7474 \
+//!           --neo4j-url bolt://localhost:7687 \
 //!           --neo4j-user neo4j --neo4j-pass password
 //! ```
 use clap::Parser;
@@ -40,8 +40,8 @@ struct Cli {
     #[arg(long, env = "QDRANT_URL", default_value = "http://localhost:6333")]
     qdrant_url: String,
 
-    /// Neo4j service URL
-    #[arg(long, env = "NEO4J_URL", default_value = "http://localhost:7474")]
+    /// Neo4j Bolt service URL
+    #[arg(long, env = "NEO4J_URL", default_value = "bolt://localhost:7687")]
     neo4j_url: String,
 
     /// Neo4j username


### PR DESCRIPTION
## Summary
- use the Bolt URL in default configuration
- update docs and tests
- log backend URLs when connecting

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687d722d2dcc8320819f6f5a7e232f4b