### PR TITLE
Launch sensors via config

### DIFF
--- a/all_souls/layka/config.toml
+++ b/all_souls/layka/config.toml
@@ -1,0 +1,11 @@
+[sensor.seen]
+enabled = true
+socket = "eye.sock"
+args = []
+log_level = "info"
+
+[sensor.whisperd]
+enabled = true
+socket = "ear.sock"
+args = []
+log_level = "info"

--- a/psyched/src/sensor.rs
+++ b/psyched/src/sensor.rs
@@ -1,0 +1,19 @@
+use crate::config::SensorConfig;
+use tokio::process::{Child, Command};
+use tracing::info;
+
+/// Launch a sensor daemon and return the child handle.
+pub async fn launch_sensor(name: &str, cfg: &SensorConfig) -> anyhow::Result<Child> {
+    let socket = cfg.socket.clone().unwrap_or_else(|| format!("{name}.sock"));
+    info!(sensor = name, socket = %socket, "Launching sensor");
+    let mut cmd = Command::new(name);
+    cmd.arg("--socket")
+        .arg(&socket)
+        .arg("--log-level")
+        .arg(&cfg.log_level);
+    for arg in &cfg.args {
+        cmd.arg(arg);
+    }
+    let child = cmd.spawn()?;
+    Ok(child)
+}

--- a/psyched/tests/distiller_config.rs
+++ b/psyched/tests/distiller_config.rs
@@ -4,16 +4,15 @@ use tempfile::tempdir;
 #[tokio::test]
 async fn load_config_parses_distillers() {
     let toml = r#"
-        [[distillers]]
-        name = "instant"
+        [wit.instant]
         input = "sensation/chat"
         output = "instant"
         prompt_template = "Summarize {{current}}"
     "#;
     let dir = tempdir().unwrap();
-    let path = dir.path().join("psyche.toml");
+    let path = dir.path().join("config.toml");
     tokio::fs::write(&path, toml).await.unwrap();
     let cfg = config::load(&path).await.unwrap();
-    assert_eq!(cfg.distillers.len(), 1);
-    assert_eq!(cfg.distillers[0].name, "instant");
+    assert_eq!(cfg.wit.len(), 1);
+    assert!(cfg.wit.contains_key("instant"));
 }


### PR DESCRIPTION
## Summary
- introduce `[sensor.*]` configuration for `psyched`
- rename distiller config section to `[wit.*]`
- spawn `seen` and `whisperd` daemons from config
- add sample config for Layka
- adjust tests for new config parser

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68890b29cdbc8320aa76c237b9276028