### PR TITLE
Update distill CLI flags

### DIFF
--- a/distill/tests/pull_model.rs
+++ b/distill/tests/pull_model.rs
@@ -56,6 +56,8 @@ async fn pulls_missing_model() {
         prompt: "Summarize: {{current}}".into(),
         model: "phi4".into(),
         terminal: "\n".into(),
+        history_depth: 1,
+        beat: 0,
     };
     let ollama = Ollama::try_new(format!("http://{}", addr)).unwrap();
     let input = BufReader::new("hello".as_bytes());

--- a/distill/tests/stream.rs
+++ b/distill/tests/stream.rs
@@ -27,6 +27,8 @@ async fn run_streams_output() {
         prompt: "Summarize: {{current}}".into(),
         model: "llama3".into(),
         terminal: "\n".into(),
+        history_depth: 1,
+        beat: 0,
     };
     let input = BufReader::new("hi".as_bytes());
     let mut out = Vec::new();


### PR DESCRIPTION
## Summary
- add history depth and beat options to distill
- wire new options into Config and main entry
- adjust tests for new config fields

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68816a67c2c483209e96dc666dca6d99