### PR TITLE
Remove server-side disconnect in whisperd

### DIFF
--- a/whisperd/src/lib.rs
+++ b/whisperd/src/lib.rs
@@ -175,8 +175,6 @@ pub(crate) async fn handle_connection(
         }
     }
 
-    stream.shutdown().await.ok();
-
     Ok(())
 }
 

--- a/whisperd/src/test_helpers.rs
+++ b/whisperd/src/test_helpers.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::{Stt, handle_connection};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncReadExt;
 use tokio::net::UnixListener;
 use tracing::error;
 
@@ -59,6 +59,5 @@ pub async fn run_with_stt_no_vad<S: Stt + Send + Sync + 'static>(
                 crate::send_transcription(&mut stream, &trans).await?;
             }
         }
-        stream.shutdown().await.ok();
     }
 }


### PR DESCRIPTION
## Summary
- keep whisperd socket open by removing `shutdown` call
- adjust test helpers accordingly

## Testing
- `cargo test -p whisperd -- --quiet`
- `cargo test --workspace -- --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6886b55f056883209e138b2bdc7dfaf7