### PR TITLE
Enable memory store input querying

### DIFF
--- a/psyched/Cargo.toml
+++ b/psyched/Cargo.toml
@@ -20,6 +20,7 @@ qdrant-client = "1"
 neo4rs = "0.9.0-rc.6"
 indexmap = { version = "2", features = ["serde"] }
 daemon-common = { path = "../daemon-common" }
+async-trait = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/psyched/src/file_memory.rs
+++ b/psyched/src/file_memory.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::sync::Mutex;
 
+use crate::db_memory::QueryMemory;
+use async_trait::async_trait;
 use chrono::Utc;
 use psyche::models::{MemoryEntry, Sensation};
 use psyche::utils::{first_sentence, parse_json_or_string};
@@ -14,6 +16,13 @@ use uuid::Uuid;
 pub struct FileMemory {
     dir: PathBuf,
     offsets: Arc<Mutex<HashMap<String, usize>>>,
+}
+
+#[async_trait(?Send)]
+impl QueryMemory for FileMemory {
+    async fn query_by_kind(&self, kind: &str) -> anyhow::Result<Vec<MemoryEntry>> {
+        self.entries_by_kind(kind).await
+    }
 }
 
 use std::sync::Arc;
@@ -67,6 +76,36 @@ impl FileMemory {
                 }
             })
             .collect()
+    }
+
+    /// Return all entries for `kind` without advancing internal offsets.
+    pub async fn entries_by_kind(&self, kind: &str) -> anyhow::Result<Vec<MemoryEntry>> {
+        trace!(kind, "query_by_kind called");
+        let path = self
+            .dir
+            .join(format!("{}.jsonl", kind.split('/').next().unwrap_or(kind)));
+        let content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
+        let mut out = Vec::new();
+        for line in content.lines() {
+            if kind.starts_with("sensation") {
+                if let Ok(s) = serde_json::from_str::<Sensation>(line) {
+                    let entry_kind = format!("sensation{}", s.path);
+                    if entry_kind.starts_with(kind) {
+                        out.push(MemoryEntry {
+                            id: Uuid::parse_str(&s.id)?,
+                            kind: entry_kind,
+                            when: Utc::now(),
+                            what: serde_json::json!(s.text),
+                            how: String::new(),
+                        });
+                    }
+                }
+            } else if let Ok(mut e) = serde_json::from_str::<MemoryEntry>(line) {
+                e.kind = kind.to_string();
+                out.push(e);
+            }
+        }
+        Ok(out)
     }
 
     /// Append a new text value under the given `kind`.


### PR DESCRIPTION
## Summary
- add `QueryMemory` trait for pipeline access
- implement memory query on `DbMemory` and `FileMemory`
- query memory store in `LoadedPipelineWit::collect`
- add `async-trait` dependency for `psyched`

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687fe86efb288320b356b17a9ba2b649