### PR TITLE
Fix distill newline behavior

### DIFF
--- a/distill/src/lib.rs
+++ b/distill/src/lib.rs
@@ -43,7 +43,10 @@ pub struct Config {
     pub prompt: String,
     /// Model name for the Ollama API.
     pub model: String,
-    /// Delimiter printed after each response
+    /// Delimiter printed after each response.
+    ///
+    /// The delimiter itself is written without an extra newline, so using
+    /// `"\n"` results in a single trailing newline per summary.
     pub terminal: String,
     /// How many prior summaries to include in {{previous}}
     pub history_depth: usize,
@@ -73,7 +76,6 @@ where
             };
             let summary = summarize_into(&ollama, &cfg, &previous, &current, &mut output).await?;
             output.write_all(cfg.terminal.as_bytes()).await?;
-            output.write_all(b"\n").await?;
             if cfg.continuous && cfg.history_depth > 0 {
                 history.push_back(summary);
                 while history.len() > cfg.history_depth {
@@ -95,7 +97,6 @@ where
         };
         let summary = summarize_into(&ollama, &cfg, &previous, &current, &mut output).await?;
         output.write_all(cfg.terminal.as_bytes()).await?;
-        output.write_all(b"\n").await?;
         if cfg.continuous && cfg.history_depth > 0 {
             history.push_back(summary);
             while history.len() > cfg.history_depth {

--- a/distill/tests/pull_model.rs
+++ b/distill/tests/pull_model.rs
@@ -68,7 +68,7 @@ async fn pulls_missing_model() {
 
     let mut out = String::new();
     r.read_to_string(&mut out).await.unwrap();
-    assert_eq!(out, "ok\n\n");
+    assert_eq!(out, "ok\n");
 
     assert_eq!(*hits.lock().unwrap(), 2); // two generate calls
     handle.abort();

--- a/distill/tests/stream.rs
+++ b/distill/tests/stream.rs
@@ -33,5 +33,5 @@ async fn run_streams_output() {
     let input = BufReader::new("hi".as_bytes());
     let mut out = Vec::new();
     run(cfg, ollama, input, &mut out).await.unwrap();
-    assert_eq!(std::str::from_utf8(&out).unwrap(), "foobar\n\n");
+    assert_eq!(std::str::from_utf8(&out).unwrap(), "foobar\n");
 }


### PR DESCRIPTION
## Summary
- avoid writing two newlines for each summary in distill
- update tests for new behavior
- clarify delimiter documentation

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_688193c62a588320b7ae0cfc1417fa73