### PR TITLE
Pass model path to whisperd

### DIFF
--- a/all_souls/layka/identity.toml
+++ b/all_souls/layka/identity.toml
@@ -25,6 +25,7 @@ log_level = "trace"
 [sensor.whisperd]
 enabled = false
 socket = "ear.sock"
+whisper_model = "whisper-base.en.bin"
 args = []
 log_level = "info"
 

--- a/psyched/src/config.rs
+++ b/psyched/src/config.rs
@@ -30,6 +30,9 @@ pub struct SensorConfig {
     pub enabled: bool,
     #[serde(default)]
     pub socket: Option<String>,
+    /// Path to a model file passed to the sensor when applicable.
+    #[serde(default)]
+    pub whisper_model: Option<String>,
     #[serde(default)]
     pub args: Vec<String>,
     #[serde(default = "default_log_level")]

--- a/psyched/src/sensor.rs
+++ b/psyched/src/sensor.rs
@@ -11,6 +11,11 @@ pub async fn launch_sensor(name: &str, cfg: &SensorConfig) -> anyhow::Result<Chi
         .arg(&socket)
         .arg("--log-level")
         .arg(&cfg.log_level);
+    if name == "whisperd" {
+        if let Some(model) = &cfg.whisper_model {
+            cmd.arg("--whisper-model").arg(model);
+        }
+    }
     for arg in &cfg.args {
         cmd.arg(arg);
     }

--- a/psyched/tests/sensor_config.rs
+++ b/psyched/tests/sensor_config.rs
@@ -1,0 +1,16 @@
+use psyched::config;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn load_sensor_model() {
+    let toml = r#"
+        [sensor.whisperd]
+        whisper_model = "model.bin"
+    "#;
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    tokio::fs::write(&path, toml).await.unwrap();
+    let cfg = config::load(&path).await.unwrap();
+    let sensor = cfg.sensor.get("whisperd").expect("sensor");
+    assert_eq!(sensor.whisper_model.as_deref(), Some("model.bin"));
+}


### PR DESCRIPTION
## Summary
- allow sensors to specify an optional `whisper_model`
- propagate `whisper_model` to `whisperd`
- document the model in Layka's `identity.toml`
- test sensor config parsing

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68897a7e4c008320a9ee4f654c2a80f9