### PR TITLE
Rename distillers to wits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - Keep narrative prompt text under `daringsby/src` and pass it into library
   constructors instead of embedding it in `psyche-rs`.
 - Use `httpmock` for HTTP-based tests to avoid external network dependencies.
-- Set `USE_MOCK_LLM=1` in tests to force Ollama-backed distillers to use `MockChat`.
+- Set `USE_MOCK_LLM=1` in tests to force Ollama-backed wits to use `MockChat`.
 - Keep `.rs` files focused. Create a new source file for each new type and split
   large modules like `lib.rs` into smaller pieces.
 - Provide mutable `set_*` variants when adding builder methods to wrappers.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 psycheOS is not a conventional OS. It’s a cognitive architecture built on top of a minimal Linux environment that uses:
 
 - 🧱 **Sensation logs**: Raw data input (e.g. vision, audio, telemetry) stored chronologically.
-- 🌀 **Distillers (Wits)**: Modular cognitive layers that compress and interpret sensations into:
+- 🌀 **Wits**: Modular cognitive layers that compress and interpret sensations into:
   - **Instants** → **Situations** → **Episodes** → **Narratives**
 - 🧬 **Memory layer**: Shared bus backed by:
   - **Neo4j** for symbolic/graph memory
@@ -72,7 +72,7 @@ echo -e "/vision\nI see a red light blinking in the distance.\n.\n" | socat - UN
 └────────────┘      └─────┬──────┘
                           │
          ┌────────────────┴────────────────┐
-         │         Distillers (Wits)       │
+         │              Wits              │
          │                                  │
          │  Instant ▶ Situation ▶ Episode   │
          └────────────────┬────────────────┘
@@ -83,7 +83,7 @@ echo -e "/vision\nI see a red light blinking in the distance.\n.\n" | socat - UN
                └────────────────────┘
 ```
 
-Each *Wit* is a modular distiller defined declaratively and run by `psyched`.
+Each *Wit* is a modular wit defined declaratively and run by `psyched`.
 Pipeline sections can include a `feedback` field naming another Wit. When set,
 the originating Wit’s output is stored under the target Wit’s input kind so it
 can immediately act on that text.

--- a/all_souls/layka/config/pipeline.toml
+++ b/all_souls/layka/config/pipeline.toml
@@ -1,11 +1,11 @@
-[distiller.quick]
+[pipeline.quick]
 input_kinds = ["sensation"]
 output_kind = "instant"
 prompt_template = "From these recent sensations, infer what is happening. Generate a brief summary, emphasizing what is important and omitting what isn't. Use the first person perspective from your point of view. Be terse and concise. Use the information provided in the context to guide your responses, without inventing new details (this is real life, not fiction). Do not attempt to speak to the user here directly; these are your internal thoughts. Limit it to one sentence."
 beat_mod = 1
 postprocess = "recall"
 
-[distiller.combobulator]
+[pipeline.combobulator]
 input_kinds = ["instant"]
 output_kind = "situation"
 prompt_template = "Combine recent instants into a coherent summary of the current situation, as if explaining to yourself what is happening now. Generate a brief summary, emphasizing what is important and omitting what isn't. Use the first person perspective from your point of view. Be terse and concise.  Use the information provided in the context to guide your responses, without inventing new details (this is real life, not fiction). Do not attempt to speak to the user here directly; these are your internal thoughts. Limit it to one sentence."

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -1,9 +1,9 @@
 //! Core cognitive logic for Psyche.
 //!
-//! This crate hosts memory models and simple distillers. It is OS neutral.
+//! This crate hosts memory models and simple wits. It is OS neutral.
 
-pub mod distiller;
 pub mod llm;
 pub mod memory;
 pub mod models;
 pub mod utils;
+pub mod wit;

--- a/psyche/src/models.rs
+++ b/psyche/src/models.rs
@@ -11,7 +11,7 @@ pub struct Sensation {
     pub text: String,
 }
 
-/// Simplified representation produced by the distiller.
+/// Simplified representation produced by the wit.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Instant {
     /// Always `"instant"` for this basic vertical.
@@ -22,7 +22,7 @@ pub struct Instant {
     pub what: Vec<String>,
 }
 
-/// Generalized memory entry passed between distillers.
+/// Generalized memory entry passed between wits.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MemoryEntry {
     /// Unique identifier for this entry.

--- a/psyche/src/wit.rs
+++ b/psyche/src/wit.rs
@@ -23,12 +23,12 @@ pub fn distill(sensation: &Sensation) -> Option<Instant> {
     }
 }
 
-/// Configuration for a [`Distiller`].
+/// Configuration for a [`Wit`].
 #[derive(Clone, Debug)]
-pub struct DistillerConfig {
-    /// Human readable name for this distiller.
+pub struct WitConfig {
+    /// Human readable name for this wit.
     pub name: String,
-    /// Input memory kind this distiller consumes.
+    /// Input memory kind this wit consumes.
     pub input_kind: String,
     /// Kind of memory entry produced.
     pub output_kind: String,
@@ -40,17 +40,17 @@ pub struct DistillerConfig {
     pub post_process: Option<fn(&[MemoryEntry], &str) -> anyhow::Result<Value>>,
 }
 
-/// General-purpose distiller powered by a language model.
-pub struct Distiller {
-    /// Configuration for this distiller.
-    pub config: DistillerConfig,
+/// General-purpose wit powered by a language model.
+pub struct Wit {
+    /// Configuration for this wit.
+    pub config: WitConfig,
     /// LLM used to generate summaries.
     pub llm: Box<dyn CanChat>,
     /// Profile for the bound LLM.
     pub profile: LlmProfile,
 }
 
-impl Distiller {
+impl Wit {
     /// Distill a group of memory entries into a single output memory entry.
     pub async fn distill(&mut self, input: Vec<MemoryEntry>) -> anyhow::Result<Vec<MemoryEntry>> {
         // Filter by input kind
@@ -84,13 +84,13 @@ impl Distiller {
 
         let prompt = self.config.prompt_template.replace("{input}", &joined);
 
-        trace!(target = "llm", prompt = %prompt, "distiller prompt");
+        trace!(target = "llm", prompt = %prompt, "wit prompt");
         let mut stream = self.llm.chat_stream(&self.profile, "", &prompt).await?;
         let mut resp = String::new();
         while let Some(token) = stream.next().await {
             resp.push_str(&token);
         }
-        debug!(target = "llm", response = %resp, "distiller response");
+        debug!(target = "llm", response = %resp, "wit response");
 
         // Optional post-processing
         let value = if let Some(pp) = self.config.post_process {

--- a/psyche/tests/basic.rs
+++ b/psyche/tests/basic.rs
@@ -1,22 +1,22 @@
 use chrono::Utc;
-use psyche::distiller::{link_sources, Distiller, DistillerConfig};
 use psyche::llm::mock_chat::MockChat;
 use psyche::llm::{LlmCapability, LlmProfile};
 use psyche::models::MemoryEntry;
+use psyche::wit::{link_sources, Wit, WitConfig};
 use serde_json::json;
 use uuid::Uuid;
 
 #[tokio::test]
 async fn combobulator_config_distills_chat() {
     let entry_id = Uuid::new_v4();
-    let cfg = DistillerConfig {
+    let cfg = WitConfig {
         name: "combobulator".into(),
         input_kind: "sensation/chat".into(),
         output_kind: "instant".into(),
         prompt_template: "{input}".into(),
         post_process: Some(link_sources),
     };
-    let mut d = Distiller {
+    let mut d = Wit {
         config: cfg,
         llm: Box::new(MockChat::default()),
         profile: LlmProfile {
@@ -41,14 +41,14 @@ async fn combobulator_config_distills_chat() {
 #[tokio::test]
 async fn prefix_filter_matches_subkind() {
     let entry_id = Uuid::new_v4();
-    let cfg = DistillerConfig {
+    let cfg = WitConfig {
         name: "combobulator".into(),
         input_kind: "sensation".into(),
         output_kind: "instant".into(),
         prompt_template: "{input}".into(),
         post_process: Some(link_sources),
     };
-    let mut d = Distiller {
+    let mut d = Wit {
         config: cfg,
         llm: Box::new(MockChat::default()),
         profile: LlmProfile {
@@ -73,14 +73,14 @@ async fn prefix_filter_matches_subkind() {
 async fn memory_config_distills_instant() {
     let id1 = Uuid::new_v4();
     let id2 = Uuid::new_v4();
-    let cfg = DistillerConfig {
+    let cfg = WitConfig {
         name: "memory".into(),
         input_kind: "instant".into(),
         output_kind: "situation".into(),
         prompt_template: "{input}".into(),
         post_process: Some(link_sources),
     };
-    let mut d = Distiller {
+    let mut d = Wit {
         config: cfg,
         llm: Box::new(MockChat::default()),
         profile: LlmProfile {

--- a/psyche/tests/wit_distill.rs
+++ b/psyche/tests/wit_distill.rs
@@ -1,5 +1,5 @@
-use psyche::distiller::distill;
 use psyche::models::Sensation;
+use psyche::wit::distill;
 
 #[test]
 fn distills_basic_feeling() {

--- a/psyched/tests/postprocess_recall.rs
+++ b/psyched/tests/postprocess_recall.rs
@@ -19,7 +19,7 @@ async fn wit_recall_postprocess_sends_query() {
     let config_path = soul_dir.join("config/pipeline.toml");
     tokio::fs::write(
         &config_path,
-        "[distiller]\n\n[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 0\npostprocess = \"recall\"\n",
+        "[pipeline]\n\n[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 0\npostprocess = \"recall\"\n",
     )
     .await
     .unwrap();

--- a/psyched/tests/wit.rs
+++ b/psyched/tests/wit.rs
@@ -17,7 +17,7 @@ async fn wit_produces_output() {
     let config_path = soul_dir.join("config/pipeline.toml");
     tokio::fs::write(
         &config_path,
-        "[distiller]\n\n[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 0\nfeedback = \"\"\n",
+        "[pipeline]\n\n[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 0\nfeedback = \"\"\n",
     )
     .await
     .unwrap();
@@ -95,7 +95,7 @@ async fn feedback_forwards_output() {
         .unwrap();
     let config_path = soul_dir.join("config/pipeline.toml");
     let config = "\
-[distiller]\n\n[wit.first]\ninput = \"sensation/chat\"\noutput = \"reply1\"\nprompt = \"Respond\"\npriority = 0\nfeedback = \"second\"\n\n[wit.second]\ninput = \"reply1\"\noutput = \"reply2\"\nprompt = \"Respond2\"\npriority = 0\n";
+[pipeline]\n\n[wit.first]\ninput = \"sensation/chat\"\noutput = \"reply1\"\nprompt = \"Respond\"\npriority = 0\nfeedback = \"second\"\n\n[wit.second]\ninput = \"reply1\"\noutput = \"reply2\"\nprompt = \"Respond2\"\npriority = 0\n";
     tokio::fs::write(&config_path, config).await.unwrap();
 
     let registry = std::sync::Arc::new(psyche::llm::LlmRegistry {

--- a/psyched/tests/wit_from_config.rs
+++ b/psyched/tests/wit_from_config.rs
@@ -17,7 +17,7 @@ async fn wit_from_config_runs() {
     let config_path = soul_dir.join("config/pipeline.toml");
     tokio::fs::write(
         &config_path,
-        "[distiller]\n\n[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 1\nfeedback = \"\"\n",
+        "[pipeline]\n\n[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 1\nfeedback = \"\"\n",
     )
     .await
     .unwrap();

--- a/tests/configs/sample.toml
+++ b/tests/configs/sample.toml
@@ -1,10 +1,10 @@
-[distiller.combobulator]
+[pipeline.combobulator]
 input_kinds = ["sensation/chat"]
 output_kind = "instant"
 prompt_template = "prompts/combobulator.txt"
 beat_mod = 1
 
-[distiller.memory]
+[pipeline.memory]
 input_kinds = ["instant"]
 output_kind = "situation"
 prompt_template = "prompts/memory.txt"


### PR DESCRIPTION
## Summary
- rename distiller module and structs to wit
- update docs and configs for wit terminology
- adjust pipelines and tests for wit naming

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687d85412bd08320919df0ebe9678579