### PR TITLE
Implement recall trigger in rememberd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2876,7 +2876,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
- "toml",
+ "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3121,6 +3121,7 @@ name = "rememberd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "daemon-common",
  "neo4rs",
@@ -3131,6 +3132,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -3468,6 +3470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -3903,6 +3914,47 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -4772,6 +4824,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/rememberd/Cargo.toml
+++ b/rememberd/Cargo.toml
@@ -12,6 +12,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
+chrono = { version = "0.4", features = ["serde", "clock"] }
 anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
 daemon-common = { path = "../daemon-common" }

--- a/rememberd/src/lib.rs
+++ b/rememberd/src/lib.rs
@@ -3,6 +3,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tracing::{error, info};
 
+mod policy;
 mod rpc;
 mod store;
 

--- a/rememberd/src/policy.rs
+++ b/rememberd/src/policy.rs
@@ -1,0 +1,41 @@
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::Path;
+
+#[derive(Deserialize)]
+struct RawPolicy {
+    #[serde(default)]
+    recall: RecallSection,
+}
+
+#[derive(Deserialize, Default)]
+struct RecallSection {
+    #[serde(default)]
+    kinds: Vec<String>,
+}
+
+/// Runtime policy controlling automatic behavior.
+#[derive(Clone, Default)]
+pub struct Policy {
+    recall_kinds: HashSet<String>,
+}
+
+impl Policy {
+    /// Load policy from `policy.toml` if present.
+    pub fn load(dir: &Path) -> Self {
+        let path = dir.join("policy.toml");
+        if let Ok(text) = std::fs::read_to_string(path) {
+            if let Ok(raw) = toml::from_str::<RawPolicy>(&text) {
+                return Self {
+                    recall_kinds: raw.recall.kinds.into_iter().collect(),
+                };
+            }
+        }
+        Self::default()
+    }
+
+    /// Whether a new entry of `kind` should trigger recall.
+    pub fn recall_for(&self, kind: &str) -> bool {
+        self.recall_kinds.contains(kind)
+    }
+}

--- a/rememberd/src/store.rs
+++ b/rememberd/src/store.rs
@@ -3,20 +3,43 @@ use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
 use tracing::trace;
 
+use crate::policy::Policy;
+
 /// Simple JSONL store used by `rememberd`.
 #[derive(Clone)]
 pub struct FileStore {
     pub dir: PathBuf,
+    policy: Policy,
 }
 
 impl FileStore {
     /// Create a new store rooted at `dir`.
     pub fn new(dir: PathBuf) -> Self {
-        Self { dir }
+        let policy = Policy::load(&dir);
+        Self { dir, policy }
     }
 
     /// Append a serialized value under the provided memory `kind`.
     pub async fn append(&self, kind: &str, value: &Value) -> anyhow::Result<()> {
+        self.write(kind, value).await?;
+        if self.policy.recall_for(kind) {
+            if let Some(how) = value.get("how").and_then(|v| v.as_str()) {
+                if let Some(id) = value.get("id") {
+                    let recall = serde_json::json!({
+                        "id": uuid::Uuid::new_v4(),
+                        "kind": "recall",
+                        "when": chrono::Utc::now(),
+                        "how": how,
+                        "what": [id.clone()],
+                    });
+                    self.write("recall", &recall).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn write(&self, kind: &str, value: &Value) -> anyhow::Result<()> {
         let base = kind.split('/').next().unwrap_or(kind);
         let path = self.dir.join(format!("{}.jsonl", base));
         let mut file = tokio::fs::OpenOptions::new()

--- a/rememberd/tests/recall_policy.rs
+++ b/rememberd/tests/recall_policy.rs
@@ -1,0 +1,51 @@
+use rememberd::{run, FileStore};
+use tempfile::tempdir;
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+use tokio::task::LocalSet;
+
+#[tokio::test]
+async fn recall_policy_creates_recall_entry() {
+    let dir = tempdir().unwrap();
+    let sock = dir.path().join("memory.sock");
+    let mem_dir = dir.path().join("mem");
+    tokio::fs::create_dir_all(&mem_dir).await.unwrap();
+    // enable recall for instants
+    tokio::fs::write(
+        mem_dir.join("policy.toml"),
+        "[recall]\nkinds = [\"instant\"]\n",
+    )
+    .await
+    .unwrap();
+    let store = FileStore::new(mem_dir.clone());
+    let rt = LocalSet::new();
+    let handle = rt.spawn_local(run(sock.clone(), store.clone()));
+    rt.run_until(async {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let mut client = UnixStream::connect(&sock).await.unwrap();
+        let entry = serde_json::json!({
+            "id": uuid::Uuid::new_v4(),
+            "kind": "instant",
+            "when": chrono::Utc::now(),
+            "what": [],
+            "how": "something happened",
+        });
+        let req = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "memorize",
+            "params": {"kind": "instant", "data": entry},
+            "id": 1
+        });
+        let data = serde_json::to_vec(&req).unwrap();
+        tokio::io::AsyncWriteExt::write_all(&mut client, &data)
+            .await
+            .unwrap();
+        client.shutdown().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    })
+    .await;
+    handle.abort();
+    let recall_path = mem_dir.join("recall.jsonl");
+    let content = tokio::fs::read_to_string(recall_path).await.unwrap();
+    assert_eq!(content.lines().count(), 1);
+}


### PR DESCRIPTION
## Summary
- add policy loader for recall in rememberd
- trigger `recall` memory writes when policy matches
- test recall policy

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68856ac41fac83208f03274ce2c56557