### PR TITLE
Async transcription for whisperd segments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,3 +69,5 @@
 - When showing long download progress in CLI tools, direct `indicatif`
   progress bars to stderr to avoid polluting captured stdout in tests.
 - Maintain project documentation under the `docs/` directory.
+- When working with `webrtc_vad` in async tests, use `spawn_local` since its
+  context isn't `Send`.


### PR DESCRIPTION
## Summary
- process each audio segment in `whisperd` concurrently and send transcripts as soon as they're ready
- adjust local test helper to use `spawn_local`
- document that VAD tests must use `spawn_local`

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6886c6adfa288320900a15d64525478e