### PR TITLE
Remove unused wit fields

### DIFF
--- a/all_souls/layka/identity.toml
+++ b/all_souls/layka/identity.toml
@@ -3,17 +3,11 @@ role = "Autonomous space probe"
 purpose = "To explore meaning in solitude and report experiences"
 
 [wit.quick]
-input = "sensation"
-output = "instant"
 prompt = "From these recent sensations, infer what is happening. Generate a brief summary, emphasizing what is important and omitting what isn't. Use the first person perspective from your point of view. Be terse and concise. Use the information provided in the context to guide your responses, without inventing new details (this is real life, not fiction). Do not attempt to speak to the user here directly; these are your internal thoughts. Limit it to one sentence."
-beat_mod = 1
 postprocess = "recall"
 
 [wit.combobulator]
-input = "instant"
-output = "situation"
 prompt = "Combine recent instants into a coherent summary of the current situation, as if explaining to yourself what is happening now. Generate a brief summary, emphasizing what is important and omitting what isn't. Use the first person perspective from your point of view. Be terse and concise.  Use the information provided in the context to guide your responses, without inventing new details (this is real life, not fiction). Do not attempt to speak to the user here directly; these are your internal thoughts. Limit it to one sentence."
-beat_mod = 1
 postprocess = "recall"
 
 [sensor.seen]

--- a/psyched/src/config.rs
+++ b/psyched/src/config.rs
@@ -6,14 +6,14 @@ use std::path::Path;
 pub struct DistillerConfig {
     #[serde(default)]
     pub name: String,
-    #[serde(default, rename = "input")]
-    pub input: String,
-    #[serde(default, rename = "output")]
-    pub output: String,
     #[serde(default, rename = "prompt")]
     pub prompt: Option<String>,
     #[serde(default)]
     pub config: Option<String>,
+    #[serde(default)]
+    pub input: Option<String>,
+    #[serde(default)]
+    pub output: Option<String>,
 }
 
 fn default_sensor_enabled() -> bool {

--- a/psyched/src/lib.rs
+++ b/psyched/src/lib.rs
@@ -77,11 +77,11 @@ async fn load_identity(path: &Path) -> Result<Identity> {
         wit.insert(
             "combobulator".into(),
             wit::WitConfig {
-                input: "sensation/chat".into(),
-                output: "instant".into(),
+                input: Some("sensation/chat".into()),
+                output: Some("instant".into()),
                 prompt: "{input}".into(),
                 priority: 0,
-                beat_mod: 1,
+                beat_mod: None,
                 feedback: None,
                 llm: None,
                 postprocess: None,
@@ -90,11 +90,11 @@ async fn load_identity(path: &Path) -> Result<Identity> {
         wit.insert(
             "memory".into(),
             wit::WitConfig {
-                input: "instant".into(),
-                output: "situation".into(),
+                input: Some("instant".into()),
+                output: Some("situation".into()),
                 prompt: "{input}".into(),
                 priority: 0,
-                beat_mod: 4,
+                beat_mod: None,
                 feedback: None,
                 llm: None,
                 postprocess: Some("flatten_links".into()),

--- a/psyched/src/router.rs
+++ b/psyched/src/router.rs
@@ -13,8 +13,10 @@ impl Router {
     pub fn from_configs(cfgs: &[DistillerConfig]) -> Self {
         let mut map = HashMap::new();
         for c in cfgs {
-            let sock = PathBuf::from(format!("/run/psyche/{}.sock", c.name));
-            map.insert(c.output.clone(), sock);
+            if let Some(out) = &c.output {
+                let sock = PathBuf::from(format!("/run/psyche/{}.sock", c.name));
+                map.insert(out.clone(), sock);
+            }
         }
         Self { map }
     }

--- a/psyched/src/wit.rs
+++ b/psyched/src/wit.rs
@@ -5,25 +5,23 @@ fn default_priority() -> usize {
     0
 }
 
-fn default_beat_mod() -> usize {
-    1
-}
-
 #[derive(Debug, Clone, Deserialize)]
 pub struct WitConfig {
     /// Memory kind this Wit consumes.
-    pub input: String,
+    #[serde(default)]
+    pub input: Option<String>,
     /// Memory kind this Wit outputs.
-    pub output: String,
+    #[serde(default)]
+    pub output: Option<String>,
     /// Prompt passed to the language model. Pipeline wits treat this as a
     /// template where `"{input}"` will be replaced with recent memories.
     pub prompt: String,
     /// Execution priority for conversational wits. Lower values run more often.
     #[serde(default = "default_priority")]
     pub priority: usize,
-    /// Beat interval for pipeline wits. A value of `1` runs on every beat.
-    #[serde(default = "default_beat_mod")]
-    pub beat_mod: usize,
+    /// Beat interval for pipeline wits. No beat configured when absent.
+    #[serde(default)]
+    pub beat_mod: Option<usize>,
     /// Optional name of another Wit to receive this Wit’s output as input.
     #[serde(default)]
     pub feedback: Option<String>,

--- a/psyched/tests/connection_fallback.rs
+++ b/psyched/tests/connection_fallback.rs
@@ -12,7 +12,7 @@ async fn run_without_backends() {
         .unwrap();
     tokio::fs::write(
         soul_dir.join("identity.toml"),
-        "[wit.dummy]\ninput = \"foo\"\noutput = \"bar\"\nprompt = \"p\"",
+        "[wit.dummy]\nprompt = \"p\"",
     )
     .await
     .unwrap();

--- a/psyched/tests/distiller_config.rs
+++ b/psyched/tests/distiller_config.rs
@@ -5,8 +5,6 @@ use tempfile::tempdir;
 async fn load_config_parses_distillers() {
     let toml = r#"
         [wit.instant]
-        input = "sensation/chat"
-        output = "instant"
         prompt = "Summarize {{current}}"
     "#;
     let dir = tempdir().unwrap();

--- a/psyched/tests/postprocess_recall.rs
+++ b/psyched/tests/postprocess_recall.rs
@@ -17,7 +17,7 @@ async fn wit_recall_postprocess_sends_query() {
     let config_path = soul_dir.join("identity.toml");
     tokio::fs::write(
         &config_path,
-        "[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 0\npostprocess = \"recall\"\n",
+        "[wit.echo]\nprompt = \"Respond\"\npriority = 0\npostprocess = \"recall\"\n",
     )
     .await
     .unwrap();

--- a/psyched/tests/wit.rs
+++ b/psyched/tests/wit.rs
@@ -15,7 +15,7 @@ async fn wit_produces_output() {
     let config_path = soul_dir.join("identity.toml");
     tokio::fs::write(
         &config_path,
-        "[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 0\nfeedback = \"\"\n",
+        "[wit.echo]\nprompt = \"Respond\"\npriority = 0\nfeedback = \"\"\n",
     )
     .await
     .unwrap();
@@ -83,7 +83,7 @@ async fn feedback_forwards_output() {
         .unwrap();
     let config_path = soul_dir.join("identity.toml");
     let config = "\
-[wit.first]\ninput = \"sensation/chat\"\noutput = \"reply1\"\nprompt = \"Respond\"\npriority = 0\nfeedback = \"second\"\n\n[wit.second]\ninput = \"reply1\"\noutput = \"reply2\"\nprompt = \"Respond2\"\npriority = 0\n";
+[wit.first]\nprompt = \"Respond\"\npriority = 0\nfeedback = \"second\"\n\n[wit.second]\nprompt = \"Respond2\"\npriority = 0\n";
     tokio::fs::write(&config_path, config).await.unwrap();
 
     let registry = std::sync::Arc::new(psyche::llm::LlmRegistry {

--- a/psyched/tests/wit_from_config.rs
+++ b/psyched/tests/wit_from_config.rs
@@ -15,7 +15,7 @@ async fn wit_from_config_runs() {
     let config_path = soul_dir.join("identity.toml");
     tokio::fs::write(
         &config_path,
-        "[wit.echo]\ninput = \"sensation/chat\"\noutput = \"reply\"\nprompt = \"Respond\"\npriority = 1\nfeedback = \"\"\n",
+        "[wit.echo]\nprompt = \"Respond\"\npriority = 1\nfeedback = \"\"\n",
     )
     .await
     .unwrap();

--- a/tests/configs/sample.toml
+++ b/tests/configs/sample.toml
@@ -1,12 +1,6 @@
 [wit.combobulator]
-input = "sensation/chat"
-output = "instant"
 prompt = "prompts/combobulator.txt"
-beat_mod = 1
 
 [wit.memory]
-input = "instant"
-output = "situation"
 prompt = "prompts/memory.txt"
-beat_mod = 4
 postprocess = "flatten_links"


### PR DESCRIPTION
## Summary
- drop `input`, `output`, and `beat_mod` from wit configurations
- update identity and sample configs
- relax router to ignore missing outputs
- adjust tests for new config format

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6889839af0e88320b19d5e0879ef5d90