### PR TITLE
Add backpressure queue to whisperd

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ echo -e "/vision\nI see a red light blinking in the distance.\n.\n" | socat - UN
 
 When present as the first line, this sets the timestamp for the data. Invalid or missing prefixes default to the current local time.
 
+`whisperd` limits queued segments to avoid runaway memory use. If transcriptions fall behind the newest segments are favored.
+
 ## Architecture
 
 ```

--- a/docs/whisperd.md
+++ b/docs/whisperd.md
@@ -1,6 +1,8 @@
 # whisperd
 
 `whisperd` streams PCM audio from a Unix socket and outputs transcriptions.
+Incoming audio segments are buffered using a small queue. When the queue
+fills, older segments are dropped so that recent speech is prioritized.
 
 ## Systemd
 

--- a/whisperd/src/transcriber.rs
+++ b/whisperd/src/transcriber.rs
@@ -1,0 +1,56 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use chrono::{DateTime, Local};
+use tokio::sync::{Mutex, mpsc};
+use tracing::{debug, error};
+
+use crate::{Stt, send_transcription};
+
+pub struct SegmentJob {
+    pub id: u64,
+    pub pcm: Vec<i16>,
+    pub when: DateTime<Local>,
+    pub writer: Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
+}
+
+pub fn spawn_transcriber(
+    mut rx: mpsc::Receiver<SegmentJob>,
+    stt: Arc<dyn Stt + Send + Sync>,
+    latest: Arc<AtomicU64>,
+) {
+    tokio::spawn(async move {
+        while let Some(job) = rx.recv().await {
+            if job.id < latest.load(Ordering::Relaxed) {
+                debug!(id = job.id, "Skipping obsolete transcription job");
+                continue;
+            }
+            let handle = tokio::runtime::Handle::current();
+            let res = tokio::task::spawn_blocking({
+                let stt = stt.clone();
+                let pcm = job.pcm.clone();
+                move || handle.block_on(stt.transcribe(&pcm))
+            })
+            .await;
+
+            match res {
+                Ok(Ok(mut trans)) => {
+                    trans.when = job.when;
+                    latest.store(job.id, Ordering::Relaxed);
+                    let mut w = job.writer.lock().await;
+                    if let Err(e) = send_transcription(&mut *w, &trans).await {
+                        error!(?e, "failed to send transcription");
+                    }
+                }
+                Ok(Err(e)) => {
+                    error!(?e, "transcription failed");
+                }
+                Err(e) => {
+                    error!(?e, "transcription panicked");
+                }
+            }
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- refactor whisperd to queue segments instead of spawning uncontrolled tasks
- add transcriber module with a bounded job queue
- expose `--max-queue` option and document queue behaviour

## Testing
- `cargo test --workspace --no-default-features --exclude faced`

------
https://chatgpt.com/codex/tasks/task_e_688bac1c8ba88320b3054dbedbad0f3b