### PR TITLE
Align timestamps to first segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,9 @@ You can send input to the core daemon like so:
 echo -e "/vision\nI see a red light blinking in the distance.\n.\n" | socat - UNIX-CONNECT:/run/quick.sock
 ```
 
-### Stream Timestamp Prefix
+### Stream Timing
 
-`whisperd` and `seen` accept an optional prefix on incoming streams:
-
-```text
-@{2025-07-31T14:00:00-07:00}
-```
-
-When present as the first line, this sets the timestamp for the data. Invalid or missing prefixes default to the current local time.
+Timestamps now start when the first audio or image segment is received. Streams no longer need a `@{timestamp}` prefix.
 
 `whisperd` limits queued segments to avoid runaway memory use. If transcriptions fall behind the newest segments are favored.
 

--- a/docs/seen.md
+++ b/docs/seen.md
@@ -4,10 +4,4 @@
 
 ## Input Protocol
 
-The stream may optionally begin with a line like:
-
-```text
-@{2025-07-31T14:00:00-07:00}
-```
-
-This sets the timestamp used for incoming images. If the prefix is missing or malformed, the current local time is used.
+Image captions use the time the first frame is received. Streams no longer need a leading `@{timestamp}` line.

--- a/docs/whisperd.md
+++ b/docs/whisperd.md
@@ -43,10 +43,4 @@ whisperd gen-systemd > whisperd.service
 
 ## Input Protocol
 
-The stream may optionally begin with a line like:
-
-```text
-@{2025-07-31T14:00:00-07:00}
-```
-
-This sets the timestamp used for incoming audio. If the prefix is missing or malformed, the current local time is used.
+Transcriptions are timestamped using the moment the first segment arrives. The `@{timestamp}` prefix is no longer required.

--- a/whisperd/src/main.rs
+++ b/whisperd/src/main.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 #[command(
     name = "whisperd",
     about = "Audio ingestion and transcription daemon",
-    long_about = "Audio ingestion and transcription daemon.\n\nInput Protocol:\n  The stream may optionally begin with a line of the form:\n    @{2025-07-31T14:00:00-07:00}\n  This sets the timestamp used for the input data. If omitted or invalid, the system defaults to the current local time."
+    long_about = "Audio ingestion and transcription daemon. Timestamps begin when the first segment arrives."
 )]
 struct Cli {
     #[command(flatten)]

--- a/whisperd/src/transcriber.rs
+++ b/whisperd/src/transcriber.rs
@@ -13,6 +13,8 @@ pub struct SegmentJob {
     pub id: u64,
     pub pcm: Vec<i16>,
     pub when: DateTime<Local>,
+    /// When the segment was received from the socket.
+    pub received: DateTime<Local>,
     pub writer: Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
 }
 


### PR DESCRIPTION
## Summary
- timestamp transcriptions from first audio segment
- drop timestamp prefix handling in `whisperd` and `seen`
- document new timing behavior

## Testing
- `cargo test --workspace --exclude recognized --no-default-features --no-run`
- `cargo test --workspace --exclude recognized --no-default-features -- --test-threads=1 --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_688beff942c48320a77d96bcc61ea308