### PR TITLE
Add progress bar on model pull

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,5 @@
 - Set `NASA_API_KEY` when using rover data scripts to avoid API rate limits.
 - When adding new daemons, list them in `Cargo.toml` and provide matching
   executable scripts in `scripts/` without the `.sh` extension.
+- When showing long download progress in CLI tools, direct `indicatif`
+  progress bars to stderr to avoid polluting captured stdout in tests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1057,7 @@ dependencies = [
  "clap",
  "httpmock 0.7.0",
  "hyper 0.14.32",
+ "indicatif",
  "ollama-rs",
  "tera",
  "tokio",
@@ -1084,6 +1098,12 @@ checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1907,6 +1927,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +2710,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -4110,6 +4155,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"

--- a/distill/Cargo.toml
+++ b/distill/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1.46.1", features = ["full"] }
 tokio-stream = "0.1.17"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+indicatif = "0.17"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/distill/tests/pull_model.rs
+++ b/distill/tests/pull_model.rs
@@ -37,7 +37,7 @@ async fn pulls_missing_model() {
                     if req.method() == Method::POST && req.uri().path() == "/api/pull" {
                         return Ok(Response::builder()
                             .header("Content-Type", "application/json")
-                            .body(Body::from("{\"status\":\"success\"}"))
+                            .body(Body::from("{\"status\":\"success\"}\n"))
                             .unwrap());
                     }
                     Ok(Response::new(Body::empty()))


### PR DESCRIPTION
## Summary
- add indicatif progress bar when distill pulls a missing model
- log a warning before the download starts and emit progress updates
- update unit test to expect newline after pull response
- document stderr progress bar guidance in AGENTS

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6881241bdbb08320a8e4fb023282b5b6