### PR TITLE
Implement queued image captions in seen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,5 @@
   context isn't `Send`.
 - Set `WHISPER_SEGMENTS_DIR` to dump each PCM segment as a WAV file during tests
   or debugging.
+- For daemon tests expecting streamed output, use `BufReader::read_line` to
+  avoid hanging when connections stay open.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,23 +3405,15 @@ name = "seen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-stream",
- "async-trait",
  "base64 0.21.7",
- "chrono",
  "clap",
  "daemon-common",
- "futures-util",
  "httpmock 0.7.0",
  "ollama-rs",
- "psyche",
- "serde_json",
  "tempfile",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/seen/Cargo.toml
+++ b/seen/Cargo.toml
@@ -6,20 +6,12 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 base64 = "0.21"
-ollama-rs = { version = "0.3.2", features=["stream"] }
-psyche = { path = "../psyche" }
+ollama-rs = { version = "0.3.2" }
 tokio = { version = "1", features=["full"] }
-tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 clap = { version = "4.5", features=["derive"] }
 daemon-common = { path = "../daemon-common" }
-async-trait = "0.1"
-chrono = { version = "0.4", features=["serde"] }
-futures-util = "0.3"
-uuid = { version = "1", features=["v4", "serde"] }
-serde_json = "1"
-async-stream = "0.3"
 
 [dev-dependencies]
 httpmock = "0.7"


### PR DESCRIPTION
## Summary
- overhaul `seen` daemon to queue incoming images and broadcast captions
- simplify dependencies in `seen`
- update tests to cover broadcast behavior
- document `read_line` tip for daemon tests

## Testing
- `cargo test -p seen`
- `cargo test --workspace --exclude psyched --exclude rememberd --exclude psyched`

------
https://chatgpt.com/codex/tasks/task_e_6887d26aeed8832082d406053ec07119