### PR TITLE
Ensure wit output entries are logged

### DIFF
--- a/psyched/src/db_memory.rs
+++ b/psyched/src/db_memory.rs
@@ -195,9 +195,11 @@ RETURN e.how AS how, e.what AS what, e.when AS when, e.tags AS tags ORDER BY e.w
                     }
                 }
             }
+            debug!(target = "psyched", ?entry.kind, id = %entry.id, "stored memory entry from wit");
             trace!(id = %entry.id, "persisted entry");
             return Ok(id);
         }
+        debug!(target = "psyched", ?entry.kind, id = %entry.id, "stored memory entry from wit");
         trace!(id = %entry.id, "persisted entry");
         Ok(String::new())
     }


### PR DESCRIPTION
## Summary
- log when DbMemory persists entries from wits

## Testing
- `cargo test --workspace --lib --quiet` *(fails: due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_687fe25678808320967e66b491ae3b77