### PR TITLE
Fix distilld spawn args

### DIFF
--- a/psyched/src/config.rs
+++ b/psyched/src/config.rs
@@ -6,12 +6,12 @@ use std::path::Path;
 pub struct DistillerConfig {
     #[serde(default)]
     pub name: String,
-    #[serde(rename = "input")] // for config readability
-    pub input_kind: String,
-    #[serde(rename = "output")]
-    pub output_kind: String,
-    #[serde(default)]
-    pub prompt_template: Option<String>,
+    #[serde(default, rename = "input")]
+    pub input: String,
+    #[serde(default, rename = "output")]
+    pub output: String,
+    #[serde(default, rename = "prompt")]
+    pub prompt: Option<String>,
     #[serde(default)]
     pub config: Option<String>,
 }

--- a/psyched/src/distillers.rs
+++ b/psyched/src/distillers.rs
@@ -23,14 +23,16 @@ impl Distiller {
 
     /// Spawn the `distilld` process.
     pub async fn spawn(&mut self) -> anyhow::Result<()> {
-        let mut cmd = Command::new("distilld");
-        cmd.arg("--input-kind").arg(&self.cfg.input_kind);
-        cmd.arg("--output-kind").arg(&self.cfg.output_kind);
-        if let Some(ref t) = self.cfg.prompt_template {
-            cmd.arg("--prompt-template").arg(t);
-        }
-        if let Some(ref c) = self.cfg.config {
-            cmd.arg("--config").arg(c);
+        let exe = std::env::var("CARGO_BIN_EXE_distilld").unwrap_or_else(|_| {
+            let mut p = std::env::current_exe().expect("exe");
+            p.pop();
+            p.pop();
+            p.push("distilld");
+            p.to_string_lossy().into_owned()
+        });
+        let mut cmd = Command::new(exe);
+        if let Some(ref t) = self.cfg.prompt {
+            cmd.arg("--prompt").arg(t);
         }
         cmd.arg("--daemon");
         let child = cmd.spawn()?;

--- a/psyched/src/router.rs
+++ b/psyched/src/router.rs
@@ -14,7 +14,7 @@ impl Router {
         let mut map = HashMap::new();
         for c in cfgs {
             let sock = PathBuf::from(format!("/run/psyche/{}.sock", c.name));
-            map.insert(c.output_kind.clone(), sock);
+            map.insert(c.output.clone(), sock);
         }
         Self { map }
     }

--- a/psyched/tests/distiller_config.rs
+++ b/psyched/tests/distiller_config.rs
@@ -7,7 +7,7 @@ async fn load_config_parses_distillers() {
         [wit.instant]
         input = "sensation/chat"
         output = "instant"
-        prompt_template = "Summarize {{current}}"
+        prompt = "Summarize {{current}}"
     "#;
     let dir = tempdir().unwrap();
     let path = dir.path().join("config.toml");


### PR DESCRIPTION
## Summary
- align DistillerConfig with other daemons
- launch `distilld` with supported `--prompt` flag
- route memory kinds using new fields
- update config loader test

## Testing
- `cargo test -p psyched -- --test-threads=1 --nocapture` *(fails: io error when listing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68892b2d3664832083b9840aa1ea8326