### PR TITLE
Add queue and broadcast to spoken daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,6 +3583,7 @@ dependencies = [
  "reqwest",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "urlencoding",

--- a/scripts/spoken
+++ b/scripts/spoken
@@ -1,4 +1,9 @@
 #!/bin/sh
 
 # Run the spoken text-to-speech daemon
-cargo run -p spoken -- --socket ./voice.sock --tts-url http://localhost:5002 --log-level debug
+cargo run -p spoken -- \
+  --socket ./voice.sock \
+  --tts-url http://localhost:5002 \
+  --speaker-id p330 \
+  --language-id "" \
+  --log-level debug

--- a/spoken/Cargo.toml
+++ b/spoken/Cargo.toml
@@ -12,6 +12,7 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 anyhow = "1"
 daemon-common = { path = "../daemon-common" }
 urlencoding = "2"
+tokio-util = "0.7"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/spoken/src/lib.rs
+++ b/spoken/src/lib.rs
@@ -1,7 +1,81 @@
+use std::collections::VecDeque;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::{Mutex, Notify, broadcast};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
+
+#[derive(Clone)]
+struct TextQueue {
+    inner: Arc<Mutex<VecDeque<String>>>,
+    notify: Arc<Notify>,
+}
+
+impl TextQueue {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VecDeque::new())),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    async fn push(&self, text: String) {
+        let mut q = self.inner.lock().await;
+        q.push_back(text);
+        self.notify.notify_one();
+    }
+
+    async fn pop(&self) -> Option<String> {
+        let mut q = self.inner.lock().await;
+        q.pop_front()
+    }
+
+    async fn clear(&self) {
+        let mut q = self.inner.lock().await;
+        q.clear();
+    }
+
+    async fn wait(&self) {
+        self.notify.notified().await;
+    }
+}
+
+#[derive(Clone)]
+enum PcmMessage {
+    Data(Vec<u8>),
+    Stop,
+}
+
+async fn synth_loop(
+    tts_url: String,
+    speaker_id: String,
+    language_id: String,
+    queue: TextQueue,
+    tx: broadcast::Sender<PcmMessage>,
+    cancel: Arc<Mutex<CancellationToken>>,
+) {
+    loop {
+        let text = loop {
+            if let Some(t) = queue.pop().await {
+                break t;
+            }
+            queue.wait().await;
+        };
+        let token = { cancel.lock().await.clone() };
+        let fut = synthesize(&tts_url, &speaker_id, &language_id, &text);
+        let res = tokio::select! {
+            r = fut => r.ok(),
+            _ = token.cancelled() => None,
+        };
+        if let Some(pcm) = res {
+            if !token.is_cancelled() {
+                let _ = tx.send(PcmMessage::Data(pcm));
+            }
+        }
+    }
+}
 
 /// Extracts the raw PCM payload from a WAV file.
 fn wav_to_pcm(bytes: &[u8]) -> anyhow::Result<&[u8]> {
@@ -12,47 +86,110 @@ fn wav_to_pcm(bytes: &[u8]) -> anyhow::Result<&[u8]> {
     Ok(&bytes[44..])
 }
 
-async fn synthesize(tts_url: &str, text: &str) -> anyhow::Result<Vec<u8>> {
+async fn synthesize(
+    tts_url: &str,
+    speaker_id: &str,
+    language_id: &str,
+    text: &str,
+) -> anyhow::Result<Vec<u8>> {
     let url = format!(
-        "{}/api/tts?text={}&speaker_id=p330&style_wav=&language_id=",
+        "{}/api/tts?text={}&speaker_id={}&style_wav=&language_id={}",
         tts_url,
-        urlencoding::encode(text)
+        urlencoding::encode(text),
+        speaker_id,
+        language_id
     );
     let resp = reqwest::get(&url).await?.error_for_status()?;
     let wav = resp.bytes().await?;
     Ok(wav_to_pcm(&wav)?.to_vec())
 }
 
-async fn handle_connection(mut stream: UnixStream, tts_url: String) -> anyhow::Result<()> {
-    let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    while reader.read_line(&mut line).await? > 0 {
-        let text = line.trim();
-        if !text.is_empty() {
-            debug!(%text, "synthesizing");
-            match synthesize(&tts_url, text).await {
-                Ok(pcm) => reader.get_mut().write_all(&pcm).await?,
-                Err(e) => error!(?e, "tts failed"),
+async fn handle_connection(
+    stream: UnixStream,
+    queue: TextQueue,
+    pcm_tx: broadcast::Sender<PcmMessage>,
+    cancel: Arc<Mutex<CancellationToken>>,
+) -> anyhow::Result<()> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    let mut rx = pcm_tx.subscribe();
+    let mut buf = Vec::new();
+    loop {
+        tokio::select! {
+            read = reader.read_until(b'\n', &mut buf) => {
+                let n = read?;
+                if n == 0 { break; }
+                if let Some(pos) = buf.iter().position(|b| *b == 0x03) {
+                    buf.drain(..=pos);
+                    queue.clear().await;
+                    {
+                        let mut c = cancel.lock().await;
+                        c.cancel();
+                        *c = CancellationToken::new();
+                    }
+                    let _ = pcm_tx.send(PcmMessage::Stop);
+                }
+                if !buf.is_empty() {
+                    if let Ok(text) = std::str::from_utf8(&buf) {
+                        let text = text.trim();
+                        if !text.is_empty() {
+                            queue.push(text.to_string()).await;
+                        }
+                    }
+                }
+                buf.clear();
             }
+            msg = rx.recv() => match msg {
+                Ok(PcmMessage::Data(pcm)) => {
+                    if let Err(e) = write_half.write_all(&pcm).await {
+                        error!(?e, "write failed");
+                        break;
+                    }
+                }
+                Ok(PcmMessage::Stop) => {
+                    write_half.shutdown().await.ok();
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+            },
         }
-        line.clear();
     }
-    reader.into_inner().shutdown().await?;
     Ok(())
 }
 
 /// Run the spoken daemon.
-pub async fn run(socket: PathBuf, tts_url: String) -> anyhow::Result<()> {
+pub async fn run(
+    socket: PathBuf,
+    tts_url: String,
+    speaker_id: String,
+    language_id: String,
+) -> anyhow::Result<()> {
     if socket.exists() {
         tokio::fs::remove_file(&socket).await.ok();
     }
     let listener = UnixListener::bind(&socket)?;
-    info!(?socket, ?tts_url, "spoken listening");
+    info!(?socket, ?tts_url, %speaker_id, %language_id, "spoken listening");
+
+    let queue = TextQueue::new();
+    let cancel = Arc::new(Mutex::new(CancellationToken::new()));
+    let (pcm_tx, _) = broadcast::channel(8);
+
+    tokio::spawn(synth_loop(
+        tts_url.clone(),
+        speaker_id.clone(),
+        language_id.clone(),
+        queue.clone(),
+        pcm_tx.clone(),
+        cancel.clone(),
+    ));
+
     loop {
         let (stream, _) = listener.accept().await?;
-        let url = tts_url.clone();
+        let q = queue.clone();
+        let tx = pcm_tx.clone();
+        let c = cancel.clone();
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, url).await {
+            if let Err(e) = handle_connection(stream, q, tx, c).await {
                 error!(?e, "connection error");
             }
         });
@@ -95,7 +232,7 @@ mod tests {
         let sock = dir.path().join("voice.sock");
         let url = format!("http://{}", server.address());
         let local = LocalSet::new();
-        let handle = local.spawn_local(run(sock.clone(), url));
+        let handle = local.spawn_local(run(sock.clone(), url, "p330".into(), "".into()));
         local
             .run_until(async {
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -103,12 +240,15 @@ mod tests {
                 tokio::io::AsyncWriteExt::write_all(&mut client, b"hello\n")
                     .await
                     .unwrap();
-                client.shutdown().await.unwrap();
-                let mut buf = Vec::new();
-                tokio::io::AsyncReadExt::read_to_end(&mut client, &mut buf)
-                    .await
-                    .unwrap();
-                assert!(!buf.is_empty());
+                let mut buf = [0u8; 8];
+                let n = tokio::time::timeout(
+                    std::time::Duration::from_millis(100),
+                    tokio::io::AsyncReadExt::read(&mut client, &mut buf),
+                )
+                .await
+                .unwrap()
+                .unwrap();
+                assert!(n > 0);
             })
             .await;
         handle.abort();

--- a/spoken/src/main.rs
+++ b/spoken/src/main.rs
@@ -13,6 +13,14 @@ struct Cli {
     #[arg(long, default_value = "http://localhost:5002")]
     tts_url: String,
 
+    /// Speaker id to use for synthesis
+    #[arg(long, default_value = "p330")]
+    speaker_id: String,
+
+    /// Language id for synthesis
+    #[arg(long, default_value = "")]
+    language_id: String,
+
     /// Logging verbosity level
     #[arg(long, default_value = "info")]
     log_level: LogLevel,
@@ -29,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(tracing_subscriber::filter::LevelFilter::from(cli.log_level))
         .init();
     maybe_daemonize(cli.daemon)?;
-    spoken::run(cli.socket, cli.tts_url).await
+    spoken::run(cli.socket, cli.tts_url, cli.speaker_id, cli.language_id).await
 }
 
 #[cfg(test)]
@@ -41,5 +49,7 @@ mod tests {
         let cli = Cli::try_parse_from(["spoken"]).unwrap();
         assert!(matches!(cli.log_level, LogLevel::Info));
         assert_eq!(cli.tts_url, "http://localhost:5002");
+        assert_eq!(cli.speaker_id, "p330");
+        assert_eq!(cli.language_id, "");
     }
 }


### PR DESCRIPTION
## Summary
- add speaker and language CLI options for spoken daemon
- queue text from all clients into shared queue and broadcast PCM
- send stop signal and clear queue on `^C`
- update helper script

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6886774ce4688320ac8890ccbb5707e0