### PR TITLE
Add terminal separator option to distill

### DIFF
--- a/distill/src/main.rs
+++ b/distill/src/main.rs
@@ -38,6 +38,10 @@ struct Cli {
     /// Model name
     #[arg(long, default_value = "phi4")]
     model: String,
+
+    /// Delimiter printed after each response
+    #[arg(long, default_value = "\n")]
+    terminal: String,
 }
 
 #[tokio::main]
@@ -61,6 +65,7 @@ async fn main() -> anyhow::Result<()> {
         lines: cli.lines,
         prompt,
         model: cli.model.clone(),
+        terminal: cli.terminal.clone(),
     };
 
     let ollama = Ollama::try_new(&cli.llm_url)?;

--- a/distill/tests/pull_model.rs
+++ b/distill/tests/pull_model.rs
@@ -55,6 +55,7 @@ async fn pulls_missing_model() {
         lines: 1,
         prompt: "Summarize: {{current}}".into(),
         model: "phi4".into(),
+        terminal: "\n".into(),
     };
     let ollama = Ollama::try_new(format!("http://{}", addr)).unwrap();
     let input = BufReader::new("hello".as_bytes());
@@ -65,7 +66,7 @@ async fn pulls_missing_model() {
 
     let mut out = String::new();
     r.read_to_string(&mut out).await.unwrap();
-    assert_eq!(out.trim(), "ok");
+    assert_eq!(out, "ok\n\n");
 
     assert_eq!(*hits.lock().unwrap(), 2); // two chat calls
     handle.abort();

--- a/distill/tests/stream.rs
+++ b/distill/tests/stream.rs
@@ -26,9 +26,10 @@ async fn run_streams_output() {
         lines: 1,
         prompt: "Summarize: {{current}}".into(),
         model: "llama3".into(),
+        terminal: "\n".into(),
     };
     let input = BufReader::new("hi".as_bytes());
     let mut out = Vec::new();
     run(cfg, ollama, input, &mut out).await.unwrap();
-    assert_eq!(std::str::from_utf8(&out).unwrap(), "foobar\n");
+    assert_eq!(std::str::from_utf8(&out).unwrap(), "foobar\n\n");
 }


### PR DESCRIPTION
## Summary
- add `--terminal` option for distill CLI
- separate responses with `cfg.terminal`
- update library docs and tests for new delimiter
- default CLI delimiter is now a newline

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68814f750a608320a1410eec086c9bae