### PR TITLE
Switch distill to use ollama generate

### DIFF
--- a/distill/tests/pull_model.rs
+++ b/distill/tests/pull_model.rs
@@ -18,7 +18,7 @@ async fn pulls_missing_model() {
             Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
                 let hits = hits.clone();
                 async move {
-                    if req.method() == Method::POST && req.uri().path() == "/api/chat" {
+                    if req.method() == Method::POST && req.uri().path() == "/api/generate" {
                         let mut h = hits.lock().unwrap();
                         *h += 1;
                         if *h == 1 {
@@ -28,7 +28,7 @@ async fn pulls_missing_model() {
                                 .body(Body::from("{\"error\":\"model \\\"phi4\\\" not found, try pulling it first\"}"))
                                 .unwrap());
                         }
-                        let body = "{\"model\":\"phi4\",\"created_at\":\"0\",\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"done\":true}\n";
+                        let body = "{\"model\":\"phi4\",\"created_at\":\"0\",\"response\":\"ok\",\"done\":true}\n";
                         return Ok(Response::builder()
                             .header("Content-Type", "application/json")
                             .body(Body::from(body))
@@ -68,6 +68,6 @@ async fn pulls_missing_model() {
     r.read_to_string(&mut out).await.unwrap();
     assert_eq!(out, "ok\n\n");
 
-    assert_eq!(*hits.lock().unwrap(), 2); // two chat calls
+    assert_eq!(*hits.lock().unwrap(), 2); // two generate calls
     handle.abort();
 }

--- a/distill/tests/stream.rs
+++ b/distill/tests/stream.rs
@@ -8,12 +8,12 @@ use tokio::io::BufReader;
 async fn run_streams_output() {
     let server = MockServer::start_async().await;
     let body = concat!(
-        "{\"created_at\":\"now\",\"model\":\"llama3\",\"message\":{\"role\":\"assistant\",\"content\":\"foo\"},\"done\":false}\n",
-        "{\"created_at\":\"now\",\"model\":\"llama3\",\"message\":{\"role\":\"assistant\",\"content\":\"bar\"},\"done\":true}\n"
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"foo\",\"done\":false}\n",
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"bar\",\"done\":true}\n"
     );
     server
         .mock_async(|when, then| {
-            when.method(Method::POST).path("/api/chat");
+            when.method(Method::POST).path("/api/generate");
             then.status(200)
                 .header("content-type", "application/json")
                 .body(body);


### PR DESCRIPTION
## Summary
- swap chat-based requests for `generate` in distill
- adjust tests for new `/api/generate` endpoint

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68816690307c83208e76d1c8792c3833