### PR TITLE
Stream image captions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3412,6 +3412,7 @@ dependencies = [
  "ollama-rs",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]

--- a/seen/Cargo.toml
+++ b/seen/Cargo.toml
@@ -6,12 +6,14 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 base64 = "0.21"
-ollama-rs = { version = "0.3.2" }
+ollama-rs = { version = "0.3.2", features = ["stream"] }
 tokio = { version = "1", features=["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 clap = { version = "4.5", features=["derive"] }
 daemon-common = { path = "../daemon-common" }
+
+tokio-stream = "0.1.17"
 
 [dev-dependencies]
 httpmock = "0.7"


### PR DESCRIPTION
## Summary
- stream captions from Ollama in the `seen` daemon
- log streamed tokens for debugging
- assert base64 image encoding in tests

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6888242bcbe08320bdead3aa6e7ea768