### PR TITLE
Add would daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4890,6 +4896,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "would"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "daemon-common",
+ "psyche",
+ "roxmltree",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "toml 0.8.23",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ members = [
     "distilld",
     "spoken",
     "seen",
+    "would",
 ]
 resolver = "2"

--- a/all_souls/layka/config.toml
+++ b/all_souls/layka/config.toml
@@ -4,6 +4,11 @@ socket = "eye.sock"
 args = []
 log_level = "info"
 
+[would.motors]
+charge = "/usr/local/lib/psyche/motors/charge"
+move_towards = "/usr/local/lib/psyche/motors/move_towards"
+say = "/usr/local/lib/psyche/motors/say"
+
 [sensor.whisperd]
 enabled = true
 socket = "ear.sock"

--- a/scripts/would
+++ b/scripts/would
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Run the would daemon
+cargo run -p would -- --socket ./would.sock --config all_souls/layka/config.toml --log-level debug "$@"

--- a/would/Cargo.toml
+++ b/would/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "would"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+clap = { version = "4", features = ["derive", "env"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "0.8"
+anyhow = "1"
+async-trait = "0.1"
+tokio-stream = "0.1"
+roxmltree = "0.19"
+psyche = { path = "../psyche" }
+daemon-common = { path = "../daemon-common" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "sync"] }
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
+tempfile = "3"

--- a/would/src/lib.rs
+++ b/would/src/lib.rs
@@ -1,0 +1,206 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use psyche::llm::{CanChat, LlmProfile};
+use roxmltree::Document;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::process::Command;
+use tokio_stream::StreamExt;
+use tracing::{debug, error, info, trace};
+
+/// Mapping of available motors.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct WouldConfig {
+    #[serde(default)]
+    pub motors: HashMap<String, String>,
+}
+
+impl WouldConfig {
+    /// Load configuration from a TOML file containing a `[would.motors]` table.
+    pub async fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        #[derive(serde::Deserialize)]
+        struct Root {
+            #[serde(default)]
+            would: WouldConfig,
+        }
+        let text = tokio::fs::read_to_string(path).await?;
+        let root: Root = toml::from_str(&text)?;
+        Ok(root.would)
+    }
+}
+
+/// Parsed function call from the LLM.
+#[derive(Debug)]
+struct FnCall {
+    name: String,
+    args: HashMap<String, String>,
+    body: String,
+}
+
+fn parse_function(xml: &str) -> anyhow::Result<FnCall> {
+    let doc = Document::parse(xml)?;
+    let root = doc.root_element();
+    let mut args = HashMap::new();
+    for attr in root.attributes() {
+        args.insert(attr.name().to_string(), attr.value().to_string());
+    }
+    let body = root.text().unwrap_or("").trim().to_string();
+    Ok(FnCall {
+        name: root.tag_name().name().to_string(),
+        args,
+        body,
+    })
+}
+
+async fn interpret_urge(
+    llm: &(dyn CanChat + Sync),
+    profile: &LlmProfile,
+    urge: &str,
+) -> anyhow::Result<FnCall> {
+    const SYSTEM: &str = "Convert the urge into a single <function> call.";
+    let mut stream = llm.chat_stream(profile, SYSTEM, urge).await?;
+    let mut resp = String::new();
+    while let Some(tok) = stream.next().await {
+        trace!(target = "llm", token = %tok, "stream token");
+        resp.push_str(&tok);
+    }
+    debug!(target = "llm", response = %resp, "llm response");
+    parse_function(&resp)
+}
+
+async fn run_motor(path: &str, call: FnCall, output_sock: Option<PathBuf>) -> anyhow::Result<()> {
+    let mut cmd = Command::new(path);
+    for (k, v) in &call.args {
+        cmd.arg(format!("--{}", k)).arg(v);
+    }
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    info!(motor = %call.name, path, args = ?call.args, "executing motor");
+    let mut child = cmd.spawn()?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(call.body.as_bytes()).await?;
+    }
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout).lines();
+    while let Some(line) = reader.next_line().await? {
+        info!(response = %line, "motor response");
+        if let Some(sock) = &output_sock {
+            if let Ok(mut s) = UnixStream::connect(sock).await {
+                s.write_all(b"/response\n").await.ok();
+                s.write_all(line.as_bytes()).await.ok();
+                s.write_all(b"\n---\n").await.ok();
+                s.shutdown().await.ok();
+            }
+        }
+    }
+    let status = child.wait().await?;
+    if !status.success() {
+        error!(status = ?status, "motor exited with error");
+    }
+    Ok(())
+}
+
+async fn handle_connection(
+    stream: UnixStream,
+    cfg: WouldConfig,
+    llm: std::sync::Arc<dyn CanChat + Sync + Send>,
+    profile: LlmProfile,
+    output_sock: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let mut reader = BufReader::new(stream);
+    let mut buf = String::new();
+    reader.read_to_string(&mut buf).await?;
+    if buf.trim().is_empty() {
+        return Ok(());
+    }
+    info!(urge = %buf, "urge received");
+    let call = interpret_urge(llm.as_ref(), &profile, &buf).await?;
+    if let Some(path) = cfg.motors.get(&call.name) {
+        run_motor(path, call, output_sock).await?;
+    } else {
+        error!(motor = %call.name, "motor not found");
+    }
+    Ok(())
+}
+
+/// Run the would daemon.
+pub async fn run(
+    socket: PathBuf,
+    config: PathBuf,
+    output_sock: Option<PathBuf>,
+    llm: std::sync::Arc<dyn CanChat + Sync + Send>,
+    profile: LlmProfile,
+) -> anyhow::Result<()> {
+    if socket.exists() {
+        tokio::fs::remove_file(&socket).await.ok();
+    }
+    let listener = UnixListener::bind(&socket)?;
+    let cfg = WouldConfig::load(config).await?;
+    info!(?socket, "would listening");
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let cfg = cfg.clone();
+        let llm = llm.clone();
+        let profile = profile.clone();
+        let out = output_sock.clone();
+        tokio::task::spawn_local(async move {
+            if let Err(e) = handle_connection(stream, cfg, llm, profile, out).await {
+                error!(?e, "connection error");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use psyche::llm::mock_chat::NamedMockChat;
+    use tempfile::tempdir;
+    use tokio::task::LocalSet;
+
+    #[tokio::test]
+    async fn executes_motor_and_forwards_output() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("would.sock");
+        let out_sock = dir.path().join("out.sock");
+        let config_path = dir.path().join("config.toml");
+        tokio::fs::write(&config_path, "[would.motors]\necho = \"/bin/echo\"\n")
+            .await
+            .unwrap();
+        let llm = NamedMockChat {
+            name: "<echo/>".into(),
+        };
+        let llm = std::sync::Arc::new(llm);
+        let profile = LlmProfile {
+            provider: "mock".into(),
+            model: "mock".into(),
+            capabilities: vec![],
+        };
+        let local = LocalSet::new();
+        let handle = local.spawn_local(run(
+            sock.clone(),
+            config_path.clone(),
+            Some(out_sock.clone()),
+            llm,
+            profile,
+        ));
+        local
+            .run_until(async {
+                let listener = UnixListener::bind(&out_sock).unwrap();
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                let mut client = UnixStream::connect(&sock).await.unwrap();
+                client.write_all(b"test\n").await.unwrap();
+                client.shutdown().await.unwrap();
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut buf = String::new();
+                BufReader::new(&mut stream)
+                    .read_line(&mut buf)
+                    .await
+                    .unwrap();
+                assert!(buf.contains("/response"));
+            })
+            .await;
+        handle.abort();
+    }
+}

--- a/would/src/main.rs
+++ b/would/src/main.rs
@@ -1,0 +1,45 @@
+use clap::Parser;
+use daemon_common::{LogLevel, maybe_daemonize};
+use psyche::llm::mock_chat::NamedMockChat;
+use psyche::llm::{LlmCapability, LlmProfile};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "would", about = "Motor execution daemon")]
+struct Cli {
+    /// Path to the Unix socket for urge input
+    #[arg(long, default_value = "/run/would.sock")]
+    socket: PathBuf,
+
+    /// Path to config TOML with [would.motors]
+    #[arg(long, default_value = "config.toml")]
+    config: PathBuf,
+
+    /// Optional output socket for motor responses
+    #[arg(long)]
+    output: Option<PathBuf>,
+
+    /// Logging verbosity level
+    #[arg(long, default_value = "info")]
+    log_level: LogLevel,
+
+    /// Run as a background daemon
+    #[arg(short = 'd', long)]
+    daemon: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing_subscriber::filter::LevelFilter::from(cli.log_level))
+        .init();
+    maybe_daemonize(cli.daemon)?;
+    let llm = std::sync::Arc::new(NamedMockChat::default());
+    let profile = LlmProfile {
+        provider: "mock".into(),
+        model: "mock".into(),
+        capabilities: vec![LlmCapability::Chat],
+    };
+    would::run(cli.socket, cli.config, cli.output, llm, profile).await
+}


### PR DESCRIPTION
## Summary
- implement `would` motor executor daemon
- wire new would config section and script
- include unit test verifying a motor runs

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_688910c94b008320a82e5175b4a65487