### PR TITLE
Add timestamped logging and function dispatch to layka

### DIFF
--- a/layka/functions/blink_led.sh
+++ b/layka/functions/blink_led.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# blink_led.sh: simulate LED blink feedback.
+count="${1:-1}"
+for ((i=0;i<count;i++)); do
+  echo "blink" >&2
+  sleep 0.1
+  echo "off" >&2
+  sleep 0.1
+done

--- a/layka/functions/record.sh
+++ b/layka/functions/record.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# record.sh: simulate recording audio for a given duration in seconds.
+duration="${1:-1}"
+# shellcheck disable=SC2034
+file="/tmp/recording.wav" # placeholder for recording file
+sleep "$duration"
+echo "recorded $duration s" >&2

--- a/layka/functions/speak.sh
+++ b/layka/functions/speak.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# speak.sh: synthesize speech for provided text or print to stdout.
+text="${1:-}"
+if command -v say >/dev/null 2>&1; then
+  say "$text"
+else
+  echo "speak: $text"
+fi

--- a/layka/layka.sh
+++ b/layka/layka.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"
+case "$cmd" in
+  say)
+    shift
+    msg="$*"
+    sock="/run/quick.sock"
+    if [[ ! -p "$sock" ]]; then
+      echo "socket $sock not found" >&2
+      exit 1
+    fi
+    echo "audio:$msg" > "$sock"
+    ;;
+  recall)
+    shift
+    "$(dirname "$0")/recall.sh" "$*"
+    ;;
+  *)
+    echo "usage: $0 {say <text>|recall <query>}" >&2
+    exit 1
+    ;;
+ esac

--- a/layka/memory-loop.sh
+++ b/layka/memory-loop.sh
@@ -7,6 +7,46 @@ split_sentences() {
 }
 # </function>
 
+# log_block TYPE CONTENT
+log_block() {
+  local type="$1"
+  local content="$2"
+  local ts
+  ts=$(date --iso-8601=seconds)
+  local color="\e[0m"
+  case "$type" in
+    INSTANT) color="\e[32m" ;;
+    SITUATION) color="\e[34m" ;;
+    FUNCTION) color="\e[35m" ;;
+  esac
+  echo -e "[$ts]\n${color}${content}\e[0m" >> "$LAYKA_LOG"
+  rotate_log
+}
+
+rotate_log() {
+  local max_bytes=1000000
+  if [[ $(stat -c%s "$LAYKA_LOG") -gt $max_bytes ]]; then
+    mv "$LAYKA_LOG" "${LAYKA_LOG}.1"
+    : > "$LAYKA_LOG"
+  fi
+}
+
+dispatch_function() {
+  local block="$1"
+  local name
+  name=$(grep -oP '<function name="\K[^"]+' <<<"$block")
+  local body
+  body=$(grep -oP '(?s)<function name="[^"]+">\K.*?(?=</function>)' <<<"$block")
+  log_block FUNCTION "Function $name: $body"
+  if declare -F "$name" >/dev/null; then
+    "$name" "$body"
+  elif [[ -x "$FUNCTIONS_DIR/$name.sh" ]]; then
+    "$FUNCTIONS_DIR/$name.sh" "$body"
+  else
+    echo "unknown function $name" >&2
+  fi
+}
+
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
   return 0
 fi
@@ -15,6 +55,7 @@ LOG_DIR="$(dirname "$0")"
 SENSATION_FILE="$LOG_DIR/sensations.jsonl"
 LAYKA_LOG="$LOG_DIR/layka-log.txt"
 TICK_FILE="$LOG_DIR/tick.txt"
+FUNCTIONS_DIR="$LOG_DIR/functions"
 
 mkdir -p "$LOG_DIR"
 touch "$SENSATION_FILE" "$LAYKA_LOG" "$TICK_FILE"
@@ -34,7 +75,13 @@ while IFS= read -r line; do
     [[ -z "$sentence" ]] && continue
     ts=$(date --iso-8601=seconds)
     id=$(printf '%s' "$sentence" | sha1sum | awk '{print $1}')
-    json=$(jq -n --arg ts "$ts" --arg src "$src" --arg id "$id" --arg text "$sentence" '{ts:$ts, source:$src, id:$id, text:$text}')
+    device="unknown"
+    case "$src" in
+      image) device="camera0" ;;
+      audio) device="mic0" ;;
+      *) device="${src}0" ;;
+    esac
+    json=$(jq -n --arg ts "$ts" --arg modality "$src" --arg device "$device" --arg id "$id" --arg text "$sentence" '{ts:$ts, source:{modality:$modality, device:$device}, id:$id, text:$text}')
     echo "$json" >> "$SENSATION_FILE"
     recent_ids+=("$id")
     recent_texts+=("$sentence")
@@ -46,19 +93,30 @@ while IFS= read -r line; do
     joined=$(printf '%s. ' "${recent_texts[@]}")
     how="Observations: $joined"
     instant=$(jq -n --arg ts "$(date --iso-8601=seconds)" --argjson ids "$ids_json" --arg how "$how" '{ts:$ts, ids:$ids, how:$how}')
-    echo "#INSTANT $instant" >> "$LAYKA_LOG"
+    log_block INSTANT "#INSTANT $instant"
+
+    recall_text=""
+    if [[ -s "$SENSATION_FILE" ]]; then
+      recall_text=$("$LOG_DIR/recall.sh" "$joined" | tr '\n' ' ')
+    fi
 
     if [[ "${USE_MOCK_LLM:-0}" = "1" ]]; then
       llm="#SITUATION mock situation"
     else
-      prompt="This is a live memory log. No fiction, hallucination, or speculation allowed. Only infer from data present.\nRecent instant:\n$instant\nLog tail:\n$(tail -n 20 "$LAYKA_LOG")"
-      llm=$(curl -sS http://localhost:11434/api/generate -d "$(jq -n --arg prompt "$prompt" '{model:"llama2", prompt:$prompt}')" | jq -r '.response')
+      prompt="This is a live memory log. No fiction, hallucination, or speculation allowed. Only infer from data present.\nRelevant memories: $recall_text\nRecent instant:\n$instant\nLog tail:\n$(tail -n 20 "$LAYKA_LOG")"
+      for attempt in 1 2 3; do
+        llm=$(curl -sS http://localhost:11434/api/generate -d "$(jq -n --arg prompt "$prompt" '{model:"llama2", prompt:$prompt}')" | jq -r '.response') && break
+        sleep $((attempt * attempt))
+      done
     fi
-    echo "$llm" >> "$LAYKA_LOG"
+    log_block SITUATION "$llm"
+    if [[ -x "$FUNCTIONS_DIR/speak.sh" ]]; then
+      "$FUNCTIONS_DIR/speak.sh" "$llm" >/dev/null
+    fi
 
     if grep -q '<function name=' <<<"$llm"; then
       func=$(grep -oP '(?s)<function name="[^"]+">.*?</function>' <<<"$llm")
-      echo "$func" >> "$LAYKA_LOG"
+      dispatch_function "$func"
     fi
 
     echo "$now" > "$TICK_FILE"

--- a/layka/recall.sh
+++ b/layka/recall.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# recall.sh: fuzzy search sensations for a query.
+query="${1:-}"
+if [[ -z "$query" ]]; then
+  echo "usage: $0 <query>" >&2
+  exit 1
+fi
+file="$(dirname "$0")/sensations.jsonl"
+if [[ ! -f "$file" ]]; then
+  echo "sensations file not found" >&2
+  exit 1
+fi
+jq -r --arg q "$query" 'select(.text | test($q; "i")) | .text' "$file" | head -n 5

--- a/layka/start.sh
+++ b/layka/start.sh
@@ -10,33 +10,86 @@ announce_ready() {
 LOG_DIR="$(dirname "$0")"
 LOG_FILE="$LOG_DIR/layka-log.txt"
 
+log_msg() {
+  local ts
+  ts=$(date --iso-8601=seconds)
+  echo "[$ts] $1" | tee -a "$LOG_FILE"
+}
+
 intro="This is a real autobiographical system log. LLMs must not fabricate or fictionalize."
-echo "$intro" | tee -a "$LOG_FILE"
+log_msg "$intro"
 
 tee -a "$LOG_FILE" < "$0"
 
 grep -oP '(?s)<function name="[^"]+">.*?</function>' "$0" | \
-  sed -e 's/<function name="\([^"]*\)">/Function \1:\n/' -e 's|</function>||' | tee -a "$LOG_FILE"
+  sed -e 's/<function name="\([^"]*\)">/Function \1:\n/' -e 's|</function>||' | while IFS= read -r line; do log_msg "$line"; done
 
 SOCK="/run/quick.sock"
 [ -p "$SOCK" ] || { rm -f "$SOCK" 2>/dev/null; mkfifo "$SOCK"; }
 
+declare -a PIDS=()
+
 if command -v whisperd >/dev/null 2>&1; then
   whisperd --mic default 2>&1 | sed 's/^/audio:/' > "$SOCK" &
   WHISPER_PID=$!
-  echo "whisperd PID $WHISPER_PID" | tee -a "$LOG_FILE"
+  PIDS+=("$WHISPER_PID")
+  log_msg "whisperd PID $WHISPER_PID"
 else
-  echo "whisperd not found" | tee -a "$LOG_FILE"
+  log_msg "whisperd not found"
 fi
 
 if command -v seen >/dev/null 2>&1; then
   seen --interval 60 --camera 0 2>&1 | sed 's/^/image:/' > "$SOCK" &
   SEEN_PID=$!
-  echo "seen PID $SEEN_PID" | tee -a "$LOG_FILE"
+  PIDS+=("$SEEN_PID")
+  log_msg "seen PID $SEEN_PID"
 else
-  echo "seen not found" | tee -a "$LOG_FILE"
+  log_msg "seen not found"
+fi
+
+if command -v locationd >/dev/null 2>&1; then
+  locationd 2>&1 | sed 's/^/location:/' > "$SOCK" &
+  LOCATION_PID=$!
+  PIDS+=("$LOCATION_PID")
+  log_msg "locationd PID $LOCATION_PID"
+else
+  log_msg "locationd not found"
+fi
+
+if command -v lightd >/dev/null 2>&1; then
+  lightd 2>&1 | sed 's/^/light:/' > "$SOCK" &
+  LIGHT_PID=$!
+  PIDS+=("$LIGHT_PID")
+  log_msg "lightd PID $LIGHT_PID"
+else
+  log_msg "lightd not found"
+fi
+
+if command -v tempd >/dev/null 2>&1; then
+  tempd 2>&1 | sed 's/^/temperature:/' > "$SOCK" &
+  TEMP_PID=$!
+  PIDS+=("$TEMP_PID")
+  log_msg "tempd PID $TEMP_PID"
+else
+  log_msg "tempd not found"
 fi
 
 "$LOG_DIR/memory-loop.sh" &
 MEM_PID=$!
-echo "memory-loop PID $MEM_PID" | tee -a "$LOG_FILE"
+PIDS+=("$MEM_PID")
+log_msg "memory-loop PID $MEM_PID"
+
+cleanup() {
+  for pid in "${PIDS[@]}"; do
+    if kill "$pid" 2>/dev/null; then
+      wait "$pid" || true
+      log_msg "daemon $pid terminated"
+    fi
+  done
+}
+trap cleanup INT TERM
+
+for pid in "${PIDS[@]}"; do
+  wait "$pid"
+  log_msg "daemon $pid exited"
+done

--- a/tests/layka_dispatch.rs
+++ b/tests/layka_dispatch.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+#[test]
+fn dispatch_invokes_function_script() {
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg("source layka/memory-loop.sh; export FUNCTIONS_DIR=layka/functions; dispatch_function '<function name=\"speak\">hello</function>'")
+        .output()
+        .expect("run bash");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("speak: hello"));
+}


### PR DESCRIPTION
## Summary
- log layka events with timestamps, colors and rotation
- dispatch <function> blocks to new functions/ scripts and CLI
- add recall script and optional sensor startup with daemon shutdown logging

## Testing
- `shellcheck layka/start.sh layka/memory-loop.sh layka/recall.sh layka/layka.sh layka/functions/speak.sh layka/functions/record.sh layka/functions/blink_led.sh`
- `cargo test --workspace` *(fails: failed to run custom build command for `opencv v0.95.1`)*
- `cargo test --workspace --no-default-features` *(fails: failed to run custom build command for `opencv v0.95.1`)*

------
https://chatgpt.com/codex/tasks/task_e_6892d9c82c048320ba44e768ba8878f4