### PR TITLE
Add whisper model downloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.1",
  "windows-sys 0.59.0",
 ]
 
@@ -840,6 +840,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1962,8 +1987,24 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.1",
  "web-time",
+]
+
+[[package]]
+name = "inquire"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm",
+ "dyn-clone",
+ "lazy_static",
+ "newline-converter",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2287,6 +2328,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -2356,6 +2409,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "newline-converter"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nom"
@@ -3594,6 +3656,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3919,7 +4002,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -4314,6 +4397,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4605,11 +4700,17 @@ name = "whisperd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "chrono",
  "clap",
  "daemon-common",
+ "futures-util",
  "hound",
+ "httpmock 0.7.0",
+ "indicatif",
+ "inquire",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/whisperd/Cargo.toml
+++ b/whisperd/Cargo.toml
@@ -17,8 +17,14 @@ anyhow = "1"
 daemon-common = { path = "../daemon-common" }
 hound = "3.5"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+reqwest = { version = "0.12", features = ["stream"] }
+indicatif = "0.17"
+inquire = "0.6"
+futures-util = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
 tempfile = "3"
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
+assert_cmd = "2"
+httpmock = "0.7"

--- a/whisperd/src/lib.rs
+++ b/whisperd/src/lib.rs
@@ -45,6 +45,7 @@ mod local_ts_seconds {
 }
 mod audio_segmenter;
 use audio_segmenter::AudioSegmenter;
+pub mod model;
 
 #[cfg(test)]
 pub mod test_helpers;

--- a/whisperd/src/model.rs
+++ b/whisperd/src/model.rs
@@ -1,0 +1,93 @@
+use futures_util::StreamExt;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
+use tracing::{debug, trace};
+
+/// Available Whisper models.
+pub const MODELS: &[&str] = &[
+    "tiny.en",
+    "tiny",
+    "base.en",
+    "base",
+    "small.en",
+    "small",
+    "medium.en",
+    "medium",
+    "large",
+];
+
+/// Prompt the user to select a model using [`inquire`].
+pub fn prompt_model() -> anyhow::Result<String> {
+    let sel = inquire::Select::new("Whisper model", MODELS.to_vec()).prompt()?;
+    Ok(sel.to_string())
+}
+
+/// Download the given model into `dir` and return the saved path.
+///
+/// The base download URL can be overridden with the `WHISPER_MODEL_BASE_URL`
+/// environment variable for testing.
+pub async fn download(model: &str, dir: &Path) -> anyhow::Result<PathBuf> {
+    let base = std::env::var("WHISPER_MODEL_BASE_URL")
+        .unwrap_or_else(|_| "https://huggingface.co/ggerganov/whisper.cpp/resolve/main".into());
+    let url = format!("{base}/ggml-{model}.bin");
+    debug!(%url, "downloading model");
+    tokio::fs::create_dir_all(dir).await?;
+    let resp = reqwest::get(&url).await?.error_for_status()?;
+    let total = resp.content_length().unwrap_or(0);
+    let pb = ProgressBar::new(total);
+    pb.set_draw_target(ProgressDrawTarget::stderr());
+    pb.set_style(ProgressStyle::with_template(
+        "{bar:40.cyan/blue} {bytes}/{total_bytes}",
+    )?);
+    let path = dir.join(format!("whisper-{model}.bin"));
+    let mut file = tokio::fs::File::create(&path).await?;
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        file.write_all(&chunk).await?;
+        if total > 0 {
+            pb.inc(chunk.len() as u64);
+        } else {
+            pb.tick();
+        }
+    }
+    file.flush().await?;
+    pb.finish_and_clear();
+    trace!(path = %path.display(), "download complete");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).await?;
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::Method;
+    use httpmock::prelude::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn download_saves_file() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(Method::GET).path("/ggml-tiny.en.bin");
+                then.status(200).body("ok");
+            })
+            .await;
+
+        let dir = tempdir().unwrap();
+        unsafe {
+            std::env::set_var("WHISPER_MODEL_BASE_URL", server.base_url());
+        }
+        let path = download("tiny.en", dir.path()).await.unwrap();
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), "ok");
+        unsafe {
+            std::env::remove_var("WHISPER_MODEL_BASE_URL");
+        }
+    }
+}

--- a/whisperd/tests/fetch.rs
+++ b/whisperd/tests/fetch.rs
@@ -1,0 +1,36 @@
+use assert_cmd::Command;
+use httpmock::Method;
+use httpmock::prelude::*;
+use tempfile::tempdir;
+
+#[test]
+fn fetch_model_downloads_file() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(GET).path("/ggml-tiny.en.bin");
+        then.status(200).body("ok");
+    });
+
+    let dir = tempdir().unwrap();
+    unsafe {
+        std::env::set_var("WHISPER_MODEL_BASE_URL", server.url(""));
+    }
+
+    Command::cargo_bin("whisperd")
+        .unwrap()
+        .args([
+            "fetch-model",
+            "--model",
+            "tiny.en",
+            "--dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    unsafe {
+        std::env::remove_var("WHISPER_MODEL_BASE_URL");
+    }
+    let data = std::fs::read(dir.path().join("whisper-tiny.en.bin")).unwrap();
+    assert_eq!(data, b"ok");
+}


### PR DESCRIPTION
## Summary
- implement `fetch-model` subcommand for `whisperd`
- provide interactive model selection and downloading helpers
- test model downloads with `httpmock`

## Testing
- `cargo test -p whisperd --no-default-features`

------
https://chatgpt.com/codex/tasks/task_e_688ba66211608320a646ed04398c63dc