### PR TITLE
Improve whisperd debugging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,5 @@
 - Maintain project documentation under the `docs/` directory.
 - When working with `webrtc_vad` in async tests, use `spawn_local` since its
   context isn't `Send`.
+- Set `WHISPER_SEGMENTS_DIR` to dump each PCM segment as a WAV file during tests
+  or debugging.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4544,8 +4544,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "clap",
  "daemon-common",
+ "hound",
  "serde",
  "serde_json",
  "tempfile",

--- a/whisperd/Cargo.toml
+++ b/whisperd/Cargo.toml
@@ -15,6 +15,8 @@ webrtc-vad = "0.4"
 async-trait = "0.1"
 anyhow = "1"
 daemon-common = { path = "../daemon-common" }
+hound = "3.5"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }


### PR DESCRIPTION
## Summary
- save each PCM segment to a WAV file when `WHISPER_SEGMENTS_DIR` is set
- add new unit test for saving segments
- document `WHISPER_SEGMENTS_DIR` usage in AGENTS.md

## Testing
- `cargo test -p whisperd --quiet`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6886fced0a848320bc2c6c1cabd2ed6c