### PR TITLE
Add spoken TTS daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,6 +3572,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "spoken"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "daemon-common",
+ "hound",
+ "httpmock 0.7.0",
+ "reqwest",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "urlencoding",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4231,6 +4254,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
 [workspace]
-members = ["psyche", "psyched", "whisperd", "rememberd", "daemon-common", "distilld"]
+members = [
+    "psyche",
+    "psyched",
+    "whisperd",
+    "rememberd",
+    "daemon-common",
+    "distilld",
+    "spoken",
+]
 resolver = "2"

--- a/scripts/spoken
+++ b/scripts/spoken
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Run the spoken text-to-speech daemon
+cargo run -p spoken -- --socket ./voice.sock --tts-url http://localhost:5002 --log-level debug

--- a/spoken/Cargo.toml
+++ b/spoken/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "spoken"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+clap = { version = "4", features = ["derive", "env"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+anyhow = "1"
+daemon-common = { path = "../daemon-common" }
+urlencoding = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+httpmock = "0.7"
+hound = "3"
+tempfile = "3"

--- a/spoken/src/lib.rs
+++ b/spoken/src/lib.rs
@@ -1,0 +1,112 @@
+use std::path::PathBuf;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{debug, error, info};
+
+/// Extracts the raw PCM payload from a WAV file.
+fn wav_to_pcm(bytes: &[u8]) -> anyhow::Result<&[u8]> {
+    // very naive: assume 44 byte header
+    if bytes.len() <= 44 {
+        anyhow::bail!("wav data too short");
+    }
+    Ok(&bytes[44..])
+}
+
+async fn synthesize(tts_url: &str, text: &str) -> anyhow::Result<Vec<u8>> {
+    let url = format!("{}/api/tts?text={}", tts_url, urlencoding::encode(text));
+    let resp = reqwest::get(&url).await?.error_for_status()?;
+    let wav = resp.bytes().await?;
+    Ok(wav_to_pcm(&wav)?.to_vec())
+}
+
+async fn handle_connection(mut stream: UnixStream, tts_url: String) -> anyhow::Result<()> {
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    while reader.read_line(&mut line).await? > 0 {
+        let text = line.trim();
+        if !text.is_empty() {
+            debug!(%text, "synthesizing");
+            match synthesize(&tts_url, text).await {
+                Ok(pcm) => reader.get_mut().write_all(&pcm).await?,
+                Err(e) => error!(?e, "tts failed"),
+            }
+        }
+        line.clear();
+    }
+    reader.into_inner().shutdown().await?;
+    Ok(())
+}
+
+/// Run the spoken daemon.
+pub async fn run(socket: PathBuf, tts_url: String) -> anyhow::Result<()> {
+    if socket.exists() {
+        tokio::fs::remove_file(&socket).await.ok();
+    }
+    let listener = UnixListener::bind(&socket)?;
+    info!(?socket, ?tts_url, "spoken listening");
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let url = tts_url.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream, url).await {
+                error!(?e, "connection error");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound;
+    use httpmock::Method::GET;
+    use httpmock::MockServer;
+    use tempfile::tempdir;
+    use tokio::net::UnixStream;
+    use tokio::task::LocalSet;
+
+    fn wav_bytes() -> Vec<u8> {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        let mut writer = hound::WavWriter::new(&mut cursor, spec).unwrap();
+        writer.write_sample::<i16>(0).unwrap();
+        writer.finalize().unwrap();
+        cursor.into_inner()
+    }
+
+    #[tokio::test]
+    async fn synthesizes_input_line() {
+        let server = MockServer::start_async().await;
+        let wav = wav_bytes();
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/api/tts");
+            then.status(200).body(wav.clone());
+        });
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("voice.sock");
+        let url = format!("http://{}", server.address());
+        let local = LocalSet::new();
+        let handle = local.spawn_local(run(sock.clone(), url));
+        local
+            .run_until(async {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                let mut client = UnixStream::connect(&sock).await.unwrap();
+                tokio::io::AsyncWriteExt::write_all(&mut client, b"hello\n")
+                    .await
+                    .unwrap();
+                client.shutdown().await.unwrap();
+                let mut buf = Vec::new();
+                tokio::io::AsyncReadExt::read_to_end(&mut client, &mut buf)
+                    .await
+                    .unwrap();
+                assert!(!buf.is_empty());
+            })
+            .await;
+        handle.abort();
+    }
+}

--- a/spoken/src/main.rs
+++ b/spoken/src/main.rs
@@ -1,0 +1,45 @@
+use clap::Parser;
+use daemon_common::{LogLevel, maybe_daemonize};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "spoken", about = "Text-to-speech daemon")]
+struct Cli {
+    /// Path to the Unix socket
+    #[arg(long, default_value = "/run/psyched/voice.sock")]
+    socket: PathBuf,
+
+    /// Base URL of the coqui TTS server
+    #[arg(long, default_value = "http://localhost:5002")]
+    tts_url: String,
+
+    /// Logging verbosity level
+    #[arg(long, default_value = "info")]
+    log_level: LogLevel,
+
+    /// Run as a background daemon
+    #[arg(short = 'd', long)]
+    daemon: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing_subscriber::filter::LevelFilter::from(cli.log_level))
+        .init();
+    maybe_daemonize(cli.daemon)?;
+    spoken::run(cli.socket, cli.tts_url).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_defaults() {
+        let cli = Cli::try_parse_from(["spoken"]).unwrap();
+        assert!(matches!(cli.log_level, LogLevel::Info));
+        assert_eq!(cli.tts_url, "http://localhost:5002");
+    }
+}


### PR DESCRIPTION
## Summary
- add new `spoken` crate providing a text-to-speech daemon
- register `spoken` in the workspace
- include runnable helper script

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68866a9326f4832098bfa63863ed69c2