### PR TITLE
Fix distill empty response handling

### DIFF
--- a/distill/tests/stream.rs
+++ b/distill/tests/stream.rs
@@ -236,5 +236,39 @@ async fn run_skips_empty_summaries() {
     let input = BufReader::new("hi".as_bytes());
     let mut out = Vec::new();
     run(cfg, ollama, input, &mut out).await.unwrap();
+    eprintln!("out={:?}", std::str::from_utf8(&out).unwrap());
+    assert!(std::str::from_utf8(&out).unwrap().is_empty());
+}
+#[tokio::test]
+async fn run_no_trim_skips_empty_summaries() {
+    let server = MockServer::start_async().await;
+    let body = concat!(
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"\\n\",\"done\":false}\n",
+        "{\"model\":\"llama3\",\"created_at\":\"now\",\"response\":\"\\n\",\"done\":true}\n",
+    );
+    server
+        .mock_async(|when, then| {
+            when.method(Method::POST).path("/api/generate");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(body);
+        })
+        .await;
+
+    let ollama = Ollama::try_new(&server.base_url()).unwrap();
+    let cfg = Config {
+        continuous: false,
+        lines: 1,
+        prompt: "Summarize: {{current}}".into(),
+        model: "llama3".into(),
+        terminal: "\n".into(),
+        history_depth: 1,
+        beat: 0,
+        trim_newlines: false,
+    };
+    let input = BufReader::new("hi".as_bytes());
+    let mut out = Vec::new();
+    run(cfg, ollama, input, &mut out).await.unwrap();
+    eprintln!("new out={:?}", std::str::from_utf8(&out).unwrap());
     assert!(std::str::from_utf8(&out).unwrap().is_empty());
 }


### PR DESCRIPTION
## Summary
- avoid printing delimiters when the LLM only returns whitespace
- return empty summaries for whitespace-only output
- test no-trim behaviour with empty summaries

## Testing
- `cargo test -p distill --test stream run_no_trim_skips_empty_summaries -- --nocapture`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_688294c088588320ac8b054091bf6618