### PR TITLE
Add silence-based transcription to whisperd

### DIFF
--- a/scripts/whisperd
+++ b/scripts/whisperd
@@ -4,5 +4,5 @@ if [ -z "$1" ]; then
     set -- "layka"
 fi
 
-cargo run -p whisperd -- --socket ./quick.sock --listen ./ear.sock --whisper-model whisper-base.en.bin --log-level debug
+cargo run -p whisperd -- --socket ./quick.sock --listen ./ear.sock --whisper-model whisper-base.en.bin --log-level debug --silence-ms 1000
 


### PR DESCRIPTION
## Summary
- parameterize audio segmenter by silence duration
- add `--silence-ms` option to `whisperd`
- keep test helpers and daemon using silence thresholds
- update helper script for new option

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6886c38fa0288320a7e69f21a6640c3b