### PR TITLE
Enable spoken voice

### DIFF
--- a/all_souls/layka/identity.toml
+++ b/all_souls/layka/identity.toml
@@ -36,8 +36,15 @@ path = "/vision"
 socket = "ear.sock"
 path = "/hearing"
 
+[spoken]
+socket = "voice.sock"
+tts_url = "http://localhost:5002"
+speaker_id = "p300"
+language_id = ""
+log_level = "debug"
+
 [would.motors]
 charge = "/usr/local/lib/psyche/motors/charge"
 move_towards = "/usr/local/lib/psyche/motors/move_towards"
-say = "/usr/local/lib/psyche/motors/say"
+say = "./scripts/say"
 

--- a/psyched/src/config.rs
+++ b/psyched/src/config.rs
@@ -43,6 +43,36 @@ pub struct PipeConfig {
     pub path: String,
 }
 
+fn default_spoken_socket() -> String {
+    "voice.sock".into()
+}
+
+fn default_tts_url() -> String {
+    "http://localhost:5002".into()
+}
+
+fn default_speaker_id() -> String {
+    "p330".into()
+}
+
+fn default_language_id() -> String {
+    "".into()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SpokenConfig {
+    #[serde(default = "default_spoken_socket")]
+    pub socket: String,
+    #[serde(default = "default_tts_url")]
+    pub tts_url: String,
+    #[serde(default = "default_speaker_id")]
+    pub speaker_id: String,
+    #[serde(default = "default_language_id")]
+    pub language_id: String,
+    #[serde(default = "default_log_level")]
+    pub log_level: String,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct PsycheConfig {
     #[serde(default)]
@@ -51,6 +81,8 @@ pub struct PsycheConfig {
     pub sensor: IndexMap<String, SensorConfig>,
     #[serde(default)]
     pub pipe: IndexMap<String, PipeConfig>,
+    #[serde(default)]
+    pub spoken: Option<SpokenConfig>,
 }
 
 impl Default for PsycheConfig {
@@ -59,6 +91,7 @@ impl Default for PsycheConfig {
             wit: IndexMap::new(),
             sensor: IndexMap::new(),
             pipe: IndexMap::new(),
+            spoken: None,
         }
     }
 }

--- a/psyched/src/daemon.rs
+++ b/psyched/src/daemon.rs
@@ -40,3 +40,30 @@ pub async fn spawn_would(socket: &Path, config: &Path) -> anyhow::Result<Child> 
     info!(daemon = "would", socket = %socket.display(), "launching daemon");
     Ok(cmd.spawn()?)
 }
+
+use crate::config::SpokenConfig;
+
+/// Spawn the `spoken` daemon if configured.
+pub async fn spawn_spoken(cfg: &SpokenConfig) -> anyhow::Result<Child> {
+    let exe = env::var("CARGO_BIN_EXE_spoken").unwrap_or_else(|_| {
+        let mut p = env::current_exe().expect("exe");
+        p.pop();
+        p.pop();
+        p.push("spoken");
+        p.to_string_lossy().into_owned()
+    });
+    let mut cmd = Command::new(exe);
+    cmd.arg("--socket")
+        .arg(&cfg.socket)
+        .arg("--tts-url")
+        .arg(&cfg.tts_url)
+        .arg("--speaker-id")
+        .arg(&cfg.speaker_id)
+        .arg("--language-id")
+        .arg(&cfg.language_id)
+        .arg("--log-level")
+        .arg(&cfg.log_level)
+        .arg("--daemon");
+    info!(daemon = "spoken", socket = %cfg.socket, speaker = %cfg.speaker_id, "launching daemon");
+    Ok(cmd.spawn()?)
+}

--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -166,6 +166,11 @@ pub async fn run(
             config::PsycheConfig::default()
         }
     };
+    if let Some(spk) = psyche_cfg.spoken.clone() {
+        if let Ok(child) = daemon::spawn_spoken(&spk).await {
+            daemon_children.push(child);
+        }
+    }
     let mut sensor_children = Vec::new();
     for (name, cfg) in &psyche_cfg.sensor {
         if !cfg.enabled {

--- a/psyched/tests/spoken_config.rs
+++ b/psyched/tests/spoken_config.rs
@@ -1,0 +1,20 @@
+use psyched::config;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn load_spoken_config() {
+    let toml = r#"
+        [spoken]
+        socket = "voice.sock"
+        tts_url = "http://localhost:5002"
+        speaker_id = "p1"
+        language_id = ""
+    "#;
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    tokio::fs::write(&path, toml).await.unwrap();
+    let cfg = config::load(&path).await.unwrap();
+    let spk = cfg.spoken.expect("spoken config");
+    assert_eq!(spk.speaker_id, "p1");
+    assert_eq!(spk.socket, "voice.sock");
+}

--- a/scripts/psyched
+++ b/scripts/psyched
@@ -4,5 +4,11 @@ if [ -z "$1" ]; then
     set -- "layka"
 fi
 
+# Start spoken alongside psyched
+./scripts/spoken &
+SPOKEN_PID=$!
+
 # Run the psyche daemon in development mode
 cargo run -p psyched -- --soul all_souls/$1 --socket ./quick.sock --log-level debug
+
+kill $SPOKEN_PID

--- a/scripts/say
+++ b/scripts/say
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Send text to voice.sock and play the synthesized audio.
+# Usage: say [TEXT]
+
+SOCK=${VOICE_SOCK:-/run/psyched/voice.sock}
+DEVICE=${AUDIO_DEV:-default}
+
+if [ $# -gt 0 ]; then
+    TEXT="$*"
+else
+    TEXT=$(cat)
+fi
+
+echo "$TEXT" | nc -U "$SOCK" | aplay -q -D "$DEVICE" -f S16_LE -r 16000

--- a/scripts/spoken
+++ b/scripts/spoken
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 # Run the spoken text-to-speech daemon
+SPEAKER_ID=${SPEAKER_ID:-p330}
 cargo run -p spoken -- \
   --socket ./voice.sock \
   --tts-url http://localhost:5002 \
-  --speaker-id p330 \
+  --speaker-id "$SPEAKER_ID" \
   --language-id "" \
   --log-level debug


### PR DESCRIPTION
## Summary
- spawn the spoken daemon from `psyched`
- add `[spoken]` configuration block with voice options
- wire the `say` motor script into Layka's identity
- create a helper script to say text via `voice.sock`
- start spoken automatically in the `psyched` helper script
- test spoken config parsing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68896dbc2fe08320b5a3d2df5ed9bc7f