### PR TITLE
Add newline trimming to distill

### DIFF
--- a/distill/src/lib.rs
+++ b/distill/src/lib.rs
@@ -15,6 +15,7 @@
 //!     terminal: "\n".into(),
 //!     history_depth: 1,
 //!     beat: 0,
+//!     trim_newlines: true,
 //! };
 //! let ollama = ollama_rs::Ollama::try_new("http://localhost:11434")?;
 //! distill::run(cfg, ollama, tokio::io::BufReader::new(stdin()), stdout()).await?;
@@ -52,6 +53,8 @@ pub struct Config {
     pub history_depth: usize,
     /// Delay between batches in milliseconds
     pub beat: u64,
+    /// Trim newline tokens emitted by the LLM
+    pub trim_newlines: bool,
 }
 
 /// Processes the input stream and writes summaries to the output stream.
@@ -145,6 +148,9 @@ where
                     let mut text = resp.response;
                     if let Some(t) = text.strip_prefix('\u{FEFF}') {
                         text = t.to_string();
+                    }
+                    if cfg.trim_newlines && text == "\n" {
+                        continue;
                     }
                     output_token(&text);
                     output.write_all(text.as_bytes()).await?;

--- a/distill/src/main.rs
+++ b/distill/src/main.rs
@@ -51,6 +51,10 @@ struct Cli {
     /// Delimiter printed after each response
     #[arg(long, default_value = "\n")]
     terminal: String,
+
+    /// Do not trim newline tokens from the LLM output
+    #[arg(long)]
+    no_trim: bool,
 }
 
 #[tokio::main]
@@ -77,6 +81,7 @@ async fn main() -> anyhow::Result<()> {
         terminal: cli.terminal.clone(),
         history_depth: cli.history_depth,
         beat: cli.beat,
+        trim_newlines: !cli.no_trim,
     };
 
     let ollama = Ollama::try_new(&cli.llm_url)?;

--- a/distill/tests/pull_model.rs
+++ b/distill/tests/pull_model.rs
@@ -58,6 +58,7 @@ async fn pulls_missing_model() {
         terminal: "\n".into(),
         history_depth: 1,
         beat: 0,
+        trim_newlines: true,
     };
     let ollama = Ollama::try_new(format!("http://{}", addr)).unwrap();
     let input = BufReader::new("hello".as_bytes());

--- a/distill/tests/stream.rs
+++ b/distill/tests/stream.rs
@@ -29,9 +29,78 @@ async fn run_streams_output() {
         terminal: "\n".into(),
         history_depth: 1,
         beat: 0,
+        trim_newlines: true,
     };
     let input = BufReader::new("hi".as_bytes());
     let mut out = Vec::new();
     run(cfg, ollama, input, &mut out).await.unwrap();
     assert_eq!(std::str::from_utf8(&out).unwrap(), "foobar\n");
+}
+
+#[tokio::test]
+async fn run_trims_newlines() {
+    let server = MockServer::start_async().await;
+    let body = concat!(
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"foo\",\"done\":false}\n",
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"\\n\",\"done\":false}\n",
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"bar\",\"done\":true}\n"
+    );
+    server
+        .mock_async(|when, then| {
+            when.method(Method::POST).path("/api/generate");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(body);
+        })
+        .await;
+
+    let ollama = Ollama::try_new(&server.base_url()).unwrap();
+    let cfg = Config {
+        continuous: false,
+        lines: 1,
+        prompt: "Summarize: {{current}}".into(),
+        model: "llama3".into(),
+        terminal: "\n".into(),
+        history_depth: 1,
+        beat: 0,
+        trim_newlines: true,
+    };
+    let input = BufReader::new("hi".as_bytes());
+    let mut out = Vec::new();
+    run(cfg, ollama, input, &mut out).await.unwrap();
+    assert_eq!(std::str::from_utf8(&out).unwrap(), "foobar\n");
+}
+
+#[tokio::test]
+async fn run_no_trim_includes_newlines() {
+    let server = MockServer::start_async().await;
+    let body = concat!(
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"foo\",\"done\":false}\n",
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"\\n\",\"done\":false}\n",
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"bar\",\"done\":true}\n"
+    );
+    server
+        .mock_async(|when, then| {
+            when.method(Method::POST).path("/api/generate");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(body);
+        })
+        .await;
+
+    let ollama = Ollama::try_new(&server.base_url()).unwrap();
+    let cfg = Config {
+        continuous: false,
+        lines: 1,
+        prompt: "Summarize: {{current}}".into(),
+        model: "llama3".into(),
+        terminal: "\n".into(),
+        history_depth: 1,
+        beat: 0,
+        trim_newlines: false,
+    };
+    let input = BufReader::new("hi".as_bytes());
+    let mut out = Vec::new();
+    run(cfg, ollama, input, &mut out).await.unwrap();
+    assert_eq!(std::str::from_utf8(&out).unwrap(), "foo\nbar\n");
 }


### PR DESCRIPTION
## Summary
- add `--no-trim` flag in distill CLI
- trim newline tokens from the LLM stream by default
- test trimmed and untrimmed output

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68827d2124e88320af0b7d6d3664cca6